### PR TITLE
docs: add Explorer Destinations PRD baseline

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -30,6 +30,7 @@ Welcome to the WMV Cycling Series documentation. Start with **Getting Started**,
 ### Future Work
 
 - **[Roadmap](./ROADMAP.md)** - Planned features: webhooks, email, season archival, mobile app, analytics
+- **[PRDs](./prds/README.md)** - Product requirements and implementation planning docs for upcoming features
 
 ### Branding & Standards
 
@@ -71,6 +72,7 @@ Welcome to the WMV Cycling Series documentation. Start with **Getting Started**,
 ```
 /docs/
 ├── README.md                   # This file - your entry point
+├── prds/                       # Product and implementation planning docs
 ├── QUICK_START.md              # Get running in 5 minutes
 ├── ARCHITECTURE.md             # System design overview
 ├── API.md                      # Endpoint reference
@@ -104,6 +106,7 @@ Welcome to the WMV Cycling Series documentation. Start with **Getting Started**,
 | **SECURITY_AUDIT.md** | Security review & compliance | You're auditing the codebase or deploying |
 | **DEPLOYMENT.md** | Deploy to production | You're going live |
 | **ROADMAP.md** | Future features & roadmap | You want to know what's planned |
+| **prds/** | Product and implementation planning docs | You're preparing multi-phase feature work |
 | **ADMIN_GUIDE.md** | Manage competitions | You're running events |
 | **STRAVA_BRANDING.md** | Follow brand guidelines | You're adding Strava UI elements |
 

--- a/docs/prds/README.md
+++ b/docs/prds/README.md
@@ -1,0 +1,17 @@
+# PRDs
+
+This directory holds product and implementation planning documents that are intended to carry forward across multiple phases of work.
+
+## WMV Explorer Destinations
+
+- [PRD](./wmv-explorer-destinations-prd.md)
+- [Technical Spec](./wmv-explorer-destinations-tech-spec.md)
+- [Implementation Phases](./wmv-explorer-destinations-phases.md)
+- [Ideas Backlog](./wmv-explorer-destinations-ideas.md)
+
+These docs are designed to separate product requirements from implementation detail:
+
+- The PRD defines the product intent, user experience, scope, and success criteria.
+- The technical spec defines the current recommended architecture and data model direction.
+- The phases document identifies the planned execution sequence.
+- The ideas backlog captures future concepts that should not expand the current scope.

--- a/docs/prds/wmv-explorer-destinations-ideas.md
+++ b/docs/prds/wmv-explorer-destinations-ideas.md
@@ -1,0 +1,12 @@
+# WMV Explorer Destinations Ideas Backlog
+
+- Season-wide Explorer accumulation across stored weekly completion history.
+- Weekly or season badge system for full completions, streaks, and themed destination sets.
+- Virtual-only or mixed virtual or outdoor destination series using Strava segments.
+- Completers celebration treatment for athletes who hit every destination in a week.
+- Shared-segment mini-races that auto-surface when multiple riders hit the same segment.
+- Destination categories such as scenic, climb, event, gravel, or coffee stop.
+- Profile accomplishments tied to Explorer completions and target history.
+- Club-wide completion metrics such as percent of riders who hit at least one destination in a week.
+- Bonus rules beyond 1 point per destination, such as first completion of the week, full-set completion, or rarity bonuses.
+- Admin-curated recurring challenge templates for monthly or seasonal Explorer campaigns.

--- a/docs/prds/wmv-explorer-destinations-phases.md
+++ b/docs/prds/wmv-explorer-destinations-phases.md
@@ -1,0 +1,76 @@
+# WMV Explorer Destinations Implementation Phases
+
+This document captures the current execution sequence for Explorer Destinations. It is intentionally narrower than the PRD and technical spec: it exists to turn the agreed direction into concrete follow-on work.
+
+## Phase 0: Documentation Baseline
+
+Goal: land the PRD, technical spec, phase outline, and ideas backlog in the repository so future implementation work has a stable source of truth.
+
+Deliverables:
+
+- Explorer PRD in `docs/prds`
+- Explorer technical spec in `docs/prds`
+- Explorer ideas backlog in `docs/prds`
+- Follow-on issue creation for the first engineering phase
+
+## Phase 1: Webhook Ingestion Refactor
+
+Goal: refactor webhook processing into a thin orchestrator with delegated in-process handlers so Explorer can be added without further overloading the current processor.
+
+Scope:
+
+- Introduce the handler or matcher abstraction for ingested activity contexts
+- Preserve existing competition processing behavior
+- Preserve existing chain wax behavior
+- Establish a reusable seam for Explorer matching and later refresh paths
+
+Out of scope:
+
+- Explorer schema
+- Explorer UI
+- Explorer admin setup
+
+## Phase 2: Explorer Data Model And Matching
+
+Goal: add Explorer week, destination, and match storage plus the shared matching service used by both webhooks and refresh actions.
+
+Scope:
+
+- Schema additions
+- Explorer matching service
+- Admin or service-level refresh path
+- Idempotent storage rules
+
+## Phase 3: Explorer Admin Setup
+
+Goal: let admins create Explorer weeks, add destinations from Strava URLs one at a time, label them, order them, and manage activation.
+
+Scope:
+
+- Explorer admin routes and service layer
+- Explorer admin UI
+- Activation guard requiring at least one destination
+
+## Phase 4: Explorer Hub MVP
+
+Goal: ship the athlete-facing weekly Explorer view.
+
+Scope:
+
+- Challenges hub route
+- Active week header
+- Progress bar
+- Destination checklist
+- Completers summary with all names
+
+## Phase 5: Hardening And Follow-on Expansion
+
+Goal: stabilize the Explorer feature and prepare later work.
+
+Candidate items:
+
+- Season-wide Explorer aggregation
+- Better admin search and validation tooling
+- Explorer profile rollups
+- Badges and themed campaigns
+- Shared-segment mini-races

--- a/docs/prds/wmv-explorer-destinations-prd.md
+++ b/docs/prds/wmv-explorer-destinations-prd.md
@@ -1,0 +1,261 @@
+# Product Requirements Document (PRD)
+
+## WMV Explorer Destinations
+
+|  |  |
+|  |  |
+| Product Name | WMV Explorer Destinations |
+| Version | 0.1 |
+| Author | GitHub Copilot |
+| Date | 2026-04-12 |
+| Status | Draft |
+
+## 1. Executive Summary
+
+WMV Explorer Destinations is a new offseason participation feature for the WMV Cycling Series app. Instead of rewarding speed or rank, it gives athletes a weekly set of admin-curated Strava segment destinations to visit. Each matched destination counts as one completion point for that week, and the primary experience is personal progress: how many destinations an athlete has completed, which ones remain, and whether they finished the full weekly set.
+
+The feature is designed to work for both outdoor and virtual riding, as long as the destination is represented by a Strava segment. This makes the experience more inclusive for riders doing real-world routes, Zwift routes, or a mix of both. The product also stores Explorer results across weeks so WMV can later expand into season-wide Explorer campaigns and broader participation tracking.
+
+## 2. Problem Statement
+
+The current WMV Cycling Series product is centered on weekly segment competition, time-based scoring, and season standings. That model works well for time trials and hill climbs, but it does not serve riders who want a lower-pressure, more exploratory way to participate during the offseason.
+
+Existing gaps include:
+
+- Participation is currently framed mainly as competition rather than exploration.
+- There is no product area for weekly destination-based riding goals.
+- There is no persistent record of exploration-style accomplishments across weeks.
+- The current UI does not support a simple personal-progress model such as checklist completion or progress bars.
+- The current webhook processor is already serving multiple purposes and needs a cleaner extension path before adding Explorer matching.
+
+WMV Explorer Destinations addresses these problems by adding a progress-first weekly experience that reuses Strava activity data and admin curation without forcing riders into a race-style leaderboard.
+
+## 3. Goals & Objectives
+
+|  |  |  |
+|  |  |  |
+| Inclusive offseason participation | Give riders a way to participate without needing to compete on speed | Riders can engage through weekly destination completion rather than race ranking |
+| Weekly motivation | Provide a clear set of weekly riding goals | Athletes can see a weekly progress bar and destination checklist |
+| Low admin friction | Let admins create a weekly Explorer challenge from Strava segments | Admin can create an Explorer week and configure destinations in one workflow |
+| Reuse current WMV systems | Build on existing Strava auth and ingestion patterns | No manual athlete submissions required for normal use |
+| Preserve future flexibility | Store Explorer results in a way that supports season-wide Explorer later | Weekly completion history is queryable across multiple weeks |
+| Avoid regression in competition features | Add Explorer without breaking current leaderboard and scoring behavior | Current competition routes and scoring remain unchanged |
+
+## 4. Target Audience
+
+|  |  |  |
+|  |  |  |
+| Existing WMV athlete | Club rider already using the app for seasonal competition | A fun, low-pressure weekly riding goal |
+| Casual or exploratory rider | Rider less interested in racing but motivated by destinations and completion | A checklist-style challenge rather than a ranking system |
+| Indoor or hybrid rider | Athlete who rides on Zwift and outdoors | Weekly destinations that can be either virtual or real-world Strava segments |
+| Club admin | Person organizing offseason engagement | A simple workflow to define weekly destinations and monitor completions |
+
+## 5. User Stories
+
+### 5.1 Athlete Experience
+
+|  |  |  |  |
+|  |  |  |  |
+| US-01 | As an athlete, I want to see the active Explorer week so I know what destinations are available now | Must | Active Explorer week is clearly visible in the Challenges hub |
+| US-02 | As an athlete, I want to see the weekly destination list so I know what segments count | Must | Destination list shows all configured segments for the week |
+| US-03 | As an athlete, I want to see my Explorer progress as a progress bar so I can quickly tell how far along I am | Must | Progress bar shows completed destinations versus total destinations |
+| US-04 | As an athlete, I want a checklist of completed and remaining destinations so I can track what I still need | Must | Each destination shows complete or incomplete state for the logged-in athlete |
+| US-05 | As an athlete, I want each matched destination to count once for the week so the rules are easy to understand | Must | Repeated visits to the same destination in the same week do not increase progress |
+| US-06 | As an athlete, I want virtual and outdoor Strava segments to count equally as destinations so the feature feels inclusive | Must | Eligibility depends on matching configured Strava segments, not whether a ride is virtual or outdoor |
+| US-07 | As an athlete, I want to know if I completed all destinations for the week so I can celebrate finishing the set | Must | Full completion state is visible when all destinations are matched |
+
+### 5.2 Club Visibility
+
+|  |  |  |  |
+|  |  |  |  |
+| US-08 | As a club member, I want to know whether anyone completed all destinations this week so the feature feels communal | Must | Weekly view includes a completers summary showing all athlete names who completed the full set |
+| US-09 | As a club member, I do not want the Explorer hub to feel like another race leaderboard | Must | Weekly view emphasizes progress and completion, not rank ordering |
+
+### 5.3 Admin Experience
+
+|  |  |  |  |
+|  |  |  |  |
+| US-10 | As an admin, I want to create a dedicated Explorer week so the feature can run independently from race weeks | Must | Admin can create Explorer weeks with their own date range |
+| US-11 | As an admin, I want to add destinations from Strava URLs so setup matches the regular admin panel workflow | Must | Admin can paste one Strava segment URL at a time and the system extracts the segment ID |
+| US-12 | As an admin, I want to add labels to destinations so the weekly challenge is presented clearly | Must | Destinations support optional labels in addition to the underlying segment metadata |
+| US-13 | As an admin, I want to reorder destinations so the weekly challenge is presented clearly | Should | Destinations support display order |
+| US-14 | As an admin, I want to refresh Explorer matching so I can recover missed or late-connected activities | Must | Admin can trigger a reprocess path for Explorer data |
+| US-15 | As an admin, I want Explorer setup to be separate from race week setup so the two products do not get mixed together | Must | Explorer management uses its own admin surface or clearly separated section |
+| US-16 | As an admin, I want Explorer weeks to require at least one destination before activation so athletes never see an empty challenge | Must | Explorer week cannot be activated without at least one configured destination |
+
+## 6. MoSCoW Prioritization
+
+### Must Have (MVP)
+
+|  |  |  |
+|  |  |  |
+| Separate Challenges hub | US-01, US-10 | Explorer must feel distinct from race competition |
+| Active Explorer week view | US-01, US-02 | Core weekly experience |
+| Progress bar + checklist UX | US-03, US-04 | Primary interaction model |
+| One point per matched destination | US-05 | Simple, explainable rule set |
+| Virtual and outdoor segment support | US-06 | Inclusion requirement |
+| Weekly completion state | US-07 | Key motivator for the feature |
+| Completers summary with all athlete names | US-08 | Light communal visibility without ranking |
+| Separate Explorer week admin flow | US-10, US-15 | Keeps data model and UI boundaries clear |
+| Strava URL-based destination setup | US-11 | Matches existing admin workflow |
+| Destination labels | US-12 | Needed for flexible curation and presentation |
+| Activation requires at least one destination | US-16 | Prevents empty Explorer weeks from going live |
+| Refresh or backfill action | US-14 | Operational recovery and late joins |
+| Persistent Explorer history across weeks | — | Required for future season-wide Explorer support |
+| Delegated webhook ingestion path | — | Required to add Explorer without further overloading the webhook processor |
+
+### Should Have (Enhanced Experience)
+
+|  |  |  |
+|  |  |  |
+| Destination ordering | US-13 | Better weekly storytelling |
+| Cached destination names | — | Better display stability and admin confidence |
+| Explorer-specific empty states and help text | — | Clarifies how the feature works for first-time users |
+| Regular athlete profile summary | — | Deferred until after the core hub and admin flow are stable |
+
+### Could Have (Delight)
+
+|  |  |  |
+|  |  |  |
+| Destination categories such as scenic, climb, or event | — | Adds editorial character to weekly Explorer sets |
+| Celebration treatment on full completion | US-07 | Reinforces motivation without adding competition |
+| Destination category chips or themed labels | US-12 | Adds editorial polish without changing core rules |
+
+### Won't Have (v1.0 — Future Consideration)
+
+|  |  |
+|  |  |
+| Rank-ordered Explorer leaderboard | Explorer is progress-first in v1 |
+| Bonus scoring beyond one point per destination | Keep the rules simple first |
+| Season-wide Explorer UI | Depends on weekly history first |
+| Shared-segment mini-races | Separate future feature |
+| Badge system | Defer until core Explorer behavior is validated |
+| Out-of-process worker or CLI handoff for webhooks | In-process delegated handlers are sufficient for v1 |
+
+## 7. UI/UX Specifications
+
+### 7.1 Layout
+
+The Explorer hub should present one weekly challenge at a time, with a progress-first layout:
+
+- Header area with Explorer week title, date range, and short rules summary.
+- Progress section with a visible progress bar showing completed destinations versus total destinations.
+- Destination checklist showing all weekly destinations with completed or remaining state for the current athlete.
+- Weekly completion summary showing all athletes who completed the full set.
+- Lightweight empty or disconnected states when the athlete has no data yet.
+
+### 7.2 UX Principles
+
+|  |  |
+|  |  |
+| Progress over ranking | The page should feel like a challenge checklist, not a leaderboard |
+| Clear weekly framing | Athletes should immediately understand what counts this week |
+| Inclusive destination model | Virtual and outdoor destinations should be presented as equally valid |
+| Low cognitive load | Rules should be understandable in seconds |
+| Additive navigation | Explorer should feel like a new section, not a replacement for competition views |
+
+### 7.3 Responsive Behavior
+
+|  |  |
+|  |  |
+| Desktop | Progress summary and checklist visible without excessive scrolling |
+| Tablet | Checklist remains primary content; summary compresses gracefully |
+| Mobile | Progress bar, checklist, and completers summary stack cleanly |
+
+## 8. Non-Functional Requirements
+
+### 8.1 Performance
+
+|  |  |  |
+|  |  |  |
+| Explorer hub load | Comparable to other existing app views | Manual verification and E2E timing sanity check |
+| Matching idempotency | Reprocessing must not create duplicate destination matches | Automated backend tests |
+| Refresh behavior | Manual refresh path must be safe to rerun | Automated backend tests |
+
+### 8.2 Data Integrity
+
+|  |  |  |
+|  |  |  |
+| Durable weekly history | Explorer progress remains queryable after the week ends | Automated integration tests |
+| Correct weekly boundaries | Only activities inside the Explorer week count | Backend tests for start and end edge cases |
+| One completion per destination per athlete per week | Multiple visits do not overcount | Backend tests |
+
+### 8.3 Accessibility
+
+|  |  |  |
+|  |  |  |
+| Progress visibility | Completion state is understandable without color alone | Manual QA |
+| Checklist semantics | Destination completion is screen-reader friendly | Accessibility review |
+| Keyboard navigation | Core Explorer hub interactions are keyboard accessible | Manual QA |
+
+### 8.4 Compatibility
+
+|  |  |  |
+|  |  |  |
+| Existing WMV app routes | Explorer must coexist with current leaderboard and admin flows | Regression testing |
+| Virtual and outdoor segment ingestion | Both segment types are eligible when configured | Backend matching tests |
+
+## 9. Risks & Mitigations
+
+|  |  |  |  |
+|  |  |  |  |
+| Webhook processor complexity grows further | Harder to add Explorer safely | High | Refactor to delegated in-process handlers before adding Explorer-specific logic |
+| Strava URLs may be pasted incorrectly or parse to invalid segments | Broken destination configuration | Medium | Validate pasted URLs, extract segment IDs safely, and cache segment metadata where possible |
+| Confusion between Explorer weeks and race weeks | Users or admins may mix the two concepts | Medium | Use distinct naming, routes, and admin sections |
+| Missing activity matches for late connections or failures | Athlete progress appears incomplete | Medium | Provide explicit refresh or backfill actions |
+| Explorer drifts toward competition UX | Reduces inclusiveness and changes product intent | Medium | Avoid rank ordering and center progress/checklist UX |
+
+## 10. Success Criteria
+
+The v1 release is successful if:
+
+1. Admins can create an Explorer week and assign Strava segment destinations.
+2. Explorer weeks require at least one destination before they can be activated.
+3. Athletes can see a weekly progress bar and destination checklist in the Challenges hub.
+4. Each matched destination counts once per athlete per week.
+5. Virtual and outdoor segment destinations both work when configured.
+6. The hub includes a completers summary showing all completer names without presenting a rank-ordered leaderboard.
+7. Explorer history persists across weeks and can support future season-wide aggregation.
+8. Existing competition features continue to behave correctly.
+
+## 11. Future Considerations (Post v1.0)
+
+|  |  |  |
+|  |  |  |
+| Season-wide Explorer rollups | Medium | Enabled by stored weekly history |
+| Explorer badges and streaks | Medium | Depends on stable weekly participation data |
+| Themed destination campaigns | Medium | Adds editorial depth to weekly challenges |
+| Shared-segment mini-races | High | Requires broader segment aggregation strategy |
+| Destination search and richer admin tools | Medium | Improves authoring workflow after v1 |
+
+## 12. Technical Specification
+
+A separate technical specification will accompany this PRD and define the implementation architecture, schema direction, ingestion pattern, and test strategy for Explorer Destinations.
+
+## 13. Success of Implementation
+
+### 13.1 Definition of Done
+
+|  |  |  |
+|  |  |  |
+| Feature completeness | All Must Have PRD items are implemented and functional | Manual QA plus automated tests |
+| Architecture compliance | Explorer uses delegated webhook ingestion and separate Explorer data storage | Code review and backend tests |
+| Data integrity | Explorer progress is stored correctly across weeks without duplicate counting | Integration tests |
+| UX compliance | Weekly view uses progress bar, checklist, and completers summary without rank ordering | Product QA |
+| Regression safety | Existing race leaderboard and admin flows continue to work | Regression suite |
+
+### 13.2 Launch Checklist
+
+- Explorer week creation works in admin UI.
+- Destination setup accepts and validates Strava segment URLs.
+- Explorer week activation is blocked until at least one destination exists.
+- Active Explorer week renders in the Challenges hub.
+- Athlete progress bar and checklist render correctly.
+- Completers summary is visible and shows names.
+- Manual refresh or backfill works.
+- Explorer history persists and can be queried after week end.
+- Existing leaderboard and admin regression checks pass.
+- VERSION and CHANGELOG.md are updated with implementation.
+- Explorer ideas backlog remains separate from the v1 scope.
+
+End of PRD

--- a/docs/prds/wmv-explorer-destinations-prd.md
+++ b/docs/prds/wmv-explorer-destinations-prd.md
@@ -2,8 +2,8 @@
 
 ## WMV Explorer Destinations
 
-|  |  |
-|  |  |
+| Field | Value |
+| --- | --- |
 | Product Name | WMV Explorer Destinations |
 | Version | 0.1 |
 | Author | GitHub Copilot |
@@ -32,8 +32,8 @@ WMV Explorer Destinations addresses these problems by adding a progress-first we
 
 ## 3. Goals & Objectives
 
-|  |  |  |
-|  |  |  |
+| Goal | Description | Success Signal |
+| --- | --- | --- |
 | Inclusive offseason participation | Give riders a way to participate without needing to compete on speed | Riders can engage through weekly destination completion rather than race ranking |
 | Weekly motivation | Provide a clear set of weekly riding goals | Athletes can see a weekly progress bar and destination checklist |
 | Low admin friction | Let admins create a weekly Explorer challenge from Strava segments | Admin can create an Explorer week and configure destinations in one workflow |
@@ -43,8 +43,8 @@ WMV Explorer Destinations addresses these problems by adding a progress-first we
 
 ## 4. Target Audience
 
-|  |  |  |
-|  |  |  |
+| Audience | Description | Primary Need |
+| --- | --- | --- |
 | Existing WMV athlete | Club rider already using the app for seasonal competition | A fun, low-pressure weekly riding goal |
 | Casual or exploratory rider | Rider less interested in racing but motivated by destinations and completion | A checklist-style challenge rather than a ranking system |
 | Indoor or hybrid rider | Athlete who rides on Zwift and outdoors | Weekly destinations that can be either virtual or real-world Strava segments |
@@ -54,8 +54,8 @@ WMV Explorer Destinations addresses these problems by adding a progress-first we
 
 ### 5.1 Athlete Experience
 
-|  |  |  |  |
-|  |  |  |  |
+| ID | User Story | Priority | Acceptance Criteria |
+| --- | --- | --- | --- |
 | US-01 | As an athlete, I want to see the active Explorer week so I know what destinations are available now | Must | Active Explorer week is clearly visible in the Challenges hub |
 | US-02 | As an athlete, I want to see the weekly destination list so I know what segments count | Must | Destination list shows all configured segments for the week |
 | US-03 | As an athlete, I want to see my Explorer progress as a progress bar so I can quickly tell how far along I am | Must | Progress bar shows completed destinations versus total destinations |
@@ -66,15 +66,15 @@ WMV Explorer Destinations addresses these problems by adding a progress-first we
 
 ### 5.2 Club Visibility
 
-|  |  |  |  |
-|  |  |  |  |
+| ID | User Story | Priority | Acceptance Criteria |
+| --- | --- | --- | --- |
 | US-08 | As a club member, I want to know whether anyone completed all destinations this week so the feature feels communal | Must | Weekly view includes a completers summary showing all athlete names who completed the full set |
 | US-09 | As a club member, I do not want the Explorer hub to feel like another race leaderboard | Must | Weekly view emphasizes progress and completion, not rank ordering |
 
 ### 5.3 Admin Experience
 
-|  |  |  |  |
-|  |  |  |  |
+| ID | User Story | Priority | Acceptance Criteria |
+| --- | --- | --- | --- |
 | US-10 | As an admin, I want to create a dedicated Explorer week so the feature can run independently from race weeks | Must | Admin can create Explorer weeks with their own date range |
 | US-11 | As an admin, I want to add destinations from Strava URLs so setup matches the regular admin panel workflow | Must | Admin can paste one Strava segment URL at a time and the system extracts the segment ID |
 | US-12 | As an admin, I want to add labels to destinations so the weekly challenge is presented clearly | Must | Destinations support optional labels in addition to the underlying segment metadata |
@@ -87,8 +87,8 @@ WMV Explorer Destinations addresses these problems by adding a progress-first we
 
 ### Must Have (MVP)
 
-|  |  |  |
-|  |  |  |
+| Item | User Stories | Rationale |
+| --- | --- | --- |
 | Separate Challenges hub | US-01, US-10 | Explorer must feel distinct from race competition |
 | Active Explorer week view | US-01, US-02 | Core weekly experience |
 | Progress bar + checklist UX | US-03, US-04 | Primary interaction model |
@@ -106,8 +106,8 @@ WMV Explorer Destinations addresses these problems by adding a progress-first we
 
 ### Should Have (Enhanced Experience)
 
-|  |  |  |
-|  |  |  |
+| Item | User Stories | Rationale |
+| --- | --- | --- |
 | Destination ordering | US-13 | Better weekly storytelling |
 | Cached destination names | — | Better display stability and admin confidence |
 | Explorer-specific empty states and help text | — | Clarifies how the feature works for first-time users |
@@ -115,16 +115,16 @@ WMV Explorer Destinations addresses these problems by adding a progress-first we
 
 ### Could Have (Delight)
 
-|  |  |  |
-|  |  |  |
+| Item | User Stories | Rationale |
+| --- | --- | --- |
 | Destination categories such as scenic, climb, or event | — | Adds editorial character to weekly Explorer sets |
 | Celebration treatment on full completion | US-07 | Reinforces motivation without adding competition |
 | Destination category chips or themed labels | US-12 | Adds editorial polish without changing core rules |
 
 ### Won't Have (v1.0 — Future Consideration)
 
-|  |  |
-|  |  |
+| Item | Rationale |
+| --- | --- |
 | Rank-ordered Explorer leaderboard | Explorer is progress-first in v1 |
 | Bonus scoring beyond one point per destination | Keep the rules simple first |
 | Season-wide Explorer UI | Depends on weekly history first |
@@ -146,8 +146,8 @@ The Explorer hub should present one weekly challenge at a time, with a progress-
 
 ### 7.2 UX Principles
 
-|  |  |
-|  |  |
+| Principle | Description |
+| --- | --- |
 | Progress over ranking | The page should feel like a challenge checklist, not a leaderboard |
 | Clear weekly framing | Athletes should immediately understand what counts this week |
 | Inclusive destination model | Virtual and outdoor destinations should be presented as equally valid |
@@ -156,8 +156,8 @@ The Explorer hub should present one weekly challenge at a time, with a progress-
 
 ### 7.3 Responsive Behavior
 
-|  |  |
-|  |  |
+| Breakpoint | Behavior |
+| --- | --- |
 | Desktop | Progress summary and checklist visible without excessive scrolling |
 | Tablet | Checklist remains primary content; summary compresses gracefully |
 | Mobile | Progress bar, checklist, and completers summary stack cleanly |
@@ -166,39 +166,39 @@ The Explorer hub should present one weekly challenge at a time, with a progress-
 
 ### 8.1 Performance
 
-|  |  |  |
-|  |  |  |
+| Requirement | Target | Validation |
+| --- | --- | --- |
 | Explorer hub load | Comparable to other existing app views | Manual verification and E2E timing sanity check |
 | Matching idempotency | Reprocessing must not create duplicate destination matches | Automated backend tests |
 | Refresh behavior | Manual refresh path must be safe to rerun | Automated backend tests |
 
 ### 8.2 Data Integrity
 
-|  |  |  |
-|  |  |  |
+| Requirement | Target | Validation |
+| --- | --- | --- |
 | Durable weekly history | Explorer progress remains queryable after the week ends | Automated integration tests |
 | Correct weekly boundaries | Only activities inside the Explorer week count | Backend tests for start and end edge cases |
 | One completion per destination per athlete per week | Multiple visits do not overcount | Backend tests |
 
 ### 8.3 Accessibility
 
-|  |  |  |
-|  |  |  |
+| Requirement | Target | Validation |
+| --- | --- | --- |
 | Progress visibility | Completion state is understandable without color alone | Manual QA |
 | Checklist semantics | Destination completion is screen-reader friendly | Accessibility review |
 | Keyboard navigation | Core Explorer hub interactions are keyboard accessible | Manual QA |
 
 ### 8.4 Compatibility
 
-|  |  |  |
-|  |  |  |
+| Requirement | Target | Validation |
+| --- | --- | --- |
 | Existing WMV app routes | Explorer must coexist with current leaderboard and admin flows | Regression testing |
 | Virtual and outdoor segment ingestion | Both segment types are eligible when configured | Backend matching tests |
 
 ## 9. Risks & Mitigations
 
-|  |  |  |  |
-|  |  |  |  |
+| Risk | Impact | Severity | Mitigation |
+| --- | --- | --- | --- |
 | Webhook processor complexity grows further | Harder to add Explorer safely | High | Refactor to delegated in-process handlers before adding Explorer-specific logic |
 | Strava URLs may be pasted incorrectly or parse to invalid segments | Broken destination configuration | Medium | Validate pasted URLs, extract segment IDs safely, and cache segment metadata where possible |
 | Confusion between Explorer weeks and race weeks | Users or admins may mix the two concepts | Medium | Use distinct naming, routes, and admin sections |
@@ -220,8 +220,8 @@ The v1 release is successful if:
 
 ## 11. Future Considerations (Post v1.0)
 
-|  |  |  |
-|  |  |  |
+| Future Item | Priority | Notes |
+| --- | --- | --- |
 | Season-wide Explorer rollups | Medium | Enabled by stored weekly history |
 | Explorer badges and streaks | Medium | Depends on stable weekly participation data |
 | Themed destination campaigns | Medium | Adds editorial depth to weekly challenges |
@@ -230,14 +230,14 @@ The v1 release is successful if:
 
 ## 12. Technical Specification
 
-A separate technical specification will accompany this PRD and define the implementation architecture, schema direction, ingestion pattern, and test strategy for Explorer Destinations.
+The technical specification for Explorer Destinations is documented in [wmv-explorer-destinations-tech-spec.md](./wmv-explorer-destinations-tech-spec.md), which defines the implementation architecture, schema direction, ingestion pattern, and test strategy.
 
 ## 13. Success of Implementation
 
 ### 13.1 Definition of Done
 
-|  |  |  |
-|  |  |  |
+| Area | Definition | Validation |
+| --- | --- | --- |
 | Feature completeness | All Must Have PRD items are implemented and functional | Manual QA plus automated tests |
 | Architecture compliance | Explorer uses delegated webhook ingestion and separate Explorer data storage | Code review and backend tests |
 | Data integrity | Explorer progress is stored correctly across weeks without duplicate counting | Integration tests |

--- a/docs/prds/wmv-explorer-destinations-tech-spec.md
+++ b/docs/prds/wmv-explorer-destinations-tech-spec.md
@@ -1,0 +1,306 @@
+# WMV Explorer Destinations Technical Specification
+
+## 1. Purpose
+
+This specification translates the Explorer Destinations PRD into an implementation-oriented design for the current WMV Cycling Series codebase. It preserves the key planning decisions:
+
+- Explorer is a separate product area from the current race leaderboard.
+- Explorer uses separate week and result storage rather than reusing the current competition week model.
+- Weekly UX is progress bar plus checklist plus completers summary.
+- Strava segments are the canonical destination type, regardless of whether they represent outdoor or virtual riding.
+- Webhook ingestion remains in-process but is refactored into delegated handlers so Explorer can be added without further overloading the current webhook processor.
+
+## 2. Scope
+
+### In Scope
+
+- Separate Explorer week model
+- Admin-defined Explorer destinations from Strava segment URLs or IDs
+- Explorer matching from ingested Strava activities
+- One completion per destination per athlete per Explorer week
+- Weekly athlete progress queries
+- Weekly completers summary queries with all completer names
+- Stored Explorer history across weeks
+- Reusable refresh or backfill path
+- Explorer week activation rule requiring at least one destination
+
+### Out of Scope
+
+- Explorer rank-order leaderboard
+- Bonus scoring beyond one point per destination
+- Season-wide Explorer UI
+- Shared-segment mini-races
+- Badge systems
+- Queue-backed or out-of-process worker model
+
+## 3. Current-Codebase Constraints
+
+### Existing reusable assets
+
+- Strava auth and participant identity already exist.
+- Webhook ingestion already fetches and normalizes activity data in [server/src/webhooks/processor.ts](../../server/src/webhooks/processor.ts).
+- Batch or explicit activity processing already exists in [server/src/services/BatchFetchService.ts](../../server/src/services/BatchFetchService.ts).
+- App routing and top-level navigation patterns already exist in [src/App.tsx](../../src/App.tsx) and [src/components/NavBar.tsx](../../src/components/NavBar.tsx).
+- The regular admin panel already has a Strava URL input pattern worth mirroring for Explorer destination setup rather than exposing raw segment IDs only.
+
+### Existing constraints to respect
+
+- Do not modify the canonical race scoring model in [docs/SCORING.md](../SCORING.md).
+- Do not overload current competition week records with Explorer semantics.
+- Keep Explorer additive so existing leaderboard, season, and admin flows remain intact.
+
+## 4. Recommended Architecture
+
+### 4.1 Ingestion model
+
+Refactor webhook processing into a thin orchestrator that performs the following steps:
+
+1. Receive Strava webhook event.
+2. Fetch or normalize the relevant activity data once.
+3. Build a shared activity-ingestion context.
+4. Pass that context to registered in-process handlers.
+5. Let each handler decide whether and how to persist feature-specific records.
+
+Recommended initial handlers:
+
+- Competition week matcher
+- Explorer destination matcher
+- Chain wax tracker
+
+This keeps feature fan-out inside the app boundary while avoiding a new worker or CLI-per-event process model.
+
+### 4.2 Refresh or backfill model
+
+Explorer also needs an explicit refresh path for late joins, recovery, and admin operations. That path should reuse the same underlying Explorer matching service used by the webhook handler rather than re-implementing the logic in a separate batch-only flow.
+
+Recommended direction:
+
+- Extract Explorer matching into a reusable service.
+- Call that service from the Explorer ingestion handler.
+- Call that same service from an admin or participant-triggered refresh action.
+
+## 5. Proposed Data Model
+
+### 5.1 New entities
+
+Recommended Explorer tables or equivalent schema concepts:
+
+- ExplorerWeek
+  - id
+  - name
+  - startAt
+  - endAt
+  - status or active flag
+  - createdAt
+  - updatedAt
+
+Activation rule: an ExplorerWeek cannot move to an active state unless it has at least one ExplorerDestination.
+
+- ExplorerDestination
+  - id
+  - explorerWeekId
+  - stravaSegmentId
+  - sourceUrl nullable
+  - cachedSegmentName
+  - displayLabel nullable
+  - displayOrder
+  - surfaceType nullable such as virtual or outdoor
+  - category nullable such as scenic, event, climb
+  - createdAt
+  - updatedAt
+
+- ExplorerDestinationMatch
+  - id
+  - explorerWeekId
+  - explorerDestinationId
+  - stravaAthleteId
+  - stravaActivityId
+  - matchedAt or activityStartAt
+  - createdAt
+
+- ExplorerAthleteWeekSummary
+  - optional derived or cached summary table if needed later
+  - explorerWeekId
+  - stravaAthleteId
+  - matchedDestinationCount
+  - completedAll boolean
+  - lastMatchedAt
+
+For v1, ExplorerAthleteWeekSummary can remain computed on read if query cost is modest. The durable source of truth should be ExplorerDestinationMatch.
+
+### 5.2 Key integrity rules
+
+- One athlete can match a given destination at most once per Explorer week.
+- Multiple rides over the same destination in the same Explorer week do not increase progress.
+- Matches are constrained to the Explorer week date range.
+- Explorer records must survive after the week ends so future season views can aggregate them.
+
+### 5.3 Segment source model
+
+Admins should be able to configure destinations by pasting Strava segment URLs, following the same mental model as the regular admin panel. The system should extract the segment ID from the URL, validate it, and store the parsed segment ID plus the original source URL when available. If the segment is already known in the app's segment table, that data can be reused. If not, Explorer should still accept it and cache enough display metadata for a stable UI.
+
+## 6. Core Services
+
+### 6.1 Explorer matching service
+
+Responsibilities:
+
+- Receive normalized activity data plus athlete context.
+- Determine which Explorer weeks are active for the activity timestamp.
+- For each relevant Explorer week, compare activity segment efforts to configured Explorer destination segment IDs.
+- Create missing ExplorerDestinationMatch records idempotently.
+- Return summary information about newly matched destinations.
+
+This service is the core reusable unit for both webhook-driven ingestion and explicit refresh.
+
+### 6.2 Explorer query service
+
+Responsibilities:
+
+- Get active Explorer week for UI.
+- Get destination list for a given Explorer week.
+- Get current athlete progress for that week.
+- Get completers summary for that week, including all completer names.
+- Leave athlete profile aggregation out of the first implementation slice.
+
+### 6.3 Explorer admin service
+
+Responsibilities:
+
+- Create and update Explorer weeks.
+- Add, edit, remove, and reorder Explorer destinations.
+- Validate or enrich destination metadata from Strava where possible.
+- Trigger refresh or backfill actions.
+
+## 7. API Surface
+
+Recommended new tRPC surface areas:
+
+- explorer.getActiveWeek
+- explorer.getWeekProgress
+- explorer.getWeekCompleters
+- explorerAdmin.createWeek
+- explorerAdmin.updateWeek
+- explorerAdmin.addDestination
+- explorerAdmin.updateDestination
+- explorerAdmin.removeDestination
+- explorerAdmin.reorderDestinations
+- explorerAdmin.refreshWeek
+- explorerAdmin.refreshAthlete
+
+These names are illustrative. Final naming should fit existing router conventions.
+
+## 8. UI Surface
+
+### 8.1 User-facing hub
+
+Recommended user-facing sections:
+
+- Challenges hub route
+- Active Explorer week header
+- Progress bar
+- Destination checklist
+- Completers summary
+
+### 8.2 Admin surface
+
+Recommended initial admin capabilities:
+
+- Create Explorer week with date range
+- Add one destination at a time by pasting a Strava segment URL and parsing the segment ID
+- Edit destination display label and ordering
+- Prevent activation until at least one destination exists
+- Run refresh for a week or athlete
+
+## 9. Matching Rules
+
+### V1 rules
+
+- A destination is a Strava segment configured on an Explorer week.
+- A destination counts when the athlete has a qualifying activity containing that segment during the Explorer week.
+- Each destination is worth one point internally.
+- The athlete's visible progress is completed destinations divided by total destinations.
+- Repeated visits do not add progress beyond the first match.
+- Virtual and outdoor segments are treated equally if configured.
+
+### Open implementation decisions for later phases, not blockers for v1
+
+- Whether to display segment source labels like virtual or outdoor in the checklist
+- Whether a deleted activity should remove an Explorer match if it was the only source of completion
+- Whether to compute historical rollups on read or cache them incrementally
+
+## 10. Testing Strategy
+
+### Backend
+
+Add tests for:
+
+- Explorer week boundary handling
+- Destination match idempotency
+- Duplicate segment visits in one week
+- Multiple destinations in one activity
+- Virtual and outdoor segment parity
+- Strava URL parsing and validation
+- Refresh and webhook parity using the same matching service
+- Regression protection for current competition webhook behavior
+
+### Frontend
+
+Add tests for:
+
+- Challenges hub navigation
+- Active Explorer week rendering
+- Progress bar state
+- Checklist completion state
+- Completers summary rendering
+- Empty states for no active week or no progress yet
+
+### End-to-end
+
+Recommended E2E journeys:
+
+- Admin creates Explorer week and destinations
+- Explorer week cannot activate until at least one destination exists
+- Athlete views active Explorer week
+- Athlete completes one destination and sees progress update
+- Athlete completes full weekly set and sees completion state
+- Completers summary reflects at least one full completer
+
+## 11. Migration and Rollout Sequence
+
+1. Refactor webhook processor toward delegated handlers without changing current competition behavior.
+2. Add Explorer schema and backend services.
+3. Implement Explorer matching handler and shared refresh path.
+4. Add Explorer tRPC routes.
+5. Add admin Explorer setup UI.
+6. Add Challenges hub UI with progress bar, checklist, and completers summary.
+7. Run regression checks on race and admin flows.
+8. Update VERSION and CHANGELOG.md when implementation begins.
+
+## 12. Risks and Mitigations
+
+- Risk: Explorer ingestion logic diverges between webhook and refresh paths.
+  Mitigation: route both through the same matching service.
+
+- Risk: Strava URL parsing becomes brittle.
+  Mitigation: mirror the existing admin-panel parsing approach and test it directly.
+
+- Risk: Explorer begins to inherit competition UX by accident.
+  Mitigation: avoid ranked lists in the primary weekly surface.
+
+- Risk: Webhook processor becomes more complex during transition.
+  Mitigation: refactor to delegated handlers before layering in Explorer logic.
+
+## 13. Suggested Handoff Notes
+
+If this moves to implementation, the first engineering slice should be the delegated ingestion refactor plus Explorer schema design. That is the structural work that determines whether the rest of the feature can be added cleanly.
+
+The next slice should be the smallest end-to-end Explorer loop:
+
+- one Explorer week
+- one or more destinations
+- one athlete progress query
+- one completers summary query
+- one admin refresh action
+
+That would validate the model before building more UI.


### PR DESCRIPTION
## Summary
- add a new `docs/prds/` area for product and implementation planning docs
- add the WMV Explorer Destinations PRD, technical spec, phases doc, and ideas backlog
- link the new PRD area from the main docs index

## Why
This lands the baseline documentation for Explorer Destinations as a docs-only change before implementation begins. It also creates a stable source of truth for follow-on phase work.

## Follow-on Work
- First concrete implementation issue: #16
- Phase 1 after this PR: refactor webhook ingestion into delegated in-process handlers for Explorer groundwork

## Validation
- Repo pre-commit hooks passed during commit
- Typecheck passed
- Lint passed