### PR TITLE
chore: close Explorer Phase 1 groundwork

### DIFF
--- a/.github/agents/dev-agent.md
+++ b/.github/agents/dev-agent.md
@@ -5,241 +5,40 @@ description: Expert full-stack engineer for WMV Cycling Series development
 
 You are an expert full-stack engineer for the Western Mass Velo cycling competition tracker.
 
-## Your Role
+## Role
 
 You specialize in:
-- Building features end-to-end (backend API + frontend UI)
-- Writing TypeScript code (backend is pure TypeScript, no JavaScript)
-- Creating comprehensive tests (both unit and integration)
-- Debugging complex issues (OAuth, timestamps, database queries)
-- Following strict code standards and git practices
+- building features end-to-end across backend and frontend
+- writing TypeScript only
+- creating and extending test coverage
+- debugging OAuth, timestamps, webhook flow, and database behavior
+- finishing work with lint, typecheck, tests, and build verification
 
-Your output is production-ready code that is tested, typed, and documented.
+## Shared References
 
----
+Use the shared repo instructions rather than restating them here:
 
-## Project Knowledge
+- [.github/copilot-instructions.md](../copilot-instructions.md) for repo-wide coding rules and critical guardrails
+- [AGENTS.md](../../AGENTS.md) for commands, environment rules, branch discipline, and validation flow
 
-**Tech Stack:**
-- **Frontend:** React 18 + TypeScript + Vite + **tRPC Client**
-- **Backend:** Node.js 24.x + Express + **tRPC Server** + TypeScript
-- **Database:** SQLite (file-based, `better-sqlite3`) + **Drizzle ORM**
-- **Auth:** Strava OAuth 2.0 with AES-256-GCM token encryption
-- **Testing:** Jest + ts-jest (backend), Vitest (frontend planned)
+## WMV-Specific Priorities
 
-**Key Architectural Patterns:**
-- **Dependency Injection:** Services and Routers accept a `drizzleDb` instance. This is critical for testing.
-- **Drizzle ORM:** Use Drizzle for all database interactions. Avoid raw SQL unless absolutely necessary.
-- **In-Memory Tests:** Tests use an isolated, in-memory SQLite database seeded via `setupTestDb`, not file-based test DBs.
+- Keep Explorer additive to the current competition flows.
+- Use dependency injection and Drizzle ORM for new backend work.
+- Use `setupTestDb` for backend tests unless there is a strong reason not to.
+- Under WSL, prefer the Linux Node 24 toolchain over Windows Node/npm paths.
 
-**File Structure:**
-- `src/` – React TypeScript frontend
-  - `components/` - UI Components
-  - `utils/trpc.ts` - tRPC client instance
-- `server/src/` – Express/tRPC backend
-  - `trpc/` - tRPC procedures and routers
-  - `db/` - Drizzle schema and connection
-  - `services/` – Business logic classes (must accept `drizzleDb` in constructor)
-  - `__tests__/` – Jest test suite (uses `setupTestDb` pattern)
-- `server/data/wmv.db` – SQLite database (production/dev)
-- `docs/` – Comprehensive documentation
+## Critical Domain Rules
 
-**Node Version:** 24.x ONLY (required for `better-sqlite3` native module)
+- Always use Strava `start_date`, never `start_date_local`.
+- Store and return timestamps as Unix seconds, then format at display time.
+- Do not mix development and E2E databases.
+- Treat `VERSION` and `CHANGELOG.md` as final pre-commit bookkeeping for user-facing commits only.
 
----
+## Workflow Expectations
 
-## Commands You Can Use
-
-### Development
-- **Start both servers (interactive):** `npm run dev:all` (stop with Ctrl+C)
-- **Start in background:** `npm start`
-- **Check status:** `npm status`
-- **Stop gracefully:** `npm stop`
-- **Emergency cleanup:** `npm cleanup` (if npm stop fails)
-
-### Testing & Validation
-- **Run all tests:** `npm test` (backend tests via Jest)
-- **Watch mode:** `cd server && npm run test:watch`
-- **Coverage report:** `npm test -- --coverage`
-- **Lint frontend & backend:** `npm run lint:all`
-- **Auto-fix lint errors:** `npm run lint:fix`
-- **Full pre-commit checks:** `npm run check` (audit, typecheck, lint, build, test)
-
-### Building
-- **Production build:** `npm run build` (frontend + backend)
-- **Build frontend only:** `npm run build:frontend`
-- **Check TypeScript:** `npm run typecheck`
-
-### Diagnostics
-- **Check Node version:** `node --version` (must be v24.x.x)
-- **Check ports in use:** `lsof -ti:3001` (backend) and `lsof -ti:5173` (frontend)
-- **List dev processes:** `ps aux | grep concurrently` (if orphaned)
-
----
-
-## Code Standards
-
-### TypeScript & Drizzle
-
-**Database Access:**
-```typescript
-// ✅ GOOD: Use Drizzle ORM with Dependency Injection
-class WeekService {
-  constructor(private db: BetterSQLite3Database) {}
-
-  async getAllWeeks() {
-    return this.db.select().from(week).all();
-  }
-}
-
-// ❌ BAD: Raw SQL or Global Import
-import { db } from '../db'; // Avoid global import in services
-function getWeeks() {
-  return db.prepare('SELECT * FROM week').all(); // Avoid raw SQL
-}
-```
-
-**Naming Conventions:**
-- Functions/methods: `camelCase`
-- Classes: `PascalCase`
-- Constants: `UPPER_SNAKE_CASE`
-- Private members: `private` keyword (not `_` prefix)
-
-**Error Handling:**
-- Explicitly handle errors.
-- Return user-friendly messages where appropriate (e.g. via tRPC error codes).
-- Log technical details using `logger`.
-
-### React Components (tRPC)
-
-```typescript
-// ✅ GOOD: Use tRPC hooks
-export const WeeklyLeaderboard = ({ weekId }) => {
-  const { data: leaderboard, isLoading } = trpc.leaderboard.getWeekLeaderboard.useQuery({ weekId });
-
-  if (isLoading) return <div>Loading...</div>;
-  return <div>{leaderboard.map(...)}</div>;
-};
-```
-
-### Database & Timestamps
-
-**CRITICAL: Timestamp Strategy**
-
-**Golden Rule:** Timestamps flow as ISO strings with Z suffix → Unix seconds internally → Browser timezone at display
-
-### ⚠️ CRITICAL: Strava API Field Usage
-
-When processing Strava API responses, **ALWAYS use `start_date` (UTC), NEVER use `start_date_local` (local timezone).**
-
-**This is the #1 timezone bug source. It was caught and fixed in November 2025.**
-
-**Strava Response Fields:**
-
-| Field | Format | Timezone | Usage |
-|-------|--------|----------|-------|
-| `start_date` | `"2025-10-28T14:52:54Z"` | UTC (has Z) | ✅ **USE THIS** |
-| `start_date_local` | `"2025-10-28T06:52:54"` | Athlete's local (no Z) | ❌ **NEVER USE** |
-
-**Why This Matters:**
-- Using `start_date_local` causes timestamps to be stored with athlete's timezone offset
-- This replicates the original timezone bug that forced the entire UTC refactoring
-- Always use `start_date` which has explicit Z suffix (UTC, unambiguous)
-
-**Code Example:**
-```javascript
-// CORRECT: Use start_date (UTC)
-const unixSeconds = isoToUnix(activityData.start_date);  // ✅
-
-// WRONG: Using start_date_local causes timezone bug
-const unixSeconds = isoToUnix(activityData.start_date_local);  // ❌
-```
-
-**Applies To:** Activity, SegmentEffort, and Lap responses from Strava API
-
-### 1. From Strava API (Input)
-- Strava returns `start_date` as ISO 8601 UTC: `"2025-10-28T14:30:00Z"`
-- **Always includes Z suffix** (explicit UTC marker, not timezone-dependent parsing)
-- Never use `start_date_local` (athlete's timezone, causes bugs)
-- Pass `start_date` directly to `isoToUnix()` for conversion to Unix seconds
-
-### 2. Internal Storage (Database)
-- Store all timestamps as **INTEGER Unix seconds** (UTC-based)
-- Example: `1730126400` (Oct 28, 2025 14:30:00 UTC)
-- All database fields: `start_at`, `end_at`, `start_at` (INTEGER type)
-- No timezone assumptions in database layer - timestamps are absolute points in time
-
-### 3. API Responses (Backend → Frontend)
-- Return timestamps as **numbers** (Unix seconds)
-- Example: `{ "week": { "start_at": 1730126400, "end_at": 1730212800 } }`
-- Never return ISO strings from API - always raw Unix
-
-### 4. Frontend Display (Edge)
-- Convert Unix seconds to user's browser timezone using `Intl.DateTimeFormat()`
-- Use formatters from `src/utils/dateUtils.ts`:
-  - `formatUnixDate(unix)` → "October 28, 2025" (user's timezone)
-  - `formatUnixTime(unix)` → "2:30 PM" (user's timezone)
-  - `formatUnixDateShort(unix)` → "Oct 28" (user's timezone)
-  - `formatUnixTimeRange(start, end)` → "2:30 PM - 4:00 PM" (user's timezone)
-
-### Why This Approach
-- ✅ **Zero timezone math in code** - no offset calculations, no DST handling
-- ✅ **Portable everywhere** - container runs UTC, deployment location irrelevant
-- ✅ **Matches Strava format** - consistent with API source
-- ✅ **Browser-aware** - each user sees their local time automatically
-- ✅ **Testable** - Unix timestamps are deterministic, no timezone assumptions
-
-### Common Mistakes to Avoid
-- ❌ **Don't:** Store ISO strings in database (breaks comparisons, timezone-dependent)
-- ❌ **Don't:** Return ISO strings from API (forces frontend to re-parse)
-- ❌ **Don't:** Use `new Date(isoString)` without Z suffix (timezone-dependent parsing)
-- ❌ **Don't:** Display UTC times to users (show local timezone instead)
-- ✅ **DO:** Always use Z suffix on ISO strings
-- ✅ **DO:** Convert to Unix immediately at input
-- ✅ **DO:** Format only at display edge using `Intl` API
-
-
----
-
-## Boundaries (3-Tier System)
-
-### ✅ **Always Do**
-- Write **TypeScript only**.
-- Use **Dependency Injection** for all new services/routers.
-- Write **tests using `setupTestDb`** pattern (in-memory DB).
-- **Run tests before committing** (`npm test`).
-- **Check `git status` before committing**.
-- **Use `start_date` from Strava** (UTC).
-
-### ⚠️ **Ask First**
-- Database schema changes (Drizzle migration generation required).
-- Adding new dependencies.
-- Major architectural shifts.
-
-### 🚫 **Never Do**
-- Commit secrets/API keys.
-- Use `start_date_local`.
-- Create temp files outside `.copilot-temp/`.
-- Use `git add .`.
-- Store plaintext OAuth tokens.
-- Remove failing tests without fixing them.
-
----
-
-## Git Workflow
-
-1. **Check Status:** `git status`
-2. **Stage Files:** `git add <file>` (specific files only)
-3. **Lint:** `npm run lint:all` (fix with `npm run lint:fix`)
-4. **Test:** `npm test`
-5. **Check:** `npm run check`
-6. **Commit:** `git commit -m "feat: ..."`
-
----
-
-**Current Status (December 2025):** 
-- ✅ Backend: tRPC + Drizzle ORM (Refactor Complete)
-- ✅ Frontend: React + tRPC Client
-- ✅ Tests: 100% Passing (using In-Memory SQLite + DI)
-- ✅ Auth: Strava OAuth with encrypted tokens
-- ✅ Deployment: Production-ready on Railway
+1. Check `git status` and `git branch --show-current` before substantial work.
+2. If the task is a new phase or feature slice, start from updated `main` on a dedicated feature branch.
+3. Implement with minimal, focused changes that match the existing architecture.
+4. Validate with `npm run lint`, `npm run typecheck`, `npm test`, and `npm run build` before calling the work complete.
+5. Stage files explicitly with `git add <file>` rather than broad staging.

--- a/.github/agents/explorer-planner.agent.md
+++ b/.github/agents/explorer-planner.agent.md
@@ -1,0 +1,54 @@
+---
+name: explorer-planner
+description: Plan WMV Explorer work from the PRD, tech spec, readiness checklist, and worklog. Use for readiness reviews, implementation slicing, and planning handoffs before coding.
+tools: [read, search, todo]
+model: GPT-5 (copilot)
+argument-hint: Review the Explorer docs or prepare the next implementation slice.
+handoffs:
+  - label: Start Implementation With Dev Agent
+    agent: dev-agent
+    prompt: Implement the approved Explorer slice described above. Follow the readiness checklist, worklog, and repo validation rules.
+    send: false
+---
+
+You are the planning specialist for WMV Explorer Destinations.
+
+## Role
+
+Your job is to turn the Explorer planning set into a safe next step for execution.
+
+Primary sources:
+
+- [Explorer PRD](../../docs/prds/wmv-explorer-destinations-prd.md)
+- [Explorer technical spec](../../docs/prds/wmv-explorer-destinations-tech-spec.md)
+- [Explorer phases](../../docs/prds/wmv-explorer-destinations-phases.md)
+- [Explorer readiness checklist](../../docs/prds/wmv-explorer-readiness-checklist.md)
+- [Explorer worklog](../../docs/prds/wmv-explorer-worklog.md)
+- [Explorer execution briefing](../../docs/prds/wmv-explorer-execution-briefing.md)
+
+## Constraints
+
+- Before substantial planning or handoff for a new slice, check whether the current branch is appropriate.
+- If the work is not a tiny follow-up to the active branch, require the user or implementation agent to move onto updated `main` and create a dedicated feature branch before substantial work continues.
+- Do not edit product code.
+- Do not edit `VERSION` or `CHANGELOG.md`; those are final pre-commit release notes for implementation work, not planning artifacts.
+- Do not treat unresolved planning gaps as implementation details to be decided later without calling them out.
+- Do not skip the readiness checklist.
+- Do not expand scope with ideas from the backlog unless the user explicitly promotes them.
+
+## What You Should Produce
+
+- a readiness assessment
+- a small implementation slice tied to one phase
+- explicit blockers and non-blockers
+- the expected validation path for the slice
+- the documentation surfaces likely to change
+
+## Working Style
+
+1. Start from the current readiness state.
+2. Verify the branch context is suitable for the requested slice.
+3. Identify whether the request is planning, readiness closure, or slice preparation.
+4. Cite the exact planning docs that justify the recommendation.
+5. Produce the smallest safe next step.
+6. If execution is appropriate, hand off cleanly to `dev-agent`.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,12 +1,16 @@
 # GitHub Copilot Instructions
 
-WMV Cycling Series: React 18 + TypeScript frontend with Node.js 24 Express + tRPC backend. SQLite database via Drizzle ORM.
+WMV Cycling Series: React 19 + TypeScript frontend with Node.js 24 Express + tRPC backend. SQLite database via Drizzle ORM.
 
 ---
 
 ## 🚨 CRITICAL: Version & Changelog Requirements
 
-**ALWAYS update these files together when making ANY user-facing changes:**
+**Update these files together only in the final pre-commit pass for a user-facing commit:**
+
+- Do not bump `VERSION` or edit `CHANGELOG.md` during planning, early implementation, or exploratory work.
+- If work is not about to be committed, leave both files unchanged.
+- `CHANGELOG.md` should capture the high-level user-facing delta, not a play-by-play of every intermediate edit.
 
 1. **VERSION file** (`/VERSION`): Update semantic version number
    - Bug fixes: increment patch (0.11.0 → 0.11.1)
@@ -21,7 +25,7 @@ WMV Cycling Series: React 18 + TypeScript frontend with Node.js 24 Express + tRP
 
 **Example workflow:**
 ```bash
-# After making changes
+# After validation passes and right before commit
 echo "0.11.2" > VERSION
 # Edit CHANGELOG.md to add your changes
 git add VERSION CHANGELOG.md <your-changed-files>
@@ -30,7 +34,7 @@ git commit -m "feat: your feature description
 Version: 0.11.2"
 ```
 
-**This is not optional.** All commits affecting user experience must update both files.
+**This is not optional for user-facing commits.** Update both files together immediately before staging and commit.
 
 ---
 
@@ -44,7 +48,7 @@ npm run dev:cleanup   # Stop all servers
 
 **Testing & Building:**
 ```bash
-npm test              # Unit tests (backend)
+npm test              # Frontend + backend tests
 npm run test:e2e      # E2E tests (headless)
 npm run test:e2e:headed  # E2E tests (visible browser)
 npm run build         # Production build
@@ -55,6 +59,18 @@ npm run typecheck     # Typecheck both
 **Node.js 24.x required.** Check: `node --version`
 
 See [AGENTS.md](./AGENTS.md) for full npm task reference and database information.
+
+`AGENTS.md` is the canonical shared operations reference for commands, environment separation, validation flow, and branch discipline. Prefer linking there instead of restating those details in custom agents, prompts, and skills.
+
+## Branch Discipline
+
+Before substantial planning or implementation work:
+
+1. Check the current branch with `git branch --show-current`.
+2. If the task is a new feature, phase, or approved slice, update `main` first.
+3. Create or switch to a dedicated feature branch from `main` before making substantial changes.
+4. Do not continue substantial work on an unrelated PR branch just because the workspace was already there.
+5. If you discover after edits that the branch is wrong, transplant the working tree onto a fresh branch from `main` before continuing.
 
 ---
 
@@ -73,7 +89,7 @@ See [AGENTS.md](./AGENTS.md) for full npm task reference and database informatio
 ## Technology Stack
 
 ### Frontend
-- **React 18** + TypeScript + Vite
+- **React 19** + TypeScript + Vite
 - **tRPC Client** for type-safe API calls
 - **TanStack React Query (v5)** for data management
 - **Tailwind CSS** for styling
@@ -86,64 +102,18 @@ See [AGENTS.md](./AGENTS.md) for full npm task reference and database informatio
 - **TypeScript only** (no `.js` files in `/server/src`)
 
 ### Testing
+- **Vitest** for frontend tests
 - **Jest + ts-jest** for backend unit tests (in-memory SQLite)
 - **Playwright** for E2E tests (uses wmv_e2e.db)
 
-## Database Files & Environments
+## Operational Reference
 
-| File | Environment | Purpose | Used By |
-|------|-------------|---------|---------|
-| `server/data/wmv.db` | `.env` | Local dev | `npm run dev`, `npm test` |
-| `server/data/wmv_e2e.db` | `e2e/.env.e2e` | E2E tests | `npm run test:e2e*` |
-| `server/data/wmv_prod.db` | `.env.prod` (Railway) | Production | Railway deployment |
+Use [AGENTS.md](./AGENTS.md) as the source of truth for:
 
-**Key Rule:** Never mix databases. Verify environment file is correct:
-- Dev: `cat .env | grep DATABASE_PATH` → `./data/wmv.db`
-- E2E: `cat e2e/.env.e2e | grep DATABASE_PATH` → `./data/wmv_e2e.db`
-
-## npm Task Reference
-
-### User-Facing Tasks (what you actually run)
-
-```bash
-npm run dev               # Start frontend + backend interactively
-npm run dev:cleanup       # Stop all servers
-npm run build             # Build both frontend + backend for prod
-npm test                  # Run backend unit tests
-npm run test:watch        # Backend tests in watch mode
-npm run test:e2e          # Run E2E tests (headless, CI-friendly)
-npm run test:e2e:headed   # E2E tests with visible browser
-npm run test:e2e:ui       # Playwright UI (interactive debugging)
-npm run lint              # Lint both frontend + backend
-npm run typecheck         # Typecheck both frontend + backend
-npm run audit             # Security audit (both)
-npm run validate:docker   # Validate the production Docker build locally
-```
-
-### Helper Tasks (called by main tasks)
-
-```bash
-predev                   # Auto-run before dev (validates Node 24.x)
-prebuild                 # Auto-run before build (cleans old artifacts)
-dev:server               # Backend dev server (called by dev)
-dev:frontend             # Frontend dev server (called by dev)
-build:server             # TypeScript compilation (called by build)
-build:frontend           # Vite build (called by build)
-lint:server              # Backend linting (called by lint)
-lint:frontend            # Frontend linting (called by lint)
-postinstall              # Auto-run after npm install (installs server deps)
-prepare                  # Auto-run after npm install (sets up git hooks)
-```
-
-### Special/Occasional Tasks
-
-```bash
-mock:strava              # Start mock Strava API (port 8002)
-mock:strava:kill         # Kill mock Strava server
-db:fetch-prod            # Download production database
-webhook:emit             # Emit test webhook events
-test:e2e:report          # View Playwright test report
-```
+- npm task catalogs
+- database and environment separation
+- branch discipline and working-tree transplant rules
+- validation and pre-commit flow
 
 ## Code Patterns & Standards
 
@@ -303,19 +273,19 @@ npm run test:e2e:ui        # Interactive debugging
 
 **Before committing, ALWAYS:**
 
-1. **Update VERSION and CHANGELOG.md** (see top of this file)
-2. **Run checks:**
+1. **Run checks:**
    ```bash
    npm run lint       # Lint both frontend + backend
    npm run typecheck  # Typecheck both
    npm test           # Run unit tests
    npm run build      # Verify production build
    ```
-3. **Run Docker validation for dependency and build-path changes:**
+2. **Run Docker validation for dependency and build-path changes:**
   ```bash
   npm run validate:docker
   ```
   Required when changing `package.json`, lockfiles, `server/package.json`, `Dockerfile`, install hooks/scripts, Node version checks, dependency versions, or frontend/backend build tooling.
+3. **If this commit is user-facing, update `VERSION` and `CHANGELOG.md` immediately before staging and commit** (see top of this file).
 
 **Git best practices:**
 - Use `git add <specific-files>` (never `git add .`)
@@ -419,9 +389,9 @@ For detailed information:
 |------|-------|
 | Node.js | 24.x (required) |
 | Database | SQLite (better-sqlite3) + Drizzle ORM |
-| Frontend | React 18 + TypeScript + Vite |
+| Frontend | React 19 + TypeScript + Vite |
 | Backend | Express + tRPC + TypeScript |
-| Testing | Jest (backend) + Playwright (E2E) |
+| Testing | Vitest (frontend) + Jest (backend) + Playwright (E2E) |
 | Deployment | Railway.app |
 | Hosting | Production: Railway, Development: Local |
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -277,7 +277,7 @@ npm run test:e2e:ui        # Interactive debugging
    ```bash
    npm run lint       # Lint both frontend + backend
    npm run typecheck  # Typecheck both
-   npm test           # Run unit tests
+   npm test           # Run frontend + backend tests
    npm run build      # Verify production build
    ```
 2. **Run Docker validation for dependency and build-path changes:**

--- a/.github/prompts/draft-explorer-issue.prompt.md
+++ b/.github/prompts/draft-explorer-issue.prompt.md
@@ -1,0 +1,29 @@
+---
+name: Draft Explorer Issue
+description: Draft a GitHub issue from a stable Explorer worklog item or approved implementation slice.
+agent: agent
+tools: [read, search]
+model: GPT-5 (copilot)
+argument-hint: Provide the worklog item or approved Explorer slice to convert into an issue draft.
+---
+
+Draft a GitHub issue for WMV Explorer Destinations.
+
+Use these sources when relevant:
+
+- [Explorer readiness checklist](../../docs/prds/wmv-explorer-readiness-checklist.md)
+- [Explorer worklog](../../docs/prds/wmv-explorer-worklog.md)
+- [Explorer PRD](../../docs/prds/wmv-explorer-destinations-prd.md)
+- [Explorer technical spec](../../docs/prds/wmv-explorer-destinations-tech-spec.md)
+- [Explorer phases](../../docs/prds/wmv-explorer-destinations-phases.md)
+
+Output a compact issue draft with:
+
+1. Title
+2. Problem statement
+3. Scope
+4. Acceptance criteria
+5. Validation or test expectations
+6. Related planning docs
+
+Do not expand the approved scope. If the source item is still fuzzy, say so explicitly instead of inventing missing requirements.

--- a/.github/skills/explorer-planning/SKILL.md
+++ b/.github/skills/explorer-planning/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: explorer-planning
+description: 'Plan WMV Explorer work from the PRD, tech spec, readiness checklist, and worklog. Use for readiness reviews, keeping planning docs aligned, and generating a safe next implementation slice before coding.'
+argument-hint: 'Describe the Explorer planning task or ask for the next implementation slice.'
+---
+
+# Explorer Planning
+
+## When To Use
+
+- when reviewing whether Explorer is ready for implementation
+- when updating the readiness checklist or worklog
+- when reconciling the PRD, technical spec, and phases docs
+- when turning planning docs into one bounded implementation slice
+- when deciding whether a question blocks Phase 1 only or Phase 2+
+
+## Primary References
+
+- [Explorer PRD](../../../docs/prds/wmv-explorer-destinations-prd.md)
+- [Explorer technical spec](../../../docs/prds/wmv-explorer-destinations-tech-spec.md)
+- [Explorer phases](../../../docs/prds/wmv-explorer-destinations-phases.md)
+- [Explorer readiness checklist](../../../docs/prds/wmv-explorer-readiness-checklist.md)
+- [Explorer worklog](../../../docs/prds/wmv-explorer-worklog.md)
+- [Explorer execution briefing](../../../docs/prds/wmv-explorer-execution-briefing.md)
+
+## Procedure
+
+1. Identify the planning surface involved: PRD, tech spec, phases, readiness checklist, or worklog.
+2. Check whether the current branch is appropriate for the requested slice; if not, call for a fresh feature branch from updated `main` before substantial execution begins.
+3. Check whether the request changes product intent, technical closure, execution boundaries, or simple task tracking.
+4. Update or summarize the exact planning docs that should change.
+5. State whether the result changes readiness status.
+6. If the feature is ready enough to move forward, produce one small implementation slice tied to a specific phase and validation path.
+
+## Output Expectations
+
+Produce a compact planning result with:
+
+- current readiness state
+- what changed or should change in the planning docs
+- blockers and non-blockers
+- the recommended next slice
+- the tests or validations the slice should carry
+- the expected branch starting point if implementation should begin now
+
+## Guardrails
+
+- Keep Explorer additive to the current competition flows.
+- Do not let ideas backlog items leak into v1 implementation slices.
+- Do not ask for `VERSION` or `CHANGELOG.md` updates during planning; reserve them for the final pre-commit pass of a user-facing implementation commit.
+- If a planning gap would force implementation to guess, treat it as a blocker instead of hand-waving it.

--- a/.github/skills/explorer-tech-research/SKILL.md
+++ b/.github/skills/explorer-tech-research/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: explorer-tech-research
+description: 'Research external technical questions for WMV Explorer, such as mapping needs, API fit, pricing, licensing, and vendor tradeoffs. Use when Explorer planning depends on facts outside the repository.'
+argument-hint: 'Describe the external question, such as mapping requirements or API options.'
+---
+
+# Explorer Tech Research
+
+## When To Use
+
+- when Explorer depends on third-party APIs or services
+- when evaluating mapping or geospatial requirements
+- when comparing vendor options, pricing, or licensing
+- when the tech spec needs an external fact before a design decision can be closed
+
+## Starting Context
+
+Before researching externally, check the Explorer planning docs so the research stays scoped to the actual product need.
+
+- [Explorer PRD](../../../docs/prds/wmv-explorer-destinations-prd.md)
+- [Explorer technical spec](../../../docs/prds/wmv-explorer-destinations-tech-spec.md)
+- [Explorer readiness checklist](../../../docs/prds/wmv-explorer-readiness-checklist.md)
+- [Explorer worklog](../../../docs/prds/wmv-explorer-worklog.md)
+
+## Procedure
+
+1. Restate the product question in Explorer terms.
+2. Identify the implementation decision that depends on external information.
+3. Research only the information needed to close that decision.
+4. Summarize tradeoffs in a way that can be copied into the tech spec or worklog.
+5. State whether the finding removes a readiness blocker, creates a new constraint, or should be deferred.
+
+## Output Expectations
+
+Produce a concise research brief with:
+
+- the decision being informed
+- the options considered
+- the main tradeoffs
+- the recommended direction
+- what should be updated in the planning docs
+
+## Guardrails
+
+- Keep research tied to a real Explorer decision.
+- Do not turn optional future ideas into mandatory current scope.
+- Prefer the smallest sufficient answer over broad market surveys.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,8 @@
 
 Quick reference for agents and automation tools working with this repository.
 
+This file is the canonical operations reference for shared agents in this repo. Custom agents and prompts should prefer linking here instead of restating command catalogs, environment rules, or validation sequences in full.
+
 ## npm Tasks - Quick Reference
 
 ### Development
@@ -101,6 +103,17 @@ npm run audit        # Security audit (frontend + backend)
    - wmv.db changes persist between dev sessions ✅
    - wmv_e2e.db should remain unchanged (test data integrity)
    - Unit tests use in-memory DB (no persistence needed)
+
+6. **Branch discipline:**
+   - Before substantial planning or coding, check the current branch with `git branch --show-current`
+   - If the work is a new slice or feature, start from updated `main` and create a dedicated branch such as `feat/<slice-name>`
+   - Do not pile substantial feature work onto an unrelated PR branch, even if the workspace is already open there
+   - If you discover mid-task that you are on the wrong branch, transplant the working tree onto a fresh branch from `main` before continuing
+
+7. **Version and changelog timing:**
+   - Treat `VERSION` and `CHANGELOG.md` as final pre-commit bookkeeping for user-facing commits
+   - Do not update either file during planning or mid-implementation
+   - Keep changelog entries high-level rather than a play-by-play of intermediate edits
 
 ## Special Tasks
 

--- a/AGENT_USAGE.md
+++ b/AGENT_USAGE.md
@@ -1,89 +1,18 @@
 # How Agents Should Use This Project
 
-## Problem: Dev Server Process Management
+This file is intentionally brief. It exists to steer agent workflows toward the real shared instruction surfaces instead of duplicating them.
 
-When an agentic workflow (like Copilot) runs terminal commands:
-- `run_in_terminal` with `isBackground=true` doesn't truly daemonize Node processes
-- It becomes idle before child processes fully initialize
-- This leaves orphaned processes that can't be cleaned up
-- The .dev.pid file may not be created in time
+## Source Of Truth
 
-## The Issue (Now Resolved)
+- Use [AGENTS.md](./AGENTS.md) for commands, environments, branch discipline, and validation flow.
+- Use [.github/copilot-instructions.md](./.github/copilot-instructions.md) for always-on repo rules, coding standards, and release bookkeeping.
+- Use custom agents, prompts, and skills only for task-specific workflow guidance.
 
-Previously, `npm start` had issues with true background operation. This has been fixed:
+## Practical Rules
 
-```bash
-npm start
-# This spawns: npm -> node scripts/dev-server.cjs -> npm run dev:all -> concurrently -> nodemon + vite
-# NEW: Properly daemonized with detached: true and child.unref()
-# RESULT: Returns immediately AND child processes continue in background
-```
-
-## Solution: Use npm start (Now Truly Safe for Agents)
-
-### ✅ DO THIS (Now works correctly):
-```bash
-run_in_terminal({
-  command: "npm start",
-  isBackground: true
-})
-```
-
-### ✅ DO THIS INSTEAD:
-
-**Option A: Use npm test (runs without servers)**
-```bash
-run_in_terminal({
-  command: "npm test",
-  isBackground: false  // Blocking is fine, tests complete
-})
-```
-
-**Option B: Use npm run build (doesn't require servers)**
-```bash
-run_in_terminal({
-  command: "npm run build",
-  isBackground: false  // Blocking is fine, build completes
-})
-```
-
-**Option C: Use npm run lint (doesn't require servers)**
-```bash
-run_in_terminal({
-  command: "npm run lint:all",
-  isBackground: false  // Blocking is fine, linting completes
-})
-```
-
-## If Orphaned Processes Appear
-
-Use the safe cleanup command:
-
-```bash
-npm cleanup
-```
-
-This will:
-- Kill ONLY concurrently processes started with `npm:dev:server npm:dev`
-- Kill ONLY nodemon processes running `server/src/index.js`
-- Kill ONLY processes on ports 3001 (backend) and 5173 (frontend)
-- **Will NOT** kill VSCode server processes or other Node processes
-- Remove stale .dev.pid files
-
-## Why This Is Safe
-
-The cleanup script uses specific patterns to identify dev server processes:
-1. **Concurrently matching:** Only kills concurrently with both dev:server AND npm:dev arguments
-2. **Nodemon matching:** Only kills nodemon running the exact server path
-3. **Port-based:** Uses `lsof` to kill by port (more reliable than process name)
-4. **Never uses broad pkill patterns** that would catch VSCode or other tools
-
-## Summary for Agents
-
-1. **Start dev servers with `npm start`** - Now properly daemonized for agents
-2. **Check status with `npm status`** - Verify servers are running
-3. **Stop gracefully with `npm stop`** - Clean shutdown
-4. **Use `npm cleanup` if needed** - Emergency: force-kill orphaned processes
-5. **Don't use broad pkill patterns** - Let the script manager handle it
-6. **For one-off tasks** (test, build, lint) - Use blocking terminal commands
+1. Before substantial work, check the current branch and move to updated `main` plus a dedicated feature branch if needed.
+2. Prefer one-off validation commands over long-running background server workflows.
+3. Use `npm run dev` and `npm run dev:cleanup` when a live dev server is actually required.
+4. Do not invent package scripts or alternate process-management commands that the repo does not define.
+5. If a customization file starts repeating command catalogs or environment tables, move that information back to [AGENTS.md](./AGENTS.md) and link to it.
 

--- a/docs/prds/README.md
+++ b/docs/prds/README.md
@@ -8,6 +8,9 @@ This directory holds product and implementation planning documents that are inte
 - [Technical Spec](./wmv-explorer-destinations-tech-spec.md)
 - [Implementation Phases](./wmv-explorer-destinations-phases.md)
 - [Ideas Backlog](./wmv-explorer-destinations-ideas.md)
+- [Readiness Checklist](./wmv-explorer-readiness-checklist.md)
+- [Execution Briefing](./wmv-explorer-execution-briefing.md)
+- [Worklog](./wmv-explorer-worklog.md)
 
 These docs are designed to separate product requirements from implementation detail:
 
@@ -15,3 +18,6 @@ These docs are designed to separate product requirements from implementation det
 - The technical spec defines the current recommended architecture and data model direction.
 - The phases document identifies the planned execution sequence.
 - The ideas backlog captures future concepts that should not expand the current scope.
+- The readiness checklist defines whether the feature is safe to implement and what still blocks execution.
+- The execution briefing defines how VS Code, Copilot CLI, cloud agents, and shared customizations should be used once work moves ahead.
+- The worklog tracks active decisions, blockers, and ready-next slices.

--- a/docs/prds/wmv-explorer-destinations-phases.md
+++ b/docs/prds/wmv-explorer-destinations-phases.md
@@ -17,6 +17,8 @@ Deliverables:
 
 Goal: refactor webhook processing into a thin orchestrator with delegated in-process handlers so Explorer can be added without further overloading the current processor.
 
+Status: complete on the Phase 1 closure branch. The next Explorer PR should start Phase 2 preparation work rather than reopen the webhook seam.
+
 Scope:
 
 - Introduce the handler or matcher abstraction for ingested activity contexts
@@ -37,6 +39,8 @@ Out of scope:
 ## Phase 2: Explorer Data Model And Matching
 
 Goal: add Explorer week, destination, and match storage plus the shared matching service used by both webhooks and refresh actions.
+
+Entry condition: start from a new PR after Phase 1 is merged, and use that PR to close the remaining summary-model and destination-metadata decisions before broad Phase 2 implementation expands.
 
 Scope:
 

--- a/docs/prds/wmv-explorer-destinations-prd.md
+++ b/docs/prds/wmv-explorer-destinations-prd.md
@@ -255,7 +255,7 @@ The technical specification for Explorer Destinations is documented in [wmv-expl
 - Manual refresh or backfill works.
 - Explorer history persists and can be queried after week end.
 - Existing leaderboard and admin regression checks pass.
-- VERSION and CHANGELOG.md are updated with implementation.
+- For a user-facing Explorer commit, `VERSION` and `CHANGELOG.md` are updated in the final pre-commit pass with a high-level summary of the shipped slice.
 - Explorer ideas backlog remains separate from the v1 scope.
 
 End of PRD

--- a/docs/prds/wmv-explorer-destinations-tech-spec.md
+++ b/docs/prds/wmv-explorer-destinations-tech-spec.md
@@ -67,6 +67,8 @@ Recommended initial handlers:
 - Competition week matcher
 - Explorer destination matcher
 
+Phase 1 should land this seam with the existing competition and chain wax handlers first. The Explorer destination handler belongs to Phase 2, after the data model and matching rules are finalized.
+
 This keeps feature fan-out inside the app boundary while avoiding a new worker or CLI-per-event process model.
 
 Phase 1 implementation detail:
@@ -282,7 +284,7 @@ Recommended E2E journeys:
 5. Add admin Explorer setup UI.
 6. Add Challenges hub UI with progress bar, checklist, and completers summary.
 7. Run regression checks on race and admin flows.
-8. Update VERSION and CHANGELOG.md when implementation begins.
+8. If the slice is user-facing and ready to commit, update `VERSION` and `CHANGELOG.md` in the final pre-commit pass with a high-level summary.
 
 ## 12. Risks and Mitigations
 

--- a/docs/prds/wmv-explorer-execution-briefing.md
+++ b/docs/prds/wmv-explorer-execution-briefing.md
@@ -1,0 +1,195 @@
+# WMV Explorer Destinations Execution Briefing
+
+This briefing explains how Explorer execution should use VS Code, Copilot CLI, and cloud agents once work moves from planning into approved implementation slices.
+
+## Purpose
+
+Explorer is the first feature expected to move through a PRD-first workflow in this repository. That means the planning set, readiness checklist, and worklog are the source of truth, and execution tools should reinforce that structure rather than bypass it.
+
+## Core Rule
+
+Do not start implementation from a vague chat summary. Start from an approved slice that points back to:
+
+1. [The PRD](./wmv-explorer-destinations-prd.md)
+2. [The technical spec](./wmv-explorer-destinations-tech-spec.md)
+3. [The phases doc](./wmv-explorer-destinations-phases.md)
+4. [The readiness checklist](./wmv-explorer-readiness-checklist.md)
+5. [The worklog](./wmv-explorer-worklog.md)
+
+Do not start an approved slice on an unrelated PR branch. For Explorer work, update `main` first and create a dedicated feature branch for the slice before substantial planning or coding continues.
+
+## VS Code: Primary Environment
+
+Use VS Code as the default environment for Explorer work.
+
+### Use VS Code for
+
+- PRD and technical-spec refinement
+- readiness reviews and checklist updates
+- worklog updates
+- planning-agent and skill usage
+- implementation slicing
+- local code changes
+- local tests, lint, typecheck, and build verification
+- documentation updates
+- reviewing cloud-agent output before merge
+
+### Why VS Code is primary
+
+- It has the richest repository context.
+- It supports custom agents, skills, prompts, and local iteration in one place.
+- It is the safest place to review changes before anything becomes a PR.
+
+### Practical VS Code usage
+
+Use the built-in Chat view as the main execution surface.
+
+Example planning flow:
+
+1. Select the `explorer-planner` agent from the agent picker.
+2. Ask it to review readiness or prepare a slice, for example: `Review the Explorer readiness checklist against the tech spec and tell me the next approved implementation slice.`
+3. If you want the reusable workflow instead of the role-specific agent, run `/explorer-planning` and ask for a readiness review, spec sync, or implementation-slice brief.
+4. If the next step depends on external facts, run `/explorer-tech-research` with a concrete question, for example: `Compare mapping options for showing destination context in a later Explorer phase.`
+5. When a worklog item stabilizes, run `/draft-explorer-issue` to turn it into a GitHub issue draft.
+6. Once the slice is approved, switch to `dev-agent` for the actual code changes and local validation.
+
+VS Code should be the place where you review the readiness checklist, update the worklog, decide the slice boundary, implement locally, and inspect any output from cloud-agent work.
+
+## Copilot CLI: Supporting Shell Tool
+
+Use Copilot CLI after a slice already exists and the task is terminal-centered.
+
+### Use Copilot CLI for
+
+- log interpretation
+- command suggestions
+- shell-heavy debugging support
+- quick verification help while running tests or builds
+- portable skill usage from a command-line workflow
+
+### Do not use Copilot CLI for
+
+- primary PRD or spec authoring
+- readiness decisions
+- deciding architecture from scratch
+- replacing the worklog or checklist
+
+### Repo-specific CLI note
+
+Under WSL, use the Linux Node 24 toolchain rather than a Windows Node/npm path. Native modules such as `better-sqlite3` are sensitive to the wrong toolchain.
+
+### Practical Copilot CLI usage
+
+Use Copilot CLI when the conversation is really about terminal work, not about shaping the feature.
+
+Good examples:
+
+- after `npm test` fails, ask for help interpreting the failure and the next likely command or code area to inspect
+- after `npm run typecheck` or `npm run build`, ask for help understanding a specific error burst
+- while validating a finished slice, ask for a concise explanation of what a command sequence should verify
+
+Avoid moving the main PRD, readiness, or slice-definition conversation into the CLI. The CLI should support execution, not replace the planning set.
+
+## Cloud Agents: Bounded, Reviewable Tasks Only
+
+Use cloud agents only after the readiness gate is passed for the relevant slice.
+
+### Good cloud-agent tasks
+
+- isolated repository research tied to one approved question
+- implementing one narrow approved slice on a branch
+- making targeted follow-up changes to an existing PR
+- generating a reviewable PR for a bounded task
+
+### Bad cloud-agent tasks
+
+- resolving fuzzy product requirements
+- inventing architecture where the tech spec is still undecided
+- building an entire feature phase without a reviewed slice boundary
+- bypassing local review in VS Code
+
+### Cloud-agent input checklist
+
+Any Explorer task sent to a cloud agent should include:
+
+1. the exact phase or tech-spec section being implemented
+2. the readiness status of blocking checklist items
+3. the expected tests or validations
+4. documentation expectations for that slice
+5. a bounded outcome that can be reviewed through a PR
+
+### Practical cloud-agent usage
+
+Good first cloud-agent tasks for Explorer would look like this:
+
+- `Implement the approved Explorer query router for getActiveWeek and its tests, following the tech spec section on API surface and the current readiness checklist.`
+- `Make the requested follow-up changes on an existing Explorer PR after review comments, keeping the scope to the listed files and tests.`
+
+Bad first cloud-agent tasks would look like this:
+
+- `Build Explorer.`
+- `Figure out the schema and UI for Explorer and open a PR.`
+
+The difference is important: cloud agents are strongest when the slice is already bounded and reviewable.
+
+## Agents, Skills, And Prompts
+
+### Custom agents
+
+Custom agents should exist mainly where role boundaries matter.
+
+- `dev-agent` stays the default implementation agent for coding work.
+- `explorer-planner` should stay read-only and focus on planning, readiness, and slice preparation.
+
+### Skills
+
+Skills should carry the reusable workflow knowledge because they are portable.
+
+- `explorer-planning` should help keep the PRD, tech spec, readiness checklist, and worklog aligned.
+- `explorer-tech-research` should structure external research such as mapping or vendor evaluation.
+
+### Prompts
+
+Prompts should remain narrow and convenient.
+
+- `draft-explorer-issue` should convert a stable worklog item into a usable GitHub issue draft.
+
+## Recommended Workflow
+
+### 1. Planning and readiness in VS Code
+
+- Review the source-of-truth docs.
+- Update the readiness checklist.
+- Update the worklog.
+- Choose one bounded slice.
+
+### 2. Slice preparation in VS Code
+
+- Use the planning agent or planning skill to produce an implementation brief.
+- Confirm which checklist items still block the slice.
+- Confirm the expected tests and docs.
+
+### 3. Local implementation in VS Code
+
+- Confirm the current branch is the correct Explorer feature branch.
+- If it is not, switch back to updated `main`, create a dedicated branch for the approved slice, and only then continue.
+- Hand off to `dev-agent` for coding work.
+- Run local validation.
+- Update docs if the slice changes visible behavior or planning state.
+
+### 4. CLI support if needed
+
+- Use Copilot CLI for shell-heavy support while running commands or interpreting failures.
+
+### 5. Optional cloud-agent follow-up
+
+- Use a cloud agent only for a narrow, approved task that is suitable for PR review.
+- Review the PR locally in VS Code before treating it as complete.
+
+## Repo Execution Rules To Preserve
+
+- Respect the existing Node 24 requirement.
+- Do not mix development and E2E databases.
+- Keep Explorer additive to the current competition flows.
+- Treat `VERSION` and `CHANGELOG.md` as final pre-commit bookkeeping for user-facing implementation commits, not planning updates.
+- Do not let new planning assets replace the current repo instructions in `.github/copilot-instructions.md` and `AGENTS.md`.

--- a/docs/prds/wmv-explorer-readiness-checklist.md
+++ b/docs/prds/wmv-explorer-readiness-checklist.md
@@ -1,0 +1,166 @@
+# WMV Explorer Destinations Readiness Checklist
+
+This checklist is the implementation gate for WMV Explorer Destinations. It exists to answer one question clearly: is Explorer ready for the next implementation slice, or does the planning set still have unresolved gaps that would force engineering to guess?
+
+Explorer is the first pilot for a lightweight PRD-first workflow in this repository. The goal is not to create heavy process. The goal is to make sure substantial features have enough closure before coding starts.
+
+## Source Of Truth
+
+- [PRD](./wmv-explorer-destinations-prd.md)
+- [Technical Spec](./wmv-explorer-destinations-tech-spec.md)
+- [Implementation Phases](./wmv-explorer-destinations-phases.md)
+- [Ideas Backlog](./wmv-explorer-destinations-ideas.md)
+- [Explorer Worklog](./wmv-explorer-worklog.md)
+- [Explorer Execution Briefing](./wmv-explorer-execution-briefing.md)
+
+The ideas backlog is intentionally excluded from v1 implementation scope. It exists to capture future work without expanding the current slice.
+
+## Current Go Decision
+
+**Status:** Phase 1 Complete; Ready For New Phase 2 Preparation PR
+
+Explorer has completed the narrow Phase 1 webhook-orchestration slice that preserves current competition behavior while introducing delegated in-process handlers. It is ready for a new, separate PR to start Phase 2 preparation work, but it is not yet ready for broad Phase 2+ implementation. The remaining gaps are technical-closure gaps, not product-intent gaps.
+
+## Current Status Summary
+
+| Area | Status | Notes |
+| --- | --- | --- |
+| Product framing | Ready | The PRD is clear on goals, users, must-haves, non-goals, and success criteria. |
+| Execution phasing | Ready | The phases doc already breaks work into a useful order. |
+| Architecture closure | Partial | The overall direction is clear, but several design decisions still need to be finalized. |
+| Open questions handling | Partial | Open questions exist, but they are not yet centralized in one review surface. |
+| Blocking research closure | Partial | Some validation work is still needed before safe implementation. |
+| Test planning | Partial | The spec outlines what to test, but the exact organization and execution strategy should be made explicit. |
+| Documentation impact plan | Partial | The likely doc surfaces are known, but the required updates are not yet tracked in one place. |
+
+## Must Resolve Before Broad Implementation
+
+### 1. Current Webhook Behavior And Regression Obligations
+
+| Field | Value |
+| --- | --- |
+| Status | Ready For Phase 1 |
+| Gate | Must Resolve |
+| Why it matters | Phase 1 is explicitly about refactoring webhook processing without breaking current competition behavior. |
+| Evidence | The preserved flow is documented in [wmv-explorer-worklog.md](./wmv-explorer-worklog.md), implemented in [server/src/webhooks/processor.ts](../../server/src/webhooks/processor.ts) plus [server/src/webhooks/activityHandlers.ts](../../server/src/webhooks/activityHandlers.ts), and covered by focused webhook tests under `server/src/__tests__`. |
+| Acceptance criteria | The worklog explicitly documents the current processor responsibilities, the handler seam keeps the webhook entrypoint stable, and the focused webhook regression tests stay green. |
+| Next action | Keep the preservation summary current if new webhook handlers or side effects are added later. |
+
+### 2. Explorer Athlete Summary Model
+
+| Field | Value |
+| --- | --- |
+| Status | Partial |
+| Gate | Must Resolve |
+| Why it matters | The tech spec leaves the `ExplorerAthleteWeekSummary` decision open for v1. Engineering should not start building around two competing models. |
+| Evidence | The current spec says the summary can remain computed on read if query cost is modest, but no v1 decision is locked yet. |
+| Acceptance criteria | The tech spec explicitly chooses one v1 approach: computed on read or cached summary. It also states the reason for that choice and what is deferred. |
+| Next action | Add a design decision note to the technical spec and record the outcome in the worklog. |
+
+### 3. Explorer Destination Metadata Strategy
+
+| Field | Value |
+| --- | --- |
+| Status | Partial |
+| Gate | Must Resolve |
+| Why it matters | Explorer destination setup depends on how segment data is validated, stored, and displayed over time. |
+| Evidence | The current UI already has real segment URL parsing and validation patterns in [src/components/SegmentInput.tsx](../../src/components/SegmentInput.tsx) and [src/components/ManageSegments.tsx](../../src/components/ManageSegments.tsx), but the Explorer spec still leaves room for multiple storage strategies. |
+| Acceptance criteria | The tech spec explicitly states whether Explorer reuses the existing segment table, stores Explorer-local cached metadata, or uses both with clear responsibilities for each. |
+| Next action | Finalize the storage and enrichment rules in the technical spec before Explorer schema work starts. |
+
+### 4. Centralized Open Questions
+
+| Field | Value |
+| --- | --- |
+| Status | Missing |
+| Gate | Must Resolve |
+| Why it matters | Scattered uncertainty forces implementation chats to rediscover unresolved design choices. |
+| Evidence | Open items currently appear in narrative form across the technical spec rather than in one explicit decision list. |
+| Acceptance criteria | One section in the worklog or readiness checklist lists all unresolved questions, their current status, and whether they block implementation. |
+| Next action | Seed the worklog with a dedicated open-questions section and keep it current. |
+
+### 5. Phase 1 And Phase 2 Boundary
+
+| Field | Value |
+| --- | --- |
+| Status | Ready |
+| Gate | Must Resolve |
+| Why it matters | The team needs a shared rule for what can proceed now versus what must wait for additional closure. |
+| Evidence | The phases doc, worklog, and implemented handler seam now all point to the same narrow boundary: structural webhook refactor only. |
+| Acceptance criteria | The readiness artifacts clearly state that Explorer is ready for the approved Phase 1 slice only, and they identify which unresolved items still block Phase 2+. |
+| Next action | Keep the current go decision updated as new slices are approved. |
+
+## Should Resolve Before Phase 2 Starts
+
+### 1. Backend Test Organization
+
+| Field | Value |
+| --- | --- |
+| Status | Partial |
+| Gate | Should Resolve |
+| Why it matters | The repo already has a strong backend test pattern. Explorer should fit it rather than improvise. |
+| Evidence | Existing tests under `server/src/__tests__` use the in-memory [setupTestDb](../../server/src/__tests__/setupTestDb.ts) pattern and helper utilities. |
+| Acceptance criteria | The implementation plan names where Explorer service, router, and integration tests will live and states that they will use the existing in-memory SQLite setup unless a stronger reason appears. |
+| Next action | Record the intended test layout in the worklog before Phase 2 begins. |
+
+### 2. E2E Data Strategy
+
+| Field | Value |
+| --- | --- |
+| Status | Partial |
+| Gate | Should Resolve |
+| Why it matters | Explorer UI and admin flows will need end-to-end coverage, and the repository already enforces a separate E2E database model. |
+| Evidence | [AGENTS.md](../../AGENTS.md) defines `wmv_e2e.db` as the dedicated E2E environment and warns against mixing databases. |
+| Acceptance criteria | The implementation plan explains how Explorer E2E scenarios will be created and validated without relying on accidental shared state. |
+| Next action | Decide whether Explorer test data will be created during test setup or introduced through intentional E2E fixtures. |
+
+### 3. Documentation Impact Plan
+
+| Field | Value |
+| --- | --- |
+| Status | Partial |
+| Gate | Should Resolve |
+| Why it matters | Explorer touches admin, athlete, API, database, and release-note surfaces. That work should be visible before coding. |
+| Evidence | Likely doc surfaces already exist in `ADMIN_GUIDE.md`, `docs/API.md`, `docs/DATABASE_DESIGN.md`, `docs-site/`, `CHANGELOG.md`, and `VERSION`, but the release-note files should wait for the final pre-commit pass of a user-facing slice. |
+| Acceptance criteria | The worklog or implementation slice names the docs expected to change when the slice lands. |
+| Next action | Add a documentation-impact checklist to the worklog. |
+
+### 4. Smallest End-To-End Slice
+
+| Field | Value |
+| --- | --- |
+| Status | Completed |
+| Gate | Should Resolve |
+| Why it matters | Explorer should not start with a multi-surface implementation burst. |
+| Evidence | The worklog now records the completed Phase 1 webhook-orchestrator slice, including validation expectations and explicit out-of-scope items. |
+| Acceptance criteria | One narrow slice was named, bounded, tied to Phase 1, and validated through the focused webhook regression tests. |
+| Next action | Keep later slices equally narrow and tie the next PR to Phase 2 preparation instead of reopening Phase 1. |
+
+## Safe To Defer If Recorded Explicitly
+
+| Item | Status | Gate | Notes |
+| --- | --- | --- | --- |
+| Virtual versus outdoor labels in the checklist | Deferred | Safe To Defer | Not required for v1 matching correctness. |
+| Match retraction when a source activity is deleted | Partial | Safe To Defer | Can remain an explicit unresolved rule if v1 behavior is documented. |
+| Season-wide rollup caching strategy | Deferred | Safe To Defer | Weekly history durability matters first. |
+| Post-MVP ideas from the ideas backlog | Deferred | Safe To Defer | Keep them isolated in the ideas file. |
+
+## Execution Preconditions For The Next Slice
+
+Before any Explorer implementation slice starts, it should explicitly reference:
+
+1. One approved phase from [wmv-explorer-destinations-phases.md](./wmv-explorer-destinations-phases.md).
+2. One or more exact sections of [wmv-explorer-destinations-tech-spec.md](./wmv-explorer-destinations-tech-spec.md) that govern the slice.
+3. The status of any blocking checklist items from this document.
+4. The expected validation path, such as backend tests, E2E checks, linting, typechecking, build verification, or documentation updates.
+5. The documentation surfaces expected to change for that slice.
+
+## Sign-Off
+
+| Decision | Current State |
+| --- | --- |
+| Phase 1 Complete | Yes |
+| Ready For New Phase 2 Preparation PR | Yes |
+| Ready For Broad Feature Implementation | No |
+
+If this file says anything stronger than **Phase 1 Complete; Ready For New Phase 2 Preparation PR**, the linked worklog should show exactly what changed to justify that shift.

--- a/docs/prds/wmv-explorer-worklog.md
+++ b/docs/prds/wmv-explorer-worklog.md
@@ -1,0 +1,141 @@
+# WMV Explorer Destinations Worklog
+
+This worklog is the active operating log for Explorer. The readiness checklist is the gate. This file is where decisions, blockers, next slices, and issue candidates move over time.
+
+## Current Focus
+
+- Close Phase 1 cleanly and keep the branch ready for a dedicated PR.
+- Mark the webhook seam complete without quietly expanding into Phase 2 work.
+- Prepare the next Explorer PR to focus on Phase 2 preparation decisions.
+
+## Current Go State
+
+- **Readiness:** Phase 1 Complete; Ready For New Phase 2 Preparation PR
+- **Immediate scope:** close this branch as the Phase 1 PR and begin the next branch with Phase 2 preparation decisions only
+- **Not yet in scope:** broad Phase 2 schema or UI implementation until the remaining design blockers are closed
+
+## Decisions Made
+
+- Explorer is the first pilot for a broader PRD-first workflow in this repository.
+- The current source of truth remains the Destinations planning set, not the older Seasons naming.
+- VS Code is the primary environment for planning and implementation work.
+- The existing `dev-agent` remains the default implementation agent for coding work.
+- Skills should carry the reusable workflow knowledge because they are portable across VS Code, Copilot CLI, and cloud agents.
+- GitHub issues remain secondary for now; local planning docs stay primary until slices are stable enough to externalize cleanly.
+- Phase 1 is approved only as a structural webhook slice: preserve current behavior first, add Explorer matching later.
+- Phase 1 is complete on this branch: the shared activity-ingestion context, sequential delegated handlers, explicit handler order, and preservation tests are in place.
+
+## Open Questions
+
+| Question | Status | Blocks Implementation | Notes |
+| --- | --- | --- | --- |
+| Should athlete week summaries be computed on read or stored in a cached summary table for v1? | Open | Yes | Tech spec currently leaves this as conditional. |
+| Should Explorer reuse the existing segment table, store Explorer-local cached metadata, or do both? | Open | Yes | Existing UI parsing is proven, but final storage rules are not. |
+| How should webhook regression protection be documented for the delegated-handler refactor? | Closed For Phase 1 | No | The preservation target now lives in this worklog and the handler seam is covered by focused webhook tests. |
+| What is the exact E2E data strategy for Explorer flows? | Open | No | Should be defined before Phase 2 starts. |
+| Should deleted source activities retract Explorer completions in v1? | Open | No | Safe to defer if behavior is documented. |
+
+## Blockers
+
+### Must Resolve Before Broad Implementation
+
+1. Decide the v1 summary model.
+2. Decide the v1 destination metadata strategy.
+3. Keep unresolved questions centralized rather than scattered across planning docs.
+
+### Should Resolve Before Phase 2
+
+1. Name Explorer backend test locations and test shape.
+2. Define the E2E data approach.
+3. List documentation surfaces expected to change when Explorer slices land.
+
+## Ready-Next Slices
+
+### Completed Slice A: Webhook Orchestrator And Handler Seam
+
+- Phase: Phase 1
+- Goal: keep `createWebhookProcessor(...)` as the stable entrypoint while moving activity create or update processing behind a shared ingestion context and ordered handlers
+- Scope:
+	- build the activity-ingestion context once per event
+	- fan out to registered in-process handlers
+	- preserve existing competition week matching behavior
+	- preserve existing chain wax tracking behavior
+	- keep activity delete and athlete deauth flows intact
+- Validation:
+	- keep the existing webhook processor, replay, and segment-effort retry tests green
+	- add focused tests for handler ordering and optional non-blocking handler failures
+- Out of scope:
+	- Explorer schema
+	- Explorer destination matching
+	- Explorer admin or athlete UI
+
+Outcome:
+
+- The activity path now runs through the delegated activity-ingestion pipeline.
+- The handler order is explicit and regression-tested.
+- Activity delete and athlete deauthorization remain adjacent to the processor by design for Phase 1.
+
+### Current Webhook Behavior To Preserve
+
+The approved Phase 1 slice preserves these rules from [server/src/webhooks/processor.ts](../../server/src/webhooks/processor.ts):
+
+1. Activity create and update still resolve the participant, fetch one valid access token, capture athlete profile data, fetch activity details once, and then fan out through in-process handlers.
+2. Chain wax still evaluates the first fetched activity payload before competition retry logic and remains non-blocking for competition processing.
+3. Competition matching still retries missing segment efforts with the current four-attempt flow and `15s`, `45s`, `90s` backoff schedule, then matches all active overlapping seasons, evaluates week time windows, and continues past per-week failures.
+4. Activity delete still removes chain wax state when relevant and then deletes stored activity-related records.
+5. Athlete deauth still deletes tokens while preserving historical competition records.
+6. Replay and idempotency behavior remains part of the protected webhook surface.
+
+### Regression Coverage For Phase 1
+
+The current preservation target is backed by:
+
+1. [server/src/__tests__/webhookProcessor.test.ts](../../server/src/__tests__/webhookProcessor.test.ts)
+2. [server/src/__tests__/webhookProcessor.activityHandlers.test.ts](../../server/src/__tests__/webhookProcessor.activityHandlers.test.ts)
+3. [server/src/__tests__/webhookProcessor.segmentEffortsRetry.test.ts](../../server/src/__tests__/webhookProcessor.segmentEffortsRetry.test.ts)
+4. [server/src/__tests__/webhookAdminRouter.replayEvent.test.ts](../../server/src/__tests__/webhookAdminRouter.replayEvent.test.ts)
+
+### Slice Candidate B: Summary Model Decision
+
+- Phase: Phase 2 preparation
+- Goal: choose computed-on-read versus cached-summary for v1 and update the technical spec accordingly
+- Why this matters: it stabilizes query-service design and schema decisions
+
+### Slice Candidate C: Destination Metadata Strategy
+
+- Phase: Phase 2 preparation
+- Goal: define how Explorer destination setup reuses segment validation and metadata from the current admin flow
+- Why this matters: it stabilizes admin-service and schema direction
+
+### Recommended Next PR
+
+- Start a fresh Phase 2 preparation branch from updated `main` after this Phase 1 branch lands.
+- Keep the next PR focused on the athlete summary model, destination metadata strategy, test layout, and E2E data approach.
+- Do not mix those decisions with schema or UI implementation unless the blockers are explicitly closed in the same PR.
+
+## Issue Candidates
+
+- Decide and document Explorer athlete week summary strategy
+- Decide and document Explorer destination metadata strategy
+- Define Explorer test layout and E2E data plan
+
+## Documentation Impact Checklist
+
+When a real implementation slice lands, review whether it changes:
+
+- `ADMIN_GUIDE.md`
+- `docs/API.md`
+- `docs/DATABASE_DESIGN.md`
+- `docs-site/admin/*`
+- `docs-site/athlete/*`
+
+Only in the final pre-commit pass for a user-facing implementation commit, also update:
+
+- `CHANGELOG.md`
+- `VERSION`
+
+## Workflow Notes
+
+- Use the readiness checklist as the gate.
+- Use the execution briefing as the operational guide for VS Code, Copilot CLI, and cloud agents.
+- Promote items from this worklog into GitHub issues only when they are stable, bounded, and ready to be worked independently.

--- a/server/src/__tests__/webhookProcessor.activityHandlers.test.ts
+++ b/server/src/__tests__/webhookProcessor.activityHandlers.test.ts
@@ -1,0 +1,142 @@
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { Database } from 'better-sqlite3';
+import { type BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+import { setupTestDb } from './setupTestDb';
+import { createParticipant } from './testDataHelpers';
+import { WebhookLogger } from '../webhooks/logger';
+import {
+  type ActivityIngestionContext,
+  type ActivityWebhookHandler
+} from '../webhooks/activityHandlers';
+import { createWebhookProcessor } from '../webhooks/processor';
+
+jest.mock('../stravaClient', () => ({
+  getActivity: jest.fn(),
+  getAthleteProfile: jest.fn()
+}));
+
+jest.mock('../tokenManager', () => ({
+  getValidAccessToken: jest.fn()
+}));
+
+import * as stravaClient from '../stravaClient';
+import { getValidAccessToken } from '../tokenManager';
+
+describe('Webhook Processor - Activity Handlers', () => {
+  let db: Database;
+  let orm: BetterSQLite3Database;
+  let logger: WebhookLogger;
+
+  beforeEach(() => {
+    const testDb = setupTestDb({ seed: false });
+    db = testDb.db;
+    orm = testDb.orm || testDb.drizzleDb;
+    logger = new WebhookLogger(orm);
+
+    createParticipant(orm, '100', 'Test Athlete', { accessToken: 'fake_token' });
+
+    jest.mocked(getValidAccessToken).mockResolvedValue('fake_token');
+    jest.mocked(stravaClient.getAthleteProfile).mockResolvedValue({ weight: 72 });
+    jest.mocked(stravaClient.getActivity).mockResolvedValue({
+      id: 987654321,
+      name: 'Morning Ride',
+      start_date: '2025-06-01T10:00:00Z',
+      type: 'Ride',
+      distance: 12345,
+      segment_efforts: []
+    } as any);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    db.close();
+  });
+
+  it('passes a shared normalized context to registered activity handlers in order', async () => {
+    const callOrder: string[] = [];
+    const receivedContexts: ActivityIngestionContext[] = [];
+
+    const handlers: ActivityWebhookHandler[] = [
+      {
+        name: 'first-handler',
+        handle: async (context) => {
+          callOrder.push('first');
+          receivedContexts.push(context);
+        }
+      },
+      {
+        name: 'second-handler',
+        handle: async (context) => {
+          callOrder.push('second');
+          receivedContexts.push(context);
+        }
+      }
+    ];
+
+    const processor = createWebhookProcessor(orm, undefined, { activityHandlers: handlers });
+
+    await processor(
+      {
+        object_type: 'activity',
+        aspect_type: 'create',
+        object_id: 987654321,
+        owner_id: 100,
+        event_time: Math.floor(Date.now() / 1000),
+        subscription_id: 1
+      },
+      logger
+    );
+
+    expect(callOrder).toEqual(['first', 'second']);
+    expect(receivedContexts).toHaveLength(2);
+    expect(receivedContexts[0]).toBe(receivedContexts[1]);
+    expect(receivedContexts[0]).toMatchObject({
+      accessToken: 'fake_token',
+      activityId: '987654321',
+      athleteId: '100',
+      athleteWeight: 72,
+      participantRecord: {
+        name: 'Test Athlete',
+        strava_athlete_id: '100'
+      },
+      initialActivityData: {
+        id: 987654321,
+        name: 'Morning Ride'
+      }
+    });
+    expect(stravaClient.getActivity).toHaveBeenCalledTimes(1);
+  });
+
+  it('continues past optional handler failures without aborting the event', async () => {
+    const successfulHandler = jest.fn(async () => undefined);
+    const handlers: ActivityWebhookHandler[] = [
+      {
+        name: 'non-blocking-handler',
+        isolateErrors: true,
+        handle: async () => {
+          throw new Error('non-blocking failure');
+        }
+      },
+      {
+        name: 'successful-handler',
+        handle: successfulHandler
+      }
+    ];
+
+    const processor = createWebhookProcessor(orm, undefined, { activityHandlers: handlers });
+
+    await processor(
+      {
+        object_type: 'activity',
+        aspect_type: 'update',
+        object_id: 987654321,
+        owner_id: 100,
+        event_time: Math.floor(Date.now() / 1000),
+        subscription_id: 1
+      },
+      logger
+    );
+
+    expect(successfulHandler).toHaveBeenCalledTimes(1);
+  });
+});

--- a/server/src/webhooks/processor.ts
+++ b/server/src/webhooks/processor.ts
@@ -12,8 +12,8 @@
  * - Athlete deauth events -> remove tokens
  *
  * Retry Strategy:
- * - Max 3 attempts per event
- * - 5-second backoff between retries
+ * - Activity ingestion fetches once, then retries up to 3 more times for missing segment efforts
+ * - Backoff between retries: 15s, 45s, 90s
  * - Failures stored in database with last_error_at timestamp
  * - Re-fetches activity from Strava on retry (not cached payload)
  */


### PR DESCRIPTION
## Summary
- close WMV Explorer Phase 1 by landing the delegated webhook activity-ingestion seam and focused regression coverage
- mark the Explorer planning docs as Phase 1 complete and ready for a new Phase 2 preparation PR
- reduce duplication across shared Copilot instruction surfaces so repo-wide operational guidance stays centralized

## Details
- keep `createWebhookProcessor(...)` as the stable entrypoint while routing activity create and update processing through the shared activity-ingestion context and handler runner already present on `main`
- add processor-level regression coverage for handler ordering and isolated handler failures
- add Explorer planning assets: readiness checklist, worklog, execution briefing, planner agent, planning skill, research skill, and issue-drafting prompt
- update shared instructions to make `AGENTS.md` the canonical operations reference and make branch discipline explicit before substantial phase or feature work

## Validation
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run build`

## Follow-up
- This PR closes Phase 1 groundwork only
- The next Explorer PR should start Phase 2 preparation work from updated `main` and stay focused on summary-model, destination-metadata, backend-test-layout, and E2E-data decisions
