### PR TITLE
feat: add Explorer Phase 2 Slice A backend

### DIFF
--- a/.github/agents/explorer-planner.agent.md
+++ b/.github/agents/explorer-planner.agent.md
@@ -1,7 +1,7 @@
 ---
 name: explorer-planner
 description: Plan WMV Explorer work from the PRD, tech spec, readiness checklist, and worklog. Use for readiness reviews, implementation slicing, and planning handoffs before coding.
-tools: [read, search, todo]
+tools: [read, edit, search, todo]
 model: GPT-5 (copilot)
 argument-hint: Review the Explorer docs or prepare the next implementation slice.
 handoffs:
@@ -30,6 +30,7 @@ Primary sources:
 
 - Before substantial planning or handoff for a new slice, check whether the current branch is appropriate.
 - If the work is not a tiny follow-up to the active branch, require the user or implementation agent to move onto updated `main` and create a dedicated feature branch before substantial work continues.
+- You may edit planning artifacts and agent-planning configuration files when the task is readiness closure, slice preparation, or planning-state maintenance.
 - Do not edit product code.
 - Do not edit `VERSION` or `CHANGELOG.md`; those are final pre-commit release notes for implementation work, not planning artifacts.
 - Do not treat unresolved planning gaps as implementation details to be decided later without calling them out.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -72,6 +72,16 @@ Before substantial planning or implementation work:
 4. Do not continue substantial work on an unrelated PR branch just because the workspace was already there.
 5. If you discover after edits that the branch is wrong, transplant the working tree onto a fresh branch from `main` before continuing.
 
+## Slice Completion Discipline
+
+When an approved implementation slice is complete and the required validation passes for that slice:
+
+1. Recommend creating the commit immediately rather than continuing into the next slice on an uncommitted worktree.
+2. Recommend opening or updating the PR for that slice before switching back to planning for the next slice.
+3. Only after the slice is committed and the PR step is handled should the workflow move back to planning for the next approved slice.
+
+The goal is to keep implementation slices reviewable, preserve branch discipline, and avoid stacking new planning or coding work on top of an unsubmitted slice.
+
 ---
 
 ## Project Structure
@@ -286,6 +296,7 @@ npm run test:e2e:ui        # Interactive debugging
   ```
   Required when changing `package.json`, lockfiles, `server/package.json`, `Dockerfile`, install hooks/scripts, Node version checks, dependency versions, or frontend/backend build tooling.
 3. **If this commit is user-facing, update `VERSION` and `CHANGELOG.md` immediately before staging and commit** (see top of this file).
+4. **After a validated approved slice is committed, recommend opening or updating the PR for that slice before returning to planning for the next slice.**
 
 **Git best practices:**
 - Use `git add <specific-files>` (never `git add .`)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,6 +115,11 @@ npm run audit        # Security audit (frontend + backend)
    - Do not update either file during planning or mid-implementation
    - Keep changelog entries high-level rather than a play-by-play of intermediate edits
 
+8. **Slice completion handoff:**
+   - When an approved implementation slice has passed its required validation, recommend committing it before doing more planning or coding
+   - Recommend opening or updating the PR for that slice before moving back to planning for the next slice
+   - Do not casually stack the next slice's planning or implementation onto an uncommitted or unsubmitted slice
+
 ## Special Tasks
 
 | Task | Purpose | When to Use |

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,7 +1,7 @@
 # API reference
 
 **NOTE: The project is migrating to tRPC. The REST endpoints below are legacy or specific to Auth/Webhooks.**
-**For all data fetching (Week, Season, Leaderboard, Segments, Participants, Webhook Admin), refer to the tRPC routers in `server/src/routers`.**
+**For all data fetching (Week, Season, Leaderboard, Segments, Participants, Webhook Admin, Explorer), refer to the tRPC routers in `server/src/routers`.**
 
 Base URL (dev): http://localhost:3001
 
@@ -12,6 +12,73 @@ Base URL (dev): http://localhost:3001
 - `GET /weeks/:id` — **Migrated to `trpc.week.getById`**
 - `GET /weeks/:id/leaderboard` — **Migrated to `trpc.leaderboard.getWeekLeaderboard`**
 - `GET /seasons/:id/leaderboard` — **Migrated to `trpc.leaderboard.getSeasonLeaderboard`**
+
+## Explorer tRPC endpoints
+
+- `trpc.explorer.getActiveWeek` — Returns the currently active Explorer week and its ordered destinations.
+- `trpc.explorer.getWeekProgress` — Authenticated route that returns the current athlete's destination completion progress for an Explorer week.
+
+### `trpc.explorer.getActiveWeek`
+
+Response shape:
+```
+{
+  "id": number,
+  "name": string,
+  "startAt": number,
+  "endAt": number,
+  "status": "draft" | "active" | "archived",
+  "destinations": [
+    {
+      "id": number,
+      "stravaSegmentId": string,
+      "displayLabel": string,
+      "sourceUrl": string | null,
+      "surfaceType": string | null,
+      "category": string | null,
+      "displayOrder": number
+    }
+  ]
+}
+```
+
+### `trpc.explorer.getWeekProgress`
+
+Input:
+```
+{
+  "weekId": number
+}
+```
+
+Response shape:
+```
+{
+  "week": {
+    "id": number,
+    "name": string,
+    "startAt": number,
+    "endAt": number,
+    "status": "draft" | "active" | "archived"
+  },
+  "completedDestinations": number,
+  "totalDestinations": number,
+  "destinations": [
+    {
+      "id": number,
+      "stravaSegmentId": string,
+      "displayLabel": string,
+      "sourceUrl": string | null,
+      "surfaceType": string | null,
+      "category": string | null,
+      "displayOrder": number,
+      "completed": boolean,
+      "matchedAt": number | null,
+      "stravaActivityId": string | null
+    }
+  ]
+}
+```
 
 ### GET /weeks/:id/leaderboard (Legacy)
 

--- a/docs/DATABASE_DESIGN.md
+++ b/docs/DATABASE_DESIGN.md
@@ -18,7 +18,7 @@ The database is managed using **Drizzle ORM**. The source of truth for the schem
 - **`activity`**: The best qualifying Strava activity for a participant in a given week.
 - **`segment_effort`**: Individual laps/efforts extracted from a qualifying activity.
 - **`result`**: Calculated rankings and times (points are computed on-read).
-- **`explorer_week`**: Time-boxed Explorer challenge windows with draft/active/archive status.
+- **`explorer_week`**: Time-boxed Explorer challenge windows with draft/active/archived status.
 - **`explorer_destination`**: Ordered Explorer destinations for a week, keyed by Strava segment ID with cached display metadata.
 - **`explorer_destination_match`**: Athlete completion records linking an Explorer destination to the Strava activity that satisfied it.
 - **`participant_token`**: Encrypted OAuth tokens for Strava API access.

--- a/docs/DATABASE_DESIGN.md
+++ b/docs/DATABASE_DESIGN.md
@@ -18,6 +18,9 @@ The database is managed using **Drizzle ORM**. The source of truth for the schem
 - **`activity`**: The best qualifying Strava activity for a participant in a given week.
 - **`segment_effort`**: Individual laps/efforts extracted from a qualifying activity.
 - **`result`**: Calculated rankings and times (points are computed on-read).
+- **`explorer_week`**: Time-boxed Explorer challenge windows with draft/active/archive status.
+- **`explorer_destination`**: Ordered Explorer destinations for a week, keyed by Strava segment ID with cached display metadata.
+- **`explorer_destination_match`**: Athlete completion records linking an Explorer destination to the Strava activity that satisfied it.
 - **`participant_token`**: Encrypted OAuth tokens for Strava API access.
 - **`webhook_event`**: Log of received Strava webhook events for monitoring.
 

--- a/docs/prds/wmv-explorer-destinations-phases.md
+++ b/docs/prds/wmv-explorer-destinations-phases.md
@@ -40,14 +40,20 @@ Out of scope:
 
 Goal: add Explorer week, destination, and match storage plus the shared matching service used by both webhooks and refresh actions.
 
-Entry condition: start from a new PR after Phase 1 is merged, and use that PR to close the remaining summary-model and destination-metadata decisions before broad Phase 2 implementation expands.
+Entry condition: start from a new PR after Phase 1 is merged and after the summary-model and destination-metadata decisions are explicitly locked in the planning docs. Begin with one narrow implementation slice before expanding Phase 2 scope.
 
 Scope:
 
 - Schema additions
+- Narrow extraction of shared segment-based matching and persistence logic where Explorer would otherwise duplicate existing Competition code
 - Explorer matching service
 - Admin or service-level refresh path
 - Idempotent storage rules
+
+Implementation note:
+
+- This does not require a new top-level phase before Phase 2.
+- The clean version is to treat the extraction as the first bounded sub-slice inside Phase 2 Slice A, with an explicit requirement that Competition behavior remains unchanged.
 
 ## Phase 3: Explorer Admin Setup
 

--- a/docs/prds/wmv-explorer-destinations-tech-spec.md
+++ b/docs/prds/wmv-explorer-destinations-tech-spec.md
@@ -40,6 +40,8 @@ This specification translates the Explorer Destinations PRD into an implementati
 - Strava auth and participant identity already exist.
 - Webhook ingestion already fetches and normalizes activity data in [server/src/webhooks/processor.ts](../../server/src/webhooks/processor.ts).
 - Batch or explicit activity processing already exists in [server/src/services/BatchFetchService.ts](../../server/src/services/BatchFetchService.ts).
+- The existing shared `segment` table already persists Strava segment metadata such as name, distance, grade, elevation, and location, and Competition already joins against it for read paths.
+- The current admin segment-validation flow already centralizes Strava segment fetch and persistence in [server/src/services/SegmentService.ts](../../server/src/services/SegmentService.ts).
 - App routing and top-level navigation patterns already exist in [src/App.tsx](../../src/App.tsx) and [src/components/NavBar.tsx](../../src/components/NavBar.tsx).
 - The regular admin panel already has a Strava URL input pattern worth mirroring for Explorer destination setup rather than exposing raw segment IDs only.
 
@@ -86,6 +88,23 @@ Recommended direction:
 - Extract Explorer matching into a reusable service.
 - Call that service from the Explorer ingestion handler.
 - Call that same service from an admin or participant-triggered refresh action.
+
+### 4.3 Shared segment-based matching seam
+
+The repository already has partially reusable building blocks for segment-based activity handling:
+
+- activity-window and lap-window selection in [server/src/activityProcessor.ts](../../server/src/activityProcessor.ts)
+- activity and effort persistence in [server/src/activityStorage.ts](../../server/src/activityStorage.ts)
+- webhook competition handling in [server/src/webhooks/handlers/competitionActivityHandler.ts](../../server/src/webhooks/handlers/competitionActivityHandler.ts)
+- batch refresh handling in [server/src/services/BatchFetchService.ts](../../server/src/services/BatchFetchService.ts)
+- late metric hydration in [server/src/services/HydrationService.ts](../../server/src/services/HydrationService.ts)
+
+Explorer should not introduce a second copy of this segment-based matching flow. The first Phase 2 implementation slice should extract a narrow shared seam around segment-based qualifying activity selection and persistence where that reduces duplication between Competition and Explorer. That extraction should stay bounded:
+
+- preserve current Competition behavior and results
+- avoid reworking unrelated read/query services
+- avoid broad refactors of activity deletion or hydration unless directly needed by the shared seam
+- treat this as a structural sub-slice inside Phase 2 rather than a new standalone phase
 
 ## 5. Proposed Data Model
 
@@ -134,7 +153,7 @@ Activation rule: an ExplorerWeek cannot move to an active state unless it has at
   - completedAll boolean
   - lastMatchedAt
 
-For v1, ExplorerAthleteWeekSummary can remain computed on read if query cost is modest. The durable source of truth should be ExplorerDestinationMatch.
+For v1, ExplorerAthleteWeekSummary is computed on read. `ExplorerDestinationMatch` is the durable source of truth. Cached summary storage is deferred unless measured query cost justifies it in a later phase.
 
 ### 5.2 Key integrity rules
 
@@ -145,7 +164,15 @@ For v1, ExplorerAthleteWeekSummary can remain computed on read if query cost is 
 
 ### 5.3 Segment source model
 
-Admins should be able to configure destinations by pasting Strava segment URLs, following the same mental model as the regular admin panel. The system should extract the segment ID from the URL, validate it, and store the parsed segment ID plus the original source URL when available. If the segment is already known in the app's segment table, that data can be reused. If not, Explorer should still accept it and cache enough display metadata for a stable UI.
+Explorer uses a hybrid destination metadata strategy for v1. Admin setup should continue to accept Strava segment URLs, extract the segment ID, and store the parsed segment ID plus the original source URL when available. If the segment already exists in the app's shared `segment` table, Explorer should reuse that canonical data first rather than requiring an immediate Strava refetch. Explorer should also store Explorer-local cached display metadata needed for stable admin setup and week rendering, including cases where the segment is not already present in the shared segment table.
+
+Segment metadata should be treated as comparatively durable. For Explorer v1, the preferred policy is database-first reuse of the shared `segment` table, optional refresh on explicit admin validation or metadata-refresh actions, and optional short-lived in-memory caching inside a running server process to avoid repeated fetches during the same setup workflow. This policy should not be applied blindly to activity details or segment efforts, because activity visibility, photos, and effort availability can change shortly after upload.
+
+### 5.4 V1 decision lock
+
+- Summary model: computed on read
+- Destination metadata strategy: hybrid shared-segment reuse plus Explorer-local cached display metadata
+- These decisions close the planning blockers for narrow Phase 2 Slice A
 
 ## 6. Core Services
 
@@ -275,6 +302,8 @@ Recommended E2E journeys:
 - Athlete completes full weekly set and sees completion state
 - Completers summary reflects at least one full completer
 
+Explorer E2E journeys should provision Explorer week and destination data intentionally during test setup or controlled fixtures, and must not rely on accidental shared state.
+
 ## 11. Migration and Rollout Sequence
 
 1. Refactor webhook processor toward delegated handlers without changing current competition behavior.
@@ -294,6 +323,9 @@ Recommended E2E journeys:
 - Risk: Strava URL parsing becomes brittle.
   Mitigation: mirror the existing admin-panel parsing approach and test it directly.
 
+- Risk: Explorer burns unnecessary Strava API calls by refetching stable segment metadata too aggressively.
+  Mitigation: use shared-segment-table reuse as the default read path, refresh only when explicitly validating or rehydrating metadata, and keep any short-lived cache policy limited to segment metadata rather than activity payloads.
+
 - Risk: Explorer begins to inherit competition UX by accident.
   Mitigation: avoid ranked lists in the primary weekly surface.
 
@@ -302,7 +334,7 @@ Recommended E2E journeys:
 
 ## 13. Suggested Handoff Notes
 
-If this moves to implementation, the first engineering slice should be the delegated ingestion refactor plus Explorer schema design. That is the structural work that determines whether the rest of the feature can be added cleanly.
+If this moves to implementation, the first engineering slice should be a narrow Phase 2 Slice A: Explorer schema, a shared segment-based matching and persistence seam, Explorer matching service, refresh-path parity, the first Explorer read routes, and backend tests. That is the smallest slice that validates the model without spilling into admin or athlete UI.
 
 The next slice should be the smallest end-to-end Explorer loop:
 

--- a/docs/prds/wmv-explorer-readiness-checklist.md
+++ b/docs/prds/wmv-explorer-readiness-checklist.md
@@ -17,9 +17,9 @@ The ideas backlog is intentionally excluded from v1 implementation scope. It exi
 
 ## Current Go Decision
 
-**Status:** Phase 1 Complete; Ready For New Phase 2 Preparation PR
+**Status:** Phase 1 Complete; Phase 2 Preparation Complete; Ready For Narrow Phase 2 Implementation Slice
 
-Explorer has completed the narrow Phase 1 webhook-orchestration slice that preserves current competition behavior while introducing delegated in-process handlers. It is ready for a new, separate PR to start Phase 2 preparation work, but it is not yet ready for broad Phase 2+ implementation. The remaining gaps are technical-closure gaps, not product-intent gaps.
+Explorer has completed the narrow Phase 1 webhook-orchestration slice that preserves current competition behavior while introducing delegated in-process handlers. It has also closed the planning blockers needed to start a narrow Phase 2 implementation slice: the v1 summary-model decision, destination-metadata strategy, centralized open-question tracking, test-planning shape, and E2E data approach. It is ready for one bounded Phase 2 implementation PR, but it is not yet ready for broad Phase 2+ implementation in a multi-surface burst.
 
 ## Current Status Summary
 
@@ -27,11 +27,11 @@ Explorer has completed the narrow Phase 1 webhook-orchestration slice that prese
 | --- | --- | --- |
 | Product framing | Ready | The PRD is clear on goals, users, must-haves, non-goals, and success criteria. |
 | Execution phasing | Ready | The phases doc already breaks work into a useful order. |
-| Architecture closure | Partial | The overall direction is clear, but several design decisions still need to be finalized. |
-| Open questions handling | Partial | Open questions exist, but they are not yet centralized in one review surface. |
-| Blocking research closure | Partial | Some validation work is still needed before safe implementation. |
-| Test planning | Partial | The spec outlines what to test, but the exact organization and execution strategy should be made explicit. |
-| Documentation impact plan | Partial | The likely doc surfaces are known, but the required updates are not yet tracked in one place. |
+| Architecture closure | Ready | The v1 summary model and destination metadata strategy are now explicitly locked. |
+| Open questions handling | Ready | The worklog is now the canonical review surface for remaining open questions and their blocking status. |
+| Blocking research closure | Ready For Narrow Phase 2 Slice | The remaining open items are non-blocking or slice-local rather than architectural blockers. |
+| Test planning | Ready For Narrow Phase 2 Slice | Backend test layout and E2E data strategy are explicit enough for the next bounded implementation slice. |
+| Documentation impact plan | Ready For Narrow Phase 2 Slice | The planning set now names the likely documentation surfaces for the next slice. |
 
 ## Must Resolve Before Broad Implementation
 
@@ -39,7 +39,7 @@ Explorer has completed the narrow Phase 1 webhook-orchestration slice that prese
 
 | Field | Value |
 | --- | --- |
-| Status | Ready For Phase 1 |
+| Status | Ready |
 | Gate | Must Resolve |
 | Why it matters | Phase 1 is explicitly about refactoring webhook processing without breaking current competition behavior. |
 | Evidence | The preserved flow is documented in [wmv-explorer-worklog.md](./wmv-explorer-worklog.md), implemented in [server/src/webhooks/processor.ts](../../server/src/webhooks/processor.ts) plus [server/src/webhooks/activityHandlers.ts](../../server/src/webhooks/activityHandlers.ts), and covered by focused webhook tests under `server/src/__tests__`. |
@@ -50,34 +50,34 @@ Explorer has completed the narrow Phase 1 webhook-orchestration slice that prese
 
 | Field | Value |
 | --- | --- |
-| Status | Partial |
+| Status | Ready |
 | Gate | Must Resolve |
 | Why it matters | The tech spec leaves the `ExplorerAthleteWeekSummary` decision open for v1. Engineering should not start building around two competing models. |
-| Evidence | The current spec says the summary can remain computed on read if query cost is modest, but no v1 decision is locked yet. |
+| Evidence | The technical spec now explicitly chooses computed on read for v1, with `ExplorerDestinationMatch` as the durable source of truth and cached summary storage deferred unless measured query cost justifies it later. |
 | Acceptance criteria | The tech spec explicitly chooses one v1 approach: computed on read or cached summary. It also states the reason for that choice and what is deferred. |
-| Next action | Add a design decision note to the technical spec and record the outcome in the worklog. |
+| Next action | Carry the locked decision into the Phase 2 Slice A implementation brief and tests. |
 
 ### 3. Explorer Destination Metadata Strategy
 
 | Field | Value |
 | --- | --- |
-| Status | Partial |
+| Status | Ready |
 | Gate | Must Resolve |
 | Why it matters | Explorer destination setup depends on how segment data is validated, stored, and displayed over time. |
-| Evidence | The current UI already has real segment URL parsing and validation patterns in [src/components/SegmentInput.tsx](../../src/components/SegmentInput.tsx) and [src/components/ManageSegments.tsx](../../src/components/ManageSegments.tsx), but the Explorer spec still leaves room for multiple storage strategies. |
+| Evidence | The technical spec now explicitly chooses a hybrid strategy: reuse shared segment-table data when present, while also storing Explorer-local cached display metadata and source URL values for stable rendering and setup. The current repository already persists Strava segment metadata in the shared `segment` table and uses it across Competition read paths. |
 | Acceptance criteria | The tech spec explicitly states whether Explorer reuses the existing segment table, stores Explorer-local cached metadata, or uses both with clear responsibilities for each. |
-| Next action | Finalize the storage and enrichment rules in the technical spec before Explorer schema work starts. |
+| Next action | Carry the locked storage responsibilities and DB-first segment reuse policy into Phase 2 schema and service work. |
 
 ### 4. Centralized Open Questions
 
 | Field | Value |
 | --- | --- |
-| Status | Missing |
+| Status | Ready |
 | Gate | Must Resolve |
 | Why it matters | Scattered uncertainty forces implementation chats to rediscover unresolved design choices. |
-| Evidence | Open items currently appear in narrative form across the technical spec rather than in one explicit decision list. |
+| Evidence | The worklog open-questions table now serves as the centralized review surface for unresolved decisions, their current status, and whether they block implementation. |
 | Acceptance criteria | One section in the worklog or readiness checklist lists all unresolved questions, their current status, and whether they block implementation. |
-| Next action | Seed the worklog with a dedicated open-questions section and keep it current. |
+| Next action | Keep the worklog table current as new implementation slices close or defer questions. |
 
 ### 5. Phase 1 And Phase 2 Boundary
 
@@ -86,9 +86,9 @@ Explorer has completed the narrow Phase 1 webhook-orchestration slice that prese
 | Status | Ready |
 | Gate | Must Resolve |
 | Why it matters | The team needs a shared rule for what can proceed now versus what must wait for additional closure. |
-| Evidence | The phases doc, worklog, and implemented handler seam now all point to the same narrow boundary: structural webhook refactor only. |
-| Acceptance criteria | The readiness artifacts clearly state that Explorer is ready for the approved Phase 1 slice only, and they identify which unresolved items still block Phase 2+. |
-| Next action | Keep the current go decision updated as new slices are approved. |
+| Evidence | The phases doc, worklog, and planning decisions now point to the same narrow boundary: one bounded Phase 2 Slice A is approved next, while broader multi-surface Phase 2 work remains out of scope. |
+| Acceptance criteria | The readiness artifacts clearly state that Explorer is ready for one narrow Phase 2 implementation slice, and they identify what still remains outside that slice. |
+| Next action | Keep the current go decision updated as each additional Explorer slice is approved or deferred. |
 
 ## Should Resolve Before Phase 2 Starts
 
@@ -96,34 +96,34 @@ Explorer has completed the narrow Phase 1 webhook-orchestration slice that prese
 
 | Field | Value |
 | --- | --- |
-| Status | Partial |
+| Status | Ready For Narrow Phase 2 Slice |
 | Gate | Should Resolve |
 | Why it matters | The repo already has a strong backend test pattern. Explorer should fit it rather than improvise. |
 | Evidence | Existing tests under `server/src/__tests__` use the in-memory [setupTestDb](../../server/src/__tests__/setupTestDb.ts) pattern and helper utilities. |
 | Acceptance criteria | The implementation plan names where Explorer service, router, and integration tests will live and states that they will use the existing in-memory SQLite setup unless a stronger reason appears. |
-| Next action | Record the intended test layout in the worklog before Phase 2 begins. |
+| Next action | Use the existing in-memory backend test pattern for Phase 2 Slice A service and router coverage. |
 
 ### 2. E2E Data Strategy
 
 | Field | Value |
 | --- | --- |
-| Status | Partial |
+| Status | Ready For Narrow Phase 2 Slice |
 | Gate | Should Resolve |
 | Why it matters | Explorer UI and admin flows will need end-to-end coverage, and the repository already enforces a separate E2E database model. |
 | Evidence | [AGENTS.md](../../AGENTS.md) defines `wmv_e2e.db` as the dedicated E2E environment and warns against mixing databases. |
 | Acceptance criteria | The implementation plan explains how Explorer E2E scenarios will be created and validated without relying on accidental shared state. |
-| Next action | Decide whether Explorer test data will be created during test setup or introduced through intentional E2E fixtures. |
+| Next action | Provision Explorer E2E data intentionally during setup or controlled fixtures; do not rely on accidental shared state, and keep any cache assumptions limited to relatively stable segment metadata rather than activity freshness. |
 
 ### 3. Documentation Impact Plan
 
 | Field | Value |
 | --- | --- |
-| Status | Partial |
+| Status | Ready For Narrow Phase 2 Slice |
 | Gate | Should Resolve |
 | Why it matters | Explorer touches admin, athlete, API, database, and release-note surfaces. That work should be visible before coding. |
 | Evidence | Likely doc surfaces already exist in `ADMIN_GUIDE.md`, `docs/API.md`, `docs/DATABASE_DESIGN.md`, `docs-site/`, `CHANGELOG.md`, and `VERSION`, but the release-note files should wait for the final pre-commit pass of a user-facing slice. |
 | Acceptance criteria | The worklog or implementation slice names the docs expected to change when the slice lands. |
-| Next action | Add a documentation-impact checklist to the worklog. |
+| Next action | Update only the planning and implementation docs touched by the bounded slice; continue deferring release-note files to final pre-commit user-facing work. |
 
 ### 4. Smallest End-To-End Slice
 
@@ -134,7 +134,7 @@ Explorer has completed the narrow Phase 1 webhook-orchestration slice that prese
 | Why it matters | Explorer should not start with a multi-surface implementation burst. |
 | Evidence | The worklog now records the completed Phase 1 webhook-orchestrator slice, including validation expectations and explicit out-of-scope items. |
 | Acceptance criteria | One narrow slice was named, bounded, tied to Phase 1, and validated through the focused webhook regression tests. |
-| Next action | Keep later slices equally narrow and tie the next PR to Phase 2 preparation instead of reopening Phase 1. |
+| Next action | Keep later slices equally narrow and tie the next PR to Phase 2 Slice A instead of reopening Phase 1 or bundling multiple Explorer surfaces together. |
 
 ## Safe To Defer If Recorded Explicitly
 
@@ -160,7 +160,8 @@ Before any Explorer implementation slice starts, it should explicitly reference:
 | Decision | Current State |
 | --- | --- |
 | Phase 1 Complete | Yes |
-| Ready For New Phase 2 Preparation PR | Yes |
+| Phase 2 Preparation Complete | Yes |
+| Ready For Narrow Phase 2 Implementation Slice | Yes |
 | Ready For Broad Feature Implementation | No |
 
-If this file says anything stronger than **Phase 1 Complete; Ready For New Phase 2 Preparation PR**, the linked worklog should show exactly what changed to justify that shift.
+If this file says anything stronger than **Phase 1 Complete; Phase 2 Preparation Complete; Ready For Narrow Phase 2 Implementation Slice**, the linked worklog should show exactly what changed to justify that shift.

--- a/docs/prds/wmv-explorer-worklog.md
+++ b/docs/prds/wmv-explorer-worklog.md
@@ -4,15 +4,15 @@ This worklog is the active operating log for Explorer. The readiness checklist i
 
 ## Current Focus
 
-- Close Phase 1 cleanly and keep the branch ready for a dedicated PR.
-- Mark the webhook seam complete without quietly expanding into Phase 2 work.
-- Prepare the next Explorer PR to focus on Phase 2 preparation decisions.
+- Keep Phase 1 closure stable and documented.
+- Lock the Phase 2 preparation decisions in the planning set.
+- Launch one narrow Phase 2 implementation PR after this planning slice lands.
 
 ## Current Go State
 
-- **Readiness:** Phase 1 Complete; Ready For New Phase 2 Preparation PR
-- **Immediate scope:** close this branch as the Phase 1 PR and begin the next branch with Phase 2 preparation decisions only
-- **Not yet in scope:** broad Phase 2 schema or UI implementation until the remaining design blockers are closed
+- **Readiness:** Phase 1 Complete; Phase 2 Preparation Complete; Ready For Narrow Phase 2 Implementation Slice
+- **Immediate scope:** one bounded Phase 2 Slice A covering Explorer schema, matching service, refresh-path parity, initial query routes, and backend tests
+- **Not yet in scope:** broad Phase 2 implementation across schema, admin UI, athlete UI, and expanded API surface in one PR
 
 ## Decisions Made
 
@@ -24,30 +24,34 @@ This worklog is the active operating log for Explorer. The readiness checklist i
 - GitHub issues remain secondary for now; local planning docs stay primary until slices are stable enough to externalize cleanly.
 - Phase 1 is approved only as a structural webhook slice: preserve current behavior first, add Explorer matching later.
 - Phase 1 is complete on this branch: the shared activity-ingestion context, sequential delegated handlers, explicit handler order, and preservation tests are in place.
+- V1 athlete week summary is computed on read, with `ExplorerDestinationMatch` as the durable source of truth.
+- V1 destination metadata uses a hybrid strategy: reuse shared segment data when present, while storing Explorer-local cached display metadata and source URL values for stable setup and rendering.
+- Explorer should treat segment metadata as relatively durable and reuse the existing shared `segment` table by default, while avoiding the same cache assumptions for activity details and segment-effort availability.
+- Explorer should avoid duplicating the current Competition segment-based matching flow; the first Phase 2 slice should extract only the shared seam needed for Explorer while preserving current Competition behavior.
+- Phase 2 Slice A will follow the existing backend in-memory test pattern and will treat Explorer E2E data as intentionally provisioned test state rather than accidental shared data.
 
 ## Open Questions
 
 | Question | Status | Blocks Implementation | Notes |
 | --- | --- | --- | --- |
-| Should athlete week summaries be computed on read or stored in a cached summary table for v1? | Open | Yes | Tech spec currently leaves this as conditional. |
-| Should Explorer reuse the existing segment table, store Explorer-local cached metadata, or do both? | Open | Yes | Existing UI parsing is proven, but final storage rules are not. |
+| Should athlete week summaries be computed on read or stored in a cached summary table for v1? | Closed For v1 | No | V1 uses computed-on-read summaries with `ExplorerDestinationMatch` as the durable source of truth. |
+| Should Explorer reuse the existing segment table, store Explorer-local cached metadata, or do both? | Closed For v1 | No | V1 uses a hybrid strategy: shared segment reuse when present plus Explorer-local cached display metadata. |
 | How should webhook regression protection be documented for the delegated-handler refactor? | Closed For Phase 1 | No | The preservation target now lives in this worklog and the handler seam is covered by focused webhook tests. |
-| What is the exact E2E data strategy for Explorer flows? | Open | No | Should be defined before Phase 2 starts. |
+| What is the exact E2E data strategy for Explorer flows? | Closed For Phase 2 start | No | Explorer test data should be provisioned intentionally during setup or controlled fixtures, not inherited from accidental shared state. |
 | Should deleted source activities retract Explorer completions in v1? | Open | No | Safe to defer if behavior is documented. |
 
 ## Blockers
 
 ### Must Resolve Before Broad Implementation
 
-1. Decide the v1 summary model.
-2. Decide the v1 destination metadata strategy.
-3. Keep unresolved questions centralized rather than scattered across planning docs.
+1. No additional architecture blockers remain for entry into narrow Phase 2 Slice A.
+2. Broad Phase 2 still requires incremental readiness checks per slice rather than one multi-surface implementation push.
 
 ### Should Resolve Before Phase 2
 
-1. Name Explorer backend test locations and test shape.
-2. Define the E2E data approach.
-3. List documentation surfaces expected to change when Explorer slices land.
+1. Resolved for Slice A: Explorer backend tests should live under `server/src/__tests__` and use the existing in-memory SQLite pattern.
+2. Resolved for Slice A: Explorer E2E scenarios should provision their own challenge data intentionally.
+3. Resolved for Slice A: Planning and implementation docs touched by the slice should be listed explicitly before coding starts.
 
 ## Ready-Next Slices
 
@@ -95,29 +99,37 @@ The current preservation target is backed by:
 3. [server/src/__tests__/webhookProcessor.segmentEffortsRetry.test.ts](../../server/src/__tests__/webhookProcessor.segmentEffortsRetry.test.ts)
 4. [server/src/__tests__/webhookAdminRouter.replayEvent.test.ts](../../server/src/__tests__/webhookAdminRouter.replayEvent.test.ts)
 
-### Slice Candidate B: Summary Model Decision
+### Phase 2 Preparation Decisions Closed
 
-- Phase: Phase 2 preparation
-- Goal: choose computed-on-read versus cached-summary for v1 and update the technical spec accordingly
-- Why this matters: it stabilizes query-service design and schema decisions
-
-### Slice Candidate C: Destination Metadata Strategy
-
-- Phase: Phase 2 preparation
-- Goal: define how Explorer destination setup reuses segment validation and metadata from the current admin flow
-- Why this matters: it stabilizes admin-service and schema direction
+- Summary model: v1 summaries are computed on read, with cached-summary storage deferred until measured query cost justifies it.
+- Destination metadata strategy: v1 uses hybrid shared-segment reuse plus Explorer-local cached display metadata.
+- Segment fetch policy: default to DB-first reuse of shared segment metadata, use explicit refresh when needed, and treat any in-memory cache as segment-only rather than activity-level.
+- Shared seam policy: treat segment-based activity matching and persistence extraction as the first structural step inside Phase 2 Slice A, not as a separate top-level phase.
+- Backend test organization: Slice A should use the existing `server/src/__tests__` in-memory SQLite pattern.
+- E2E data strategy: Explorer test data should be created intentionally during setup or controlled fixtures.
 
 ### Recommended Next PR
 
-- Start a fresh Phase 2 preparation branch from updated `main` after this Phase 1 branch lands.
-- Keep the next PR focused on the athlete summary model, destination metadata strategy, test layout, and E2E data approach.
-- Do not mix those decisions with schema or UI implementation unless the blockers are explicitly closed in the same PR.
+- Start a dedicated implementation branch from updated `main` after this planning branch lands.
+- Keep the next PR scoped to Phase 2 Slice A only:
+	- Explorer schema tables
+	- Shared segment-based match-and-persist seam extracted from current Competition paths only where needed for Explorer reuse
+	- Explorer matching service
+	- Shared refresh-path parity
+	- Shared segment-metadata reuse policy in Explorer services
+	- `explorer.getActiveWeek` and `explorer.getWeekProgress`
+	- Backend tests for boundaries, idempotency, and parity
+- Keep out of scope for that PR:
+	- Explorer admin UI
+	- Explorer hub UI
+	- Expanded Explorer API surface beyond the first read paths
+	- Broad rewrites of hydration, deletion, or unrelated leaderboard query services
 
 ## Issue Candidates
 
-- Decide and document Explorer athlete week summary strategy
-- Decide and document Explorer destination metadata strategy
-- Define Explorer test layout and E2E data plan
+- Implement Explorer Phase 2 Slice A schema and matching service
+- Add initial Explorer query routes for active week and athlete progress
+- Add Explorer backend regression and parity coverage for the shared matching service
 
 ## Documentation Impact Checklist
 
@@ -126,6 +138,7 @@ When a real implementation slice lands, review whether it changes:
 - `ADMIN_GUIDE.md`
 - `docs/API.md`
 - `docs/DATABASE_DESIGN.md`
+- `docs/STRAVA_INTEGRATION.md`
 - `docs-site/admin/*`
 - `docs-site/athlete/*`
 

--- a/server/drizzle/0009_explorer_phase2_slice_a.sql
+++ b/server/drizzle/0009_explorer_phase2_slice_a.sql
@@ -1,0 +1,51 @@
+CREATE TABLE `explorer_week` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`name` text NOT NULL,
+	`start_at` integer NOT NULL,
+	`end_at` integer NOT NULL,
+	`status` text DEFAULT 'draft' NOT NULL,
+	`created_at` text DEFAULT (CURRENT_TIMESTAMP),
+	`updated_at` text DEFAULT (CURRENT_TIMESTAMP)
+);
+--> statement-breakpoint
+CREATE INDEX `idx_explorer_week_status` ON `explorer_week` (`status`);
+--> statement-breakpoint
+CREATE INDEX `idx_explorer_week_window` ON `explorer_week` (`start_at`,`end_at`);
+--> statement-breakpoint
+CREATE TABLE `explorer_destination` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`explorer_week_id` integer NOT NULL,
+	`strava_segment_id` text NOT NULL,
+	`source_url` text,
+	`cached_segment_name` text,
+	`display_label` text,
+	`display_order` integer DEFAULT 0 NOT NULL,
+	`surface_type` text,
+	`category` text,
+	`created_at` text DEFAULT (CURRENT_TIMESTAMP),
+	`updated_at` text DEFAULT (CURRENT_TIMESTAMP),
+	FOREIGN KEY (`explorer_week_id`) REFERENCES `explorer_week`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `idx_explorer_destination_week` ON `explorer_destination` (`explorer_week_id`);
+--> statement-breakpoint
+CREATE INDEX `idx_explorer_destination_segment` ON `explorer_destination` (`strava_segment_id`);
+--> statement-breakpoint
+CREATE TABLE `explorer_destination_match` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`explorer_week_id` integer NOT NULL,
+	`explorer_destination_id` integer NOT NULL,
+	`strava_athlete_id` text NOT NULL,
+	`strava_activity_id` text NOT NULL,
+	`matched_at` integer NOT NULL,
+	`created_at` text DEFAULT (CURRENT_TIMESTAMP),
+	FOREIGN KEY (`explorer_week_id`) REFERENCES `explorer_week`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`explorer_destination_id`) REFERENCES `explorer_destination`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`strava_athlete_id`) REFERENCES `participant`(`strava_athlete_id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `idx_explorer_match_week_athlete` ON `explorer_destination_match` (`explorer_week_id`,`strava_athlete_id`);
+--> statement-breakpoint
+CREATE INDEX `idx_explorer_match_activity` ON `explorer_destination_match` (`strava_activity_id`);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `idx_explorer_match_unique` ON `explorer_destination_match` (`explorer_week_id`,`explorer_destination_id`,`strava_athlete_id`);

--- a/server/drizzle/meta/_journal.json
+++ b/server/drizzle/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1774190400000,
       "tag": "0008_drop_season_is_active",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "6",
+      "when": 1776000000000,
+      "tag": "0009_explorer_phase2_slice_a",
+      "breakpoints": true
     }
   ]
 }

--- a/server/src/__tests__/ExplorerMatchingService.test.ts
+++ b/server/src/__tests__/ExplorerMatchingService.test.ts
@@ -1,0 +1,177 @@
+import { Database } from 'better-sqlite3';
+import { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+import { eq } from 'drizzle-orm';
+import {
+  clearAllData,
+  createExplorerDestination,
+  createExplorerWeek,
+  createParticipant,
+  setupTestDb,
+  teardownTestDb,
+} from './testDataHelpers';
+import { explorerDestinationMatch } from '../db/schema';
+import { ExplorerMatchingService } from '../services/ExplorerMatchingService';
+import * as stravaClient from '../stravaClient';
+
+jest.mock('../stravaClient', () => ({
+  listAthleteActivities: jest.fn(),
+  getActivity: jest.fn(),
+}));
+
+describe('ExplorerMatchingService', () => {
+  let db: Database;
+  let drizzleDb: BetterSQLite3Database;
+
+  beforeAll(() => {
+    const testDb = setupTestDb();
+    db = testDb.db;
+    drizzleDb = testDb.drizzleDb;
+  });
+
+  afterAll(() => {
+    teardownTestDb(db);
+  });
+
+  beforeEach(() => {
+    clearAllData(drizzleDb);
+    jest.clearAllMocks();
+  });
+
+  it('records one match per destination even when a ride repeats the same segment', async () => {
+    createParticipant(drizzleDb, '2001', 'Explorer Rider');
+    const week = createExplorerWeek(drizzleDb, {
+      startTime: '2025-06-01T00:00:00Z',
+      endTime: '2025-06-07T23:59:59Z',
+      status: 'active',
+    });
+
+    const destination = createExplorerDestination(drizzleDb, {
+      explorerWeekId: week.id,
+      stravaSegmentId: 'seg-100',
+      cachedSegmentName: 'Summit Road',
+    });
+
+    const service = new ExplorerMatchingService(drizzleDb);
+    const result = await service.matchActivity(
+      {
+        id: 'activity-1',
+        name: 'Big Climb',
+        start_date: '2025-06-03T10:00:00Z',
+        segment_efforts: [
+          {
+            id: 'effort-1',
+            elapsed_time: 300,
+            start_date: '2025-06-03T10:05:00Z',
+            segment: { id: 'seg-100' },
+          },
+          {
+            id: 'effort-2',
+            elapsed_time: 320,
+            start_date: '2025-06-03T10:12:00Z',
+            segment: { id: 'seg-100' },
+          },
+        ],
+      },
+      '2001'
+    );
+
+    expect(result.processedWeeks).toBe(1);
+    expect(result.matchedDestinations).toBe(1);
+    expect(result.newMatches).toBe(1);
+
+    const matches = drizzleDb
+      .select()
+      .from(explorerDestinationMatch)
+      .where(eq(explorerDestinationMatch.explorer_destination_id, destination.id))
+      .all();
+
+    expect(matches).toHaveLength(1);
+    expect(matches[0]?.strava_activity_id).toBe('activity-1');
+  });
+
+  it('is idempotent when the same activity is processed more than once', async () => {
+    createParticipant(drizzleDb, '2002', 'Repeat Rider');
+    const week = createExplorerWeek(drizzleDb, {
+      startTime: '2025-06-01T00:00:00Z',
+      endTime: '2025-06-07T23:59:59Z',
+      status: 'active',
+    });
+
+    createExplorerDestination(drizzleDb, {
+      explorerWeekId: week.id,
+      stravaSegmentId: 'seg-200',
+    });
+
+    const service = new ExplorerMatchingService(drizzleDb);
+    const activity = {
+      id: 'activity-2',
+      name: 'Evening Ride',
+      start_date: '2025-06-04T18:30:00Z',
+      segment_efforts: [
+        {
+          id: 'effort-3',
+          elapsed_time: 220,
+          start_date: '2025-06-04T18:35:00Z',
+          segment: { id: 'seg-200' },
+        },
+      ],
+    };
+
+    const firstPass = await service.matchActivity(activity, '2002');
+    const secondPass = await service.matchActivity(activity, '2002');
+
+    expect(firstPass.newMatches).toBe(1);
+    expect(secondPass.newMatches).toBe(0);
+
+    const matches = drizzleDb.select().from(explorerDestinationMatch).all();
+    expect(matches).toHaveLength(1);
+  });
+
+  it('hydrates missing segment efforts during refresh parity fetches', async () => {
+    createParticipant(drizzleDb, '2003', 'Refresh Rider');
+    const week = createExplorerWeek(drizzleDb, {
+      startTime: '2025-06-10T00:00:00Z',
+      endTime: '2025-06-16T23:59:59Z',
+      status: 'draft',
+    });
+
+    createExplorerDestination(drizzleDb, {
+      explorerWeekId: week.id,
+      stravaSegmentId: 'seg-300',
+    });
+
+    const listAthleteActivitiesMock = jest.mocked(stravaClient.listAthleteActivities);
+    const getActivityMock = jest.mocked(stravaClient.getActivity);
+
+    listAthleteActivitiesMock.mockResolvedValue([
+      {
+        id: 'activity-3',
+        name: 'Summary Activity',
+        start_date: '2025-06-12T07:00:00Z',
+        segment_efforts: [],
+      },
+    ]);
+
+    getActivityMock.mockResolvedValue({
+      id: 'activity-3',
+      name: 'Detailed Activity',
+      start_date: '2025-06-12T07:00:00Z',
+      segment_efforts: [
+        {
+          id: 'effort-4',
+          elapsed_time: 260,
+          start_date: '2025-06-12T07:05:00Z',
+          segment: { id: 'seg-300' },
+        },
+      ],
+    });
+
+    const service = new ExplorerMatchingService(drizzleDb);
+    const result = await service.refreshAthleteWeek(week.id, '2003', 'test-token');
+
+    expect(result.activitiesProcessed).toBe(1);
+    expect(result.activitiesMatched).toBe(1);
+    expect(result.newMatches).toBe(1);
+    expect(getActivityMock).toHaveBeenCalledWith('activity-3', 'test-token');
+  });
+});

--- a/server/src/__tests__/explorerActivityHandler.test.ts
+++ b/server/src/__tests__/explorerActivityHandler.test.ts
@@ -1,0 +1,96 @@
+import { Database } from 'better-sqlite3';
+import { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+import {
+  clearAllData,
+  createExplorerDestination,
+  createExplorerWeek,
+  createParticipant,
+  setupTestDb,
+  teardownTestDb,
+} from './testDataHelpers';
+import { explorerDestinationMatch } from '../db/schema';
+import { createDefaultActivityHandlers } from '../webhooks/activityHandlers';
+import { createExplorerActivityHandler } from '../webhooks/handlers/explorerActivityHandler';
+
+describe('explorerActivityHandler', () => {
+  let db: Database;
+  let drizzleDb: BetterSQLite3Database;
+
+  beforeAll(() => {
+    const testDb = setupTestDb();
+    db = testDb.db;
+    drizzleDb = testDb.drizzleDb;
+  });
+
+  afterAll(() => {
+    teardownTestDb(db);
+  });
+
+  beforeEach(() => {
+    clearAllData(drizzleDb);
+  });
+
+  it('is included in the default handler pipeline', () => {
+    const handlerNames = createDefaultActivityHandlers().map((handler) => handler.name);
+    expect(handlerNames).toContain('explorer');
+  });
+
+  it('records Explorer matches from webhook activity data', async () => {
+    createParticipant(drizzleDb, '4001', 'Webhook Rider');
+    const week = createExplorerWeek(drizzleDb, {
+      startTime: '2025-06-01T00:00:00Z',
+      endTime: '2025-06-07T23:59:59Z',
+      status: 'active',
+    });
+
+    createExplorerDestination(drizzleDb, {
+      explorerWeekId: week.id,
+      stravaSegmentId: 'seg-601',
+    });
+
+    const handler = createExplorerActivityHandler();
+    await handler.handle({
+      db: drizzleDb,
+      event: {
+        aspect_type: 'create',
+        event_time: 0,
+        object_id: 601,
+        object_type: 'activity',
+        owner_id: 4001,
+        subscription_id: 1,
+      },
+      activityId: 'activity-601',
+      athleteId: '4001',
+      participantRecord: {
+        strava_athlete_id: '4001',
+        name: 'Webhook Rider',
+      },
+      accessToken: 'unused',
+      athleteWeight: null,
+      initialActivityData: {
+        id: 'activity-601',
+        name: 'Webhook Ride',
+        start_date: '2025-06-03T09:00:00Z',
+        segment_efforts: [],
+      },
+      validationService: {} as any,
+      getActivityWithSegmentEfforts: async () => ({
+        id: 'activity-601',
+        name: 'Webhook Ride',
+        start_date: '2025-06-03T09:00:00Z',
+        segment_efforts: [
+          {
+            id: 'effort-601',
+            elapsed_time: 190,
+            start_date: '2025-06-03T09:05:00Z',
+            segment: { id: 'seg-601' },
+          },
+        ],
+      }),
+    });
+
+    const matches = drizzleDb.select().from(explorerDestinationMatch).all();
+    expect(matches).toHaveLength(1);
+    expect(matches[0]?.strava_athlete_id).toBe('4001');
+  });
+});

--- a/server/src/__tests__/setupTestDb.ts
+++ b/server/src/__tests__/setupTestDb.ts
@@ -120,6 +120,9 @@ export function teardownTestDb(db: Database.Database) {
       DELETE FROM chain_wax_activity;
       DELETE FROM chain_wax_period;
       DELETE FROM chain_wax_puck;
+      DELETE FROM explorer_destination_match;
+      DELETE FROM explorer_destination;
+      DELETE FROM explorer_week;
       DELETE FROM webhook_subscription;
       DELETE FROM webhook_event;
       DELETE FROM participant_token;

--- a/server/src/__tests__/testDataHelpers.ts
+++ b/server/src/__tests__/testDataHelpers.ts
@@ -1,6 +1,6 @@
 import { BetterSQLite3Database as DrizzleBetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
 import { isoToUnix } from '../dateUtils';
-import { season, activity, participant, participantToken, result, segment, segmentEffort, week, deletionRequest } from '../db/schema';
+import { season, activity, participant, participantToken, result, segment, segmentEffort, week, deletionRequest, explorerWeek, explorerDestination, explorerDestinationMatch } from '../db/schema';
 import { eq } from 'drizzle-orm';
 import { InferInsertModel, InferSelectModel } from 'drizzle-orm';
 
@@ -20,6 +20,12 @@ export type SelectResult = InferSelectModel<typeof result>;
 export type InsertSegmentEffort = InferInsertModel<typeof segmentEffort>;
 export type SelectSegmentEffort = InferSelectModel<typeof segmentEffort>;
 export type InsertParticipantToken = InferInsertModel<typeof participantToken>;
+export type InsertExplorerWeek = InferInsertModel<typeof explorerWeek>;
+export type SelectExplorerWeek = InferSelectModel<typeof explorerWeek>;
+export type InsertExplorerDestination = InferInsertModel<typeof explorerDestination>;
+export type SelectExplorerDestination = InferSelectModel<typeof explorerDestination>;
+export type InsertExplorerDestinationMatch = InferInsertModel<typeof explorerDestinationMatch>;
+export type SelectExplorerDestinationMatch = InferSelectModel<typeof explorerDestinationMatch>;
 
 // Type for the database instance passed to helper functions - using Drizzle instance now
 type TestDb = DrizzleBetterSQLite3Database;
@@ -86,6 +92,32 @@ interface CreateWeekWithResultsOptions {
   weekName?: string;
   participantIds?: string[];
   times?: number[];
+}
+
+interface CreateExplorerWeekOptions {
+  name?: string;
+  startTime?: string;
+  endTime?: string;
+  status?: string;
+}
+
+interface CreateExplorerDestinationOptions {
+  explorerWeekId: number;
+  stravaSegmentId: string;
+  sourceUrl?: string | null;
+  cachedSegmentName?: string | null;
+  displayLabel?: string | null;
+  displayOrder?: number;
+  surfaceType?: string | null;
+  category?: string | null;
+}
+
+interface CreateExplorerMatchOptions {
+  explorerWeekId: number;
+  explorerDestinationId: number;
+  stravaAthleteId: string;
+  stravaActivityId?: string;
+  matchedAt?: string;
 }
 
 /**
@@ -228,6 +260,76 @@ export function createWeek(db: TestDb, options: CreateWeekOptions = {}): SelectW
   const newWeek = db.insert(week).values(newWeekData).returning().get();
   console.log(`[TEST_HELPER] Created Week: id=${newWeek.id}, name=${newWeek.week_name}, seasonId=${newWeek.season_id}, segmentId=${newWeek.strava_segment_id}`);
   return newWeek;
+}
+
+export function createExplorerWeek(db: TestDb, options: CreateExplorerWeekOptions = {}): SelectExplorerWeek {
+  const {
+    name = 'Explorer Week',
+    startTime = '2025-06-01T00:00:00Z',
+    endTime = '2025-06-07T23:59:59Z',
+    status = 'active'
+  } = options;
+
+  const newExplorerWeekData: InsertExplorerWeek = {
+    name,
+    start_at: isoToUnix(startTime) || 0,
+    end_at: isoToUnix(endTime) || 0,
+    status,
+  };
+
+  const newExplorerWeek = db.insert(explorerWeek).values(newExplorerWeekData).returning().get();
+  console.log(`[TEST_HELPER] Created ExplorerWeek: id=${newExplorerWeek.id}, name=${newExplorerWeek.name}, status=${newExplorerWeek.status}`);
+  return newExplorerWeek;
+}
+
+export function createExplorerDestination(db: TestDb, options: CreateExplorerDestinationOptions): SelectExplorerDestination {
+  const {
+    explorerWeekId,
+    stravaSegmentId,
+    sourceUrl = null,
+    cachedSegmentName = `Segment ${stravaSegmentId}`,
+    displayLabel = null,
+    displayOrder = 0,
+    surfaceType = null,
+    category = null,
+  } = options;
+
+  const newExplorerDestinationData: InsertExplorerDestination = {
+    explorer_week_id: explorerWeekId,
+    strava_segment_id: stravaSegmentId,
+    source_url: sourceUrl,
+    cached_segment_name: cachedSegmentName,
+    display_label: displayLabel,
+    display_order: displayOrder,
+    surface_type: surfaceType,
+    category,
+  };
+
+  const newExplorerDestination = db.insert(explorerDestination).values(newExplorerDestinationData).returning().get();
+  console.log(`[TEST_HELPER] Created ExplorerDestination: id=${newExplorerDestination.id}, weekId=${newExplorerDestination.explorer_week_id}, segmentId=${newExplorerDestination.strava_segment_id}`);
+  return newExplorerDestination;
+}
+
+export function createExplorerMatch(db: TestDb, options: CreateExplorerMatchOptions): SelectExplorerDestinationMatch {
+  const {
+    explorerWeekId,
+    explorerDestinationId,
+    stravaAthleteId,
+    stravaActivityId = String(Math.floor(Math.random() * 1000000000)),
+    matchedAt = '2025-06-03T10:00:00Z'
+  } = options;
+
+  const newExplorerMatchData: InsertExplorerDestinationMatch = {
+    explorer_week_id: explorerWeekId,
+    explorer_destination_id: explorerDestinationId,
+    strava_athlete_id: stravaAthleteId,
+    strava_activity_id: stravaActivityId,
+    matched_at: isoToUnix(matchedAt) || 0,
+  };
+
+  const newExplorerMatch = db.insert(explorerDestinationMatch).values(newExplorerMatchData).returning().get();
+  console.log(`[TEST_HELPER] Created ExplorerMatch: id=${newExplorerMatch.id}, weekId=${newExplorerMatch.explorer_week_id}, athleteId=${newExplorerMatch.strava_athlete_id}`);
+  return newExplorerMatch;
 }
 
 /**
@@ -406,6 +508,9 @@ export function createFullUserWithActivity(db: TestDb, options: CreateFullUserOp
  */
 export function clearAllData(db: TestDb) {
   // Use Drizzle to delete from tables
+  db.delete(explorerDestinationMatch).run();
+  db.delete(explorerDestination).run();
+  db.delete(explorerWeek).run();
   db.delete(deletionRequest).run();
   db.delete(segmentEffort).run();
   db.delete(result).run();

--- a/server/src/__tests__/trpc/explorerRouter.test.ts
+++ b/server/src/__tests__/trpc/explorerRouter.test.ts
@@ -1,0 +1,158 @@
+import { Database } from 'better-sqlite3';
+import { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+import { eq } from 'drizzle-orm';
+import { appRouter } from '../../routers';
+import { createContext } from '../../trpc/context';
+import { participant } from '../../db/schema';
+import {
+  clearAllData,
+  createExplorerDestination,
+  createExplorerMatch,
+  createExplorerWeek,
+  createParticipant,
+  createSegment,
+  setupTestDb,
+  teardownTestDb,
+} from '../testDataHelpers';
+
+describe('explorerRouter', () => {
+  let db: Database;
+  let drizzleDb: BetterSQLite3Database;
+
+  beforeAll(() => {
+    const testDb = setupTestDb();
+    db = testDb.db;
+    drizzleDb = testDb.drizzleDb;
+  });
+
+  afterAll(() => {
+    teardownTestDb(db);
+  });
+
+  beforeEach(() => {
+    clearAllData(drizzleDb);
+  });
+
+  const getCaller = (athleteId?: string) => {
+    const existingParticipant = athleteId
+      ? drizzleDb
+        .select({ stravaAthleteId: participant.strava_athlete_id })
+        .from(participant)
+        .where(eq(participant.strava_athlete_id, athleteId))
+        .get()
+      : null;
+
+    if (athleteId && !existingParticipant) {
+      createParticipant(drizzleDb, athleteId, 'Explorer Athlete');
+    }
+
+    return appRouter.createCaller(createContext({
+      req: {
+        session: {
+          stravaAthleteId: athleteId,
+        },
+      } as any,
+      res: {} as any,
+      dbOverride: db,
+      drizzleDbOverride: drizzleDb,
+    }));
+  };
+
+  it('returns null when there is no active Explorer week', async () => {
+    const caller = getCaller();
+    await expect(caller.explorer.getActiveWeek()).resolves.toBeNull();
+  });
+
+  it('returns the active week with ordered destinations and resolved labels', async () => {
+    createSegment(drizzleDb, 'seg-401', 'Segment Name From DB');
+    const week = createExplorerWeek(drizzleDb, {
+      name: 'Explorer Launch',
+      startTime: '2025-06-01T00:00:00Z',
+      endTime: '2099-06-07T23:59:59Z',
+      status: 'active',
+    });
+
+    createExplorerDestination(drizzleDb, {
+      explorerWeekId: week.id,
+      stravaSegmentId: 'seg-402',
+      cachedSegmentName: 'Cached Name',
+      displayOrder: 2,
+    });
+    createExplorerDestination(drizzleDb, {
+      explorerWeekId: week.id,
+      stravaSegmentId: 'seg-401',
+      displayLabel: 'Custom Label',
+      displayOrder: 1,
+    });
+
+    const caller = getCaller();
+    const result = await caller.explorer.getActiveWeek();
+
+    expect(result?.name).toBe('Explorer Launch');
+    expect(result?.destinations).toHaveLength(2);
+    expect(result?.destinations[0]).toMatchObject({
+      stravaSegmentId: 'seg-401',
+      displayLabel: 'Custom Label',
+      displayOrder: 1,
+    });
+    expect(result?.destinations[1]).toMatchObject({
+      stravaSegmentId: 'seg-402',
+      displayLabel: 'Cached Name',
+      displayOrder: 2,
+    });
+  });
+
+  it('requires auth for getWeekProgress', async () => {
+    const week = createExplorerWeek(drizzleDb);
+    const caller = getCaller();
+    await expect(caller.explorer.getWeekProgress({ weekId: week.id })).rejects.toThrow('UNAUTHORIZED');
+  });
+
+  it('returns athlete progress for a week', async () => {
+    createParticipant(drizzleDb, '3001', 'Progress Rider');
+    createSegment(drizzleDb, 'seg-501', 'Forest Road');
+    const week = createExplorerWeek(drizzleDb, {
+      name: 'Week Progress',
+      startTime: '2025-07-01T00:00:00Z',
+      endTime: '2025-07-07T23:59:59Z',
+      status: 'active',
+    });
+
+    const completedDestination = createExplorerDestination(drizzleDb, {
+      explorerWeekId: week.id,
+      stravaSegmentId: 'seg-501',
+      cachedSegmentName: 'Forest Road',
+      displayOrder: 1,
+    });
+    createExplorerDestination(drizzleDb, {
+      explorerWeekId: week.id,
+      stravaSegmentId: 'seg-502',
+      cachedSegmentName: 'River Road',
+      displayOrder: 2,
+    });
+
+    createExplorerMatch(drizzleDb, {
+      explorerWeekId: week.id,
+      explorerDestinationId: completedDestination.id,
+      stravaAthleteId: '3001',
+      stravaActivityId: 'activity-501',
+    });
+
+    const caller = getCaller('3001');
+    const result = await caller.explorer.getWeekProgress({ weekId: week.id });
+
+    expect(result?.completedDestinations).toBe(1);
+    expect(result?.totalDestinations).toBe(2);
+    expect(result?.destinations[0]).toMatchObject({
+      stravaSegmentId: 'seg-501',
+      completed: true,
+      stravaActivityId: 'activity-501',
+      displayLabel: 'Forest Road',
+    });
+    expect(result?.destinations[1]).toMatchObject({
+      stravaSegmentId: 'seg-502',
+      completed: false,
+      displayLabel: 'River Road',
+    });
+  });
+});

--- a/server/src/db/schema.ts
+++ b/server/src/db/schema.ts
@@ -1,4 +1,4 @@
-import { sqliteTable, text, numeric, integer, index, real } from 'drizzle-orm/sqlite-core';
+import { sqliteTable, text, numeric, integer, index, real, uniqueIndex } from 'drizzle-orm/sqlite-core';
 // import { relations } from "drizzle-orm"
 
 export const sessions = sqliteTable('sessions', {
@@ -133,6 +133,53 @@ export const segment = sqliteTable('segment', {
   climb_category: integer('climb_category'),
 });
 
+export const explorerWeek = sqliteTable('explorer_week', {
+  id: integer().primaryKey({ autoIncrement: true }),
+  name: text().notNull(),
+  start_at: integer('start_at').notNull(),
+  end_at: integer('end_at').notNull(),
+  status: text().default('draft').notNull(),
+  created_at: text('created_at').default('sql`(CURRENT_TIMESTAMP)`'),
+  updated_at: text('updated_at').default('sql`(CURRENT_TIMESTAMP)`'),
+},
+(t) => [
+  index('idx_explorer_week_status').on(t.status),
+  index('idx_explorer_week_window').on(t.start_at, t.end_at),
+]);
+
+export const explorerDestination = sqliteTable('explorer_destination', {
+  id: integer().primaryKey({ autoIncrement: true }),
+  explorer_week_id: integer('explorer_week_id').notNull().references(() => explorerWeek.id, { onDelete: 'cascade' }),
+  strava_segment_id: text('strava_segment_id').notNull(),
+  source_url: text('source_url'),
+  cached_segment_name: text('cached_segment_name'),
+  display_label: text('display_label'),
+  display_order: integer('display_order').default(0).notNull(),
+  surface_type: text('surface_type'),
+  category: text(),
+  created_at: text('created_at').default('sql`(CURRENT_TIMESTAMP)`'),
+  updated_at: text('updated_at').default('sql`(CURRENT_TIMESTAMP)`'),
+},
+(t) => [
+  index('idx_explorer_destination_week').on(t.explorer_week_id),
+  index('idx_explorer_destination_segment').on(t.strava_segment_id),
+]);
+
+export const explorerDestinationMatch = sqliteTable('explorer_destination_match', {
+  id: integer().primaryKey({ autoIncrement: true }),
+  explorer_week_id: integer('explorer_week_id').notNull().references(() => explorerWeek.id, { onDelete: 'cascade' }),
+  explorer_destination_id: integer('explorer_destination_id').notNull().references(() => explorerDestination.id, { onDelete: 'cascade' }),
+  strava_athlete_id: text('strava_athlete_id').notNull().references(() => participant.strava_athlete_id, { onDelete: 'cascade' }),
+  strava_activity_id: text('strava_activity_id').notNull(),
+  matched_at: integer('matched_at').notNull(),
+  created_at: text('created_at').default('sql`(CURRENT_TIMESTAMP)`'),
+},
+(t) => [
+  index('idx_explorer_match_week_athlete').on(t.explorer_week_id, t.strava_athlete_id),
+  index('idx_explorer_match_activity').on(t.strava_activity_id),
+  uniqueIndex('idx_explorer_match_unique').on(t.explorer_week_id, t.explorer_destination_id, t.strava_athlete_id),
+]);
+
 export const webhookEvent = sqliteTable('webhook_event', {
   id: integer().primaryKey({ autoIncrement: true }),
   payload: text().notNull(),
@@ -201,6 +248,15 @@ export type NewWeek = typeof week.$inferInsert;
 
 export type Segment = typeof segment.$inferSelect;
 export type NewSegment = typeof segment.$inferInsert;
+
+export type ExplorerWeek = typeof explorerWeek.$inferSelect;
+export type NewExplorerWeek = typeof explorerWeek.$inferInsert;
+
+export type ExplorerDestination = typeof explorerDestination.$inferSelect;
+export type NewExplorerDestination = typeof explorerDestination.$inferInsert;
+
+export type ExplorerDestinationMatch = typeof explorerDestinationMatch.$inferSelect;
+export type NewExplorerDestinationMatch = typeof explorerDestinationMatch.$inferInsert;
 
 export type Participant = typeof participant.$inferSelect;
 export type NewParticipant = typeof participant.$inferInsert;

--- a/server/src/routers/explorer.ts
+++ b/server/src/routers/explorer.ts
@@ -1,0 +1,22 @@
+import { TRPCError } from '@trpc/server';
+import { z } from 'zod';
+import { router, publicProcedure } from '../trpc/init';
+import { ExplorerQueryService } from '../services/ExplorerQueryService';
+
+export const explorerRouter = router({
+  getActiveWeek: publicProcedure.query(async ({ ctx }) => {
+    const service = new ExplorerQueryService(ctx.orm);
+    return await service.getActiveWeek();
+  }),
+
+  getWeekProgress: publicProcedure
+    .input(z.object({ weekId: z.number().int().positive() }))
+    .query(async ({ ctx, input }) => {
+      if (!ctx.userId) {
+        throw new TRPCError({ code: 'UNAUTHORIZED' });
+      }
+
+      const service = new ExplorerQueryService(ctx.orm);
+      return await service.getWeekProgress(input.weekId, ctx.userId);
+    }),
+});

--- a/server/src/routers/index.ts
+++ b/server/src/routers/index.ts
@@ -9,6 +9,7 @@ import { clubRouter } from './club';
 import { profileRouter } from './profile';
 import { chatRouter } from './chat';
 import { chainWaxRouter } from './chainWax';
+import { explorerRouter } from './explorer';
 
 export const appRouter = router({
   health: publicProcedure.query(() => 'ok'),
@@ -22,6 +23,7 @@ export const appRouter = router({
   profile: profileRouter,
   chat: chatRouter,
   chainWax: chainWaxRouter,
+  explorer: explorerRouter,
 });
 
 export type AppRouter = typeof appRouter;

--- a/server/src/services/ExplorerMatchingService.ts
+++ b/server/src/services/ExplorerMatchingService.ts
@@ -1,0 +1,201 @@
+import { and, eq, gte, lte } from 'drizzle-orm';
+import { type BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+import {
+  explorerDestination,
+  explorerDestinationMatch,
+  explorerWeek,
+  type ExplorerWeek,
+} from '../db/schema';
+import {
+  getActivity,
+  listAthleteActivities,
+  type Activity as StravaActivity,
+} from '../stravaClient';
+import { isoToUnix } from '../dateUtils';
+
+interface MatchActivityResult {
+  processedWeeks: number;
+  matchedDestinations: number;
+  newMatches: number;
+}
+
+interface RefreshAthleteWeekResult {
+  activitiesProcessed: number;
+  activitiesMatched: number;
+  newMatches: number;
+}
+
+function getActivityTimestamp(activityData: StravaActivity): number | null {
+  return isoToUnix(activityData.start_date);
+}
+
+function getSegmentIdsFromActivity(activityData: StravaActivity): Set<string> {
+  const segmentIds = new Set<string>();
+
+  for (const effort of activityData.segment_efforts || []) {
+    if (effort.segment?.id !== undefined && effort.segment?.id !== null) {
+      segmentIds.add(String(effort.segment.id));
+    }
+  }
+
+  return segmentIds;
+}
+
+async function ensureSegmentEfforts(
+  activityData: StravaActivity,
+  accessToken: string
+): Promise<StravaActivity> {
+  if (Array.isArray(activityData.segment_efforts) && activityData.segment_efforts.length > 0) {
+    return activityData;
+  }
+
+  return await getActivity(String(activityData.id), accessToken);
+}
+
+export class ExplorerMatchingService {
+  constructor(private readonly db: BetterSQLite3Database) {}
+
+  async matchActivity(
+    activityData: StravaActivity,
+    athleteId: string
+  ): Promise<MatchActivityResult> {
+    const activityTimestamp = getActivityTimestamp(activityData);
+    if (activityTimestamp === null) {
+      return {
+        processedWeeks: 0,
+        matchedDestinations: 0,
+        newMatches: 0,
+      };
+    }
+
+    const activeWeeks = this.db
+      .select()
+      .from(explorerWeek)
+      .where(
+        and(
+          eq(explorerWeek.status, 'active'),
+          lte(explorerWeek.start_at, activityTimestamp),
+          gte(explorerWeek.end_at, activityTimestamp)
+        )
+      )
+      .all();
+
+    return this.matchActivityAgainstWeeks(activityData, athleteId, activeWeeks);
+  }
+
+  async refreshAthleteWeek(
+    explorerWeekId: number,
+    athleteId: string,
+    accessToken: string
+  ): Promise<RefreshAthleteWeekResult> {
+    const weekRecord = this.db
+      .select()
+      .from(explorerWeek)
+      .where(eq(explorerWeek.id, explorerWeekId))
+      .get();
+
+    if (!weekRecord) {
+      return {
+        activitiesProcessed: 0,
+        activitiesMatched: 0,
+        newMatches: 0,
+      };
+    }
+
+    const activities = await listAthleteActivities(accessToken, weekRecord.start_at, weekRecord.end_at, {
+      includeAllEfforts: true,
+    });
+
+    let activitiesMatched = 0;
+    let newMatches = 0;
+
+    for (const activity of activities) {
+      const hydratedActivity = await ensureSegmentEfforts(activity, accessToken);
+      const result = await this.matchActivityAgainstWeeks(hydratedActivity, athleteId, [weekRecord]);
+
+      if (result.matchedDestinations > 0) {
+        activitiesMatched += 1;
+      }
+
+      newMatches += result.newMatches;
+    }
+
+    return {
+      activitiesProcessed: activities.length,
+      activitiesMatched,
+      newMatches,
+    };
+  }
+
+  private async matchActivityAgainstWeeks(
+    activityData: StravaActivity,
+    athleteId: string,
+    weeks: ExplorerWeek[]
+  ): Promise<MatchActivityResult> {
+    if (weeks.length === 0) {
+      return {
+        processedWeeks: 0,
+        matchedDestinations: 0,
+        newMatches: 0,
+      };
+    }
+
+    const segmentIds = getSegmentIdsFromActivity(activityData);
+    if (segmentIds.size === 0) {
+      return {
+        processedWeeks: weeks.length,
+        matchedDestinations: 0,
+        newMatches: 0,
+      };
+    }
+
+    let matchedDestinations = 0;
+    let newMatches = 0;
+
+    for (const weekRecord of weeks) {
+      const destinations = this.db
+        .select()
+        .from(explorerDestination)
+        .where(eq(explorerDestination.explorer_week_id, weekRecord.id))
+        .all();
+
+      for (const destination of destinations) {
+        if (!segmentIds.has(destination.strava_segment_id)) {
+          continue;
+        }
+
+        matchedDestinations += 1;
+
+        const inserted = this.db
+          .insert(explorerDestinationMatch)
+          .values({
+            explorer_week_id: weekRecord.id,
+            explorer_destination_id: destination.id,
+            strava_athlete_id: athleteId,
+            strava_activity_id: String(activityData.id),
+            matched_at: getActivityTimestamp(activityData) || 0,
+          })
+          .onConflictDoNothing({
+            target: [
+              explorerDestinationMatch.explorer_week_id,
+              explorerDestinationMatch.explorer_destination_id,
+              explorerDestinationMatch.strava_athlete_id,
+            ],
+          })
+          .run();
+
+        if (inserted.changes > 0) {
+          newMatches += 1;
+        }
+      }
+    }
+
+    return {
+      processedWeeks: weeks.length,
+      matchedDestinations,
+      newMatches,
+    };
+  }
+}
+
+export type { MatchActivityResult, RefreshAthleteWeekResult };

--- a/server/src/services/ExplorerMatchingService.ts
+++ b/server/src/services/ExplorerMatchingService.ts
@@ -140,6 +140,15 @@ export class ExplorerMatchingService {
       };
     }
 
+    const activityTimestamp = getActivityTimestamp(activityData);
+    if (activityTimestamp === null) {
+      return {
+        processedWeeks: weeks.length,
+        matchedDestinations: 0,
+        newMatches: 0,
+      };
+    }
+
     const segmentIds = getSegmentIdsFromActivity(activityData);
     if (segmentIds.size === 0) {
       return {
@@ -173,7 +182,7 @@ export class ExplorerMatchingService {
             explorer_destination_id: destination.id,
             strava_athlete_id: athleteId,
             strava_activity_id: String(activityData.id),
-            matched_at: getActivityTimestamp(activityData) || 0,
+            matched_at: activityTimestamp,
           })
           .onConflictDoNothing({
             target: [

--- a/server/src/services/ExplorerQueryService.ts
+++ b/server/src/services/ExplorerQueryService.ts
@@ -1,0 +1,200 @@
+import { and, asc, desc, eq, gte, lte } from 'drizzle-orm';
+import { type BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+import {
+  explorerDestination,
+  explorerDestinationMatch,
+  explorerWeek,
+  segment,
+} from '../db/schema';
+
+interface ExplorerDestinationView {
+  id: number;
+  stravaSegmentId: string;
+  displayLabel: string;
+  sourceUrl: string | null;
+  surfaceType: string | null;
+  category: string | null;
+  displayOrder: number;
+}
+
+interface ActiveExplorerWeekView {
+  id: number;
+  name: string;
+  startAt: number;
+  endAt: number;
+  status: string;
+  destinations: ExplorerDestinationView[];
+}
+
+interface ExplorerProgressDestinationView extends ExplorerDestinationView {
+  completed: boolean;
+  matchedAt: number | null;
+  stravaActivityId: string | null;
+}
+
+interface ExplorerWeekProgressView {
+  week: {
+    id: number;
+    name: string;
+    startAt: number;
+    endAt: number;
+    status: string;
+  };
+  completedDestinations: number;
+  totalDestinations: number;
+  destinations: ExplorerProgressDestinationView[];
+}
+
+function resolveDestinationLabel(destination: {
+  strava_segment_id: string;
+  display_label: string | null;
+  cached_segment_name: string | null;
+  segment_name: string | null;
+}): string {
+  return (
+    destination.display_label ||
+    destination.cached_segment_name ||
+    destination.segment_name ||
+    `Segment ${destination.strava_segment_id}`
+  );
+}
+
+export class ExplorerQueryService {
+  constructor(private readonly db: BetterSQLite3Database) {}
+
+  async getActiveWeek(nowTimestamp: number = Math.floor(Date.now() / 1000)): Promise<ActiveExplorerWeekView | null> {
+    const weekRecord = this.db
+      .select()
+      .from(explorerWeek)
+      .where(
+        and(
+          eq(explorerWeek.status, 'active'),
+          lte(explorerWeek.start_at, nowTimestamp),
+          gte(explorerWeek.end_at, nowTimestamp)
+        )
+      )
+      .orderBy(desc(explorerWeek.start_at))
+      .get();
+
+    if (!weekRecord) {
+      return null;
+    }
+
+    const destinations = this.db
+      .select({
+        id: explorerDestination.id,
+        strava_segment_id: explorerDestination.strava_segment_id,
+        display_label: explorerDestination.display_label,
+        cached_segment_name: explorerDestination.cached_segment_name,
+        source_url: explorerDestination.source_url,
+        surface_type: explorerDestination.surface_type,
+        category: explorerDestination.category,
+        display_order: explorerDestination.display_order,
+        segment_name: segment.name,
+      })
+      .from(explorerDestination)
+      .leftJoin(segment, eq(explorerDestination.strava_segment_id, segment.strava_segment_id))
+      .where(eq(explorerDestination.explorer_week_id, weekRecord.id))
+      .orderBy(asc(explorerDestination.display_order), asc(explorerDestination.id))
+      .all();
+
+    return {
+      id: weekRecord.id,
+      name: weekRecord.name,
+      startAt: weekRecord.start_at,
+      endAt: weekRecord.end_at,
+      status: weekRecord.status,
+      destinations: destinations.map((destination) => ({
+        id: destination.id,
+        stravaSegmentId: destination.strava_segment_id,
+        displayLabel: resolveDestinationLabel(destination),
+        sourceUrl: destination.source_url,
+        surfaceType: destination.surface_type,
+        category: destination.category,
+        displayOrder: destination.display_order,
+      })),
+    };
+  }
+
+  async getWeekProgress(
+    explorerWeekId: number,
+    athleteId: string
+  ): Promise<ExplorerWeekProgressView | null> {
+    const weekRecord = this.db
+      .select()
+      .from(explorerWeek)
+      .where(eq(explorerWeek.id, explorerWeekId))
+      .get();
+
+    if (!weekRecord) {
+      return null;
+    }
+
+    const destinations = this.db
+      .select({
+        id: explorerDestination.id,
+        strava_segment_id: explorerDestination.strava_segment_id,
+        display_label: explorerDestination.display_label,
+        cached_segment_name: explorerDestination.cached_segment_name,
+        source_url: explorerDestination.source_url,
+        surface_type: explorerDestination.surface_type,
+        category: explorerDestination.category,
+        display_order: explorerDestination.display_order,
+        segment_name: segment.name,
+      })
+      .from(explorerDestination)
+      .leftJoin(segment, eq(explorerDestination.strava_segment_id, segment.strava_segment_id))
+      .where(eq(explorerDestination.explorer_week_id, explorerWeekId))
+      .orderBy(asc(explorerDestination.display_order), asc(explorerDestination.id))
+      .all();
+
+    const matches = this.db
+      .select({
+        explorer_destination_id: explorerDestinationMatch.explorer_destination_id,
+        matched_at: explorerDestinationMatch.matched_at,
+        strava_activity_id: explorerDestinationMatch.strava_activity_id,
+      })
+      .from(explorerDestinationMatch)
+      .where(
+        and(
+          eq(explorerDestinationMatch.explorer_week_id, explorerWeekId),
+          eq(explorerDestinationMatch.strava_athlete_id, athleteId)
+        )
+      )
+      .all();
+
+    const matchesByDestinationId = new Map(matches.map((match) => [match.explorer_destination_id, match]));
+
+    const progressDestinations = destinations.map((destination) => {
+      const match = matchesByDestinationId.get(destination.id);
+
+      return {
+        id: destination.id,
+        stravaSegmentId: destination.strava_segment_id,
+        displayLabel: resolveDestinationLabel(destination),
+        sourceUrl: destination.source_url,
+        surfaceType: destination.surface_type,
+        category: destination.category,
+        displayOrder: destination.display_order,
+        completed: Boolean(match),
+        matchedAt: match?.matched_at || null,
+        stravaActivityId: match?.strava_activity_id || null,
+      };
+    });
+
+    return {
+      week: {
+        id: weekRecord.id,
+        name: weekRecord.name,
+        startAt: weekRecord.start_at,
+        endAt: weekRecord.end_at,
+        status: weekRecord.status,
+      },
+      completedDestinations: progressDestinations.filter((destination) => destination.completed).length,
+      totalDestinations: progressDestinations.length,
+      destinations: progressDestinations,
+    };
+  }
+}
+
+export type { ActiveExplorerWeekView, ExplorerWeekProgressView };

--- a/server/src/webhooks/activityHandlers.ts
+++ b/server/src/webhooks/activityHandlers.ts
@@ -8,11 +8,17 @@ export {
 } from './activityHandlerRunner';
 export { createChainWaxActivityHandler } from './handlers/chainWaxActivityHandler';
 export { createCompetitionActivityHandler } from './handlers/competitionActivityHandler';
+export { createExplorerActivityHandler } from './handlers/explorerActivityHandler';
 
 import { type ActivityWebhookHandler } from './activityHandlerRunner';
 import { createChainWaxActivityHandler } from './handlers/chainWaxActivityHandler';
 import { createCompetitionActivityHandler } from './handlers/competitionActivityHandler';
+import { createExplorerActivityHandler } from './handlers/explorerActivityHandler';
 
 export function createDefaultActivityHandlers(): ActivityWebhookHandler[] {
-  return [createChainWaxActivityHandler(), createCompetitionActivityHandler()];
+  return [
+    createChainWaxActivityHandler(),
+    createCompetitionActivityHandler(),
+    createExplorerActivityHandler(),
+  ];
 }

--- a/server/src/webhooks/handlers/explorerActivityHandler.ts
+++ b/server/src/webhooks/handlers/explorerActivityHandler.ts
@@ -1,0 +1,24 @@
+import { ExplorerMatchingService } from '../../services/ExplorerMatchingService';
+import { type ActivityWebhookHandler } from '../activityHandlerRunner';
+
+export function createExplorerActivityHandler(): ActivityWebhookHandler {
+  return {
+    name: 'explorer',
+    isolateErrors: true,
+    async handle(context) {
+      const activityData = await context.getActivityWithSegmentEfforts();
+      if (!activityData) {
+        return;
+      }
+
+      const explorerMatchingService = new ExplorerMatchingService(context.db);
+      const result = await explorerMatchingService.matchActivity(activityData, context.athleteId);
+
+      if (result.newMatches > 0) {
+        console.log(
+          `[Webhook:Explorer] Recorded ${result.newMatches} new Explorer destination matches for athlete ${context.athleteId}`
+        );
+      }
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- add the Explorer Phase 2 Slice A backend data model, matching/query services, router wiring, and webhook handler
- add focused backend coverage for matching, route queries, and webhook integration, plus supporting test helpers and migration metadata
- update shared repo instructions so validated slices recommend commit plus PR handoff before returning to planning

## What changed
- added `explorer_week`, `explorer_destination`, and `explorer_destination_match` schema objects and migration `0009_explorer_phase2_slice_a`
- added `ExplorerMatchingService` and `ExplorerQueryService`
- added `trpc.explorer.getActiveWeek` and `trpc.explorer.getWeekProgress`
- registered a non-blocking Explorer webhook activity handler
- added backend tests for service behavior, router behavior, and webhook handling
- documented the Explorer API/database surface and tightened slice-completion handoff guidance in repo instructions

## Validation
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run build`

## Notes
- `VERSION` and `CHANGELOG.md` were intentionally left unchanged for this slice.
- Existing non-blocking warnings still appear during validation: duplicate Jest manual mock discovery under `server/src/__mocks__` and `server/dist/__mocks__`, and the pre-existing Vite large chunk warning during build.