### PR TITLE
docs: correct Explorer planning to season campaign model

### DIFF
--- a/.github/agents/explorer-planner.agent.md
+++ b/.github/agents/explorer-planner.agent.md
@@ -1,7 +1,7 @@
 ---
 name: explorer-planner
 description: Plan WMV Explorer work from the PRD, tech spec, readiness checklist, and worklog. Use for readiness reviews, implementation slicing, and planning handoffs before coding.
-tools: [read, search, todo]
+tools: [read, edit, search, todo, execute]
 model: GPT-5 (copilot)
 argument-hint: Review the Explorer docs or prepare the next implementation slice.
 handoffs:
@@ -30,6 +30,8 @@ Primary sources:
 
 - Before substantial planning or handoff for a new slice, check whether the current branch is appropriate.
 - If the work is not a tiny follow-up to the active branch, require the user or implementation agent to move onto updated `main` and create a dedicated feature branch before substantial work continues.
+- You may use shell execution for branch checks and for switching onto a dedicated planning branch from updated `main` when the current branch is an active implementation or PR branch and the task is a substantial planning correction.
+- You may edit planning artifacts and agent-planning configuration files when the task is readiness closure, slice preparation, or planning-state maintenance.
 - Do not edit product code.
 - Do not edit `VERSION` or `CHANGELOG.md`; those are final pre-commit release notes for implementation work, not planning artifacts.
 - Do not treat unresolved planning gaps as implementation details to be decided later without calling them out.

--- a/docs/prds/wmv-explorer-destinations-phases.md
+++ b/docs/prds/wmv-explorer-destinations-phases.md
@@ -36,48 +36,60 @@ Out of scope:
 - Explorer admin setup
 - Forcing activity delete or athlete deauthorization into the same handler abstraction before the activity path is stable
 
-## Phase 2: Explorer Data Model And Matching
+## Phase 2: Season Campaign Model Correction
 
-Goal: add Explorer week, destination, and match storage plus the shared matching service used by both webhooks and refresh actions.
+Goal: correct Explorer from a weekly-first design to a season-attached campaign model, and remove optional mini-campaign complexity from MVP planning.
 
-Entry condition: start from a new PR after Phase 1 is merged, and use that PR to close the remaining summary-model and destination-metadata decisions before broad Phase 2 implementation expands.
+Entry condition: start from a new planning PR from updated `main` because the current planning set and implementation branch were built around the wrong weekly-first model.
 
 Scope:
 
-- Schema additions
+- Rewrite PRD, tech spec, worklog, and readiness checklist around a season-attached Explorer campaign
+- Remove mini-campaigns from MVP scope and record them as future optional work
+- Remove explicit `draft` / `active` / `archived` workflow from MVP unless later implementation proves it is necessary
+- Define the smallest safe follow-on implementation slice against the corrected model
+
+## Phase 3: Explorer Campaign Data Model And Matching
+
+Goal: add Explorer campaign, destination, and match storage plus the shared matching service used by both webhooks and refresh actions.
+
+Scope:
+
+- Schema additions for a season-attached campaign model
 - Explorer matching service
 - Admin or service-level refresh path
 - Idempotent storage rules
 
-## Phase 3: Explorer Admin Setup
+## Phase 4: Explorer Admin Setup
 
-Goal: let admins create Explorer weeks, add destinations from Strava URLs one at a time, label them, order them, and manage activation.
+Goal: let admins create or manage the season campaign, add destinations from Strava URLs one at a time, label them, order them, and manage additions during the season.
 
 Scope:
 
 - Explorer admin routes and service layer
 - Explorer admin UI
-- Activation guard requiring at least one destination
+- Campaign setup attached to a season
+- Add-destination workflow that works before or during the season
 
-## Phase 4: Explorer Hub MVP
+## Phase 5: Explorer Hub MVP
 
-Goal: ship the athlete-facing weekly Explorer view.
+Goal: ship the athlete-facing season Explorer view.
 
 Scope:
 
 - Challenges hub route
-- Active week header
+- Active campaign header
 - Progress bar
 - Destination checklist
 - Completers summary with all names
 
-## Phase 5: Hardening And Follow-on Expansion
+## Phase 6: Hardening And Follow-on Expansion
 
 Goal: stabilize the Explorer feature and prepare later work.
 
 Candidate items:
 
-- Season-wide Explorer aggregation
+- Optional mini-campaigns attached to a season
 - Better admin search and validation tooling
 - Explorer profile rollups
 - Badges and themed campaigns

--- a/docs/prds/wmv-explorer-destinations-prd.md
+++ b/docs/prds/wmv-explorer-destinations-prd.md
@@ -12,9 +12,9 @@
 
 ## 1. Executive Summary
 
-WMV Explorer Destinations is a new offseason participation feature for the WMV Cycling Series app. Instead of rewarding speed or rank, it gives athletes a weekly set of admin-curated Strava segment destinations to visit. Each matched destination counts as one completion point for that week, and the primary experience is personal progress: how many destinations an athlete has completed, which ones remain, and whether they finished the full weekly set.
+WMV Explorer Destinations is a new offseason participation feature for the WMV Cycling Series app. Instead of rewarding speed or rank, it gives athletes a season-long set of admin-curated Strava segment destinations to visit. Each matched destination counts once for the season campaign, and the primary experience is personal progress: how many destinations an athlete has completed, which ones remain, and whether they finished the full season set.
 
-The feature is designed to work for both outdoor and virtual riding, as long as the destination is represented by a Strava segment. This makes the experience more inclusive for riders doing real-world routes, Zwift routes, or a mix of both. The product also stores Explorer results across weeks so WMV can later expand into season-wide Explorer campaigns and broader participation tracking.
+The feature is designed to work for both outdoor and virtual riding, as long as the destination is represented by a Strava segment. This makes the experience more inclusive for riders doing real-world routes, Zwift routes, or a mix of both. The MVP should treat the season-long campaign as the primary unit. Smaller time-boxed mini-campaigns within a season are optional future work rather than required MVP structure.
 
 ## 2. Problem Statement
 
@@ -23,32 +23,32 @@ The current WMV Cycling Series product is centered on weekly segment competition
 Existing gaps include:
 
 - Participation is currently framed mainly as competition rather than exploration.
-- There is no product area for weekly destination-based riding goals.
-- There is no persistent record of exploration-style accomplishments across weeks.
+- There is no product area for season-long destination-based riding goals.
+- There is no persistent record of exploration-style accomplishments across an entire season campaign.
 - The current UI does not support a simple personal-progress model such as checklist completion or progress bars.
 - The current webhook processor is already serving multiple purposes and needs a cleaner extension path before adding Explorer matching.
 
-WMV Explorer Destinations addresses these problems by adding a progress-first weekly experience that reuses Strava activity data and admin curation without forcing riders into a race-style leaderboard.
+WMV Explorer Destinations addresses these problems by adding a progress-first season experience that reuses Strava activity data and admin curation without forcing riders into a race-style leaderboard.
 
 ## 3. Goals & Objectives
 
 | Goal | Description | Success Signal |
 | --- | --- | --- |
 | Inclusive offseason participation | Give riders a way to participate without needing to compete on speed | Riders can engage through weekly destination completion rather than race ranking |
-| Weekly motivation | Provide a clear set of weekly riding goals | Athletes can see a weekly progress bar and destination checklist |
-| Low admin friction | Let admins create a weekly Explorer challenge from Strava segments | Admin can create an Explorer week and configure destinations in one workflow |
+| Season-long motivation | Provide a clear set of season riding goals | Athletes can see season progress and a destination checklist across the active season |
+| Low admin friction | Let admins create a season Explorer campaign from Strava segments | Admin can attach an Explorer campaign to a season and configure destinations in one workflow |
 | Reuse current WMV systems | Build on existing Strava auth and ingestion patterns | No manual athlete submissions required for normal use |
-| Preserve future flexibility | Store Explorer results in a way that supports season-wide Explorer later | Weekly completion history is queryable across multiple weeks |
+| Preserve future flexibility | Keep room for optional mini-campaigns later without complicating MVP | Future season-attached mini-campaigns can be added without rewriting core Explorer progress |
 | Avoid regression in competition features | Add Explorer without breaking current leaderboard and scoring behavior | Current competition routes and scoring remain unchanged |
 
 ## 4. Target Audience
 
 | Audience | Description | Primary Need |
 | --- | --- | --- |
-| Existing WMV athlete | Club rider already using the app for seasonal competition | A fun, low-pressure weekly riding goal |
+| Existing WMV athlete | Club rider already using the app for seasonal competition | A fun, low-pressure season-long riding goal |
 | Casual or exploratory rider | Rider less interested in racing but motivated by destinations and completion | A checklist-style challenge rather than a ranking system |
-| Indoor or hybrid rider | Athlete who rides on Zwift and outdoors | Weekly destinations that can be either virtual or real-world Strava segments |
-| Club admin | Person organizing offseason engagement | A simple workflow to define weekly destinations and monitor completions |
+| Indoor or hybrid rider | Athlete who rides on Zwift and outdoors | Season destinations that can be either virtual or real-world Strava segments |
+| Club admin | Person organizing offseason engagement | A simple workflow to define season destinations and monitor completions |
 
 ## 5. User Stories
 
@@ -56,32 +56,32 @@ WMV Explorer Destinations addresses these problems by adding a progress-first we
 
 | ID | User Story | Priority | Acceptance Criteria |
 | --- | --- | --- | --- |
-| US-01 | As an athlete, I want to see the active Explorer week so I know what destinations are available now | Must | Active Explorer week is clearly visible in the Challenges hub |
-| US-02 | As an athlete, I want to see the weekly destination list so I know what segments count | Must | Destination list shows all configured segments for the week |
-| US-03 | As an athlete, I want to see my Explorer progress as a progress bar so I can quickly tell how far along I am | Must | Progress bar shows completed destinations versus total destinations |
+| US-01 | As an athlete, I want to see the active Explorer season campaign so I know what destinations are available now | Must | The current season Explorer campaign is clearly visible in the Challenges hub |
+| US-02 | As an athlete, I want to see the season destination list so I know what segments count | Must | Destination list shows all configured segments for the active season campaign |
+| US-03 | As an athlete, I want to see my Explorer progress as a progress bar so I can quickly tell how far along I am | Must | Progress bar shows completed destinations versus total destinations for the season campaign |
 | US-04 | As an athlete, I want a checklist of completed and remaining destinations so I can track what I still need | Must | Each destination shows complete or incomplete state for the logged-in athlete |
-| US-05 | As an athlete, I want each matched destination to count once for the week so the rules are easy to understand | Must | Repeated visits to the same destination in the same week do not increase progress |
+| US-05 | As an athlete, I want each matched destination to count once for the season campaign so the rules are easy to understand | Must | Repeated visits to the same destination during the same season campaign do not increase progress |
 | US-06 | As an athlete, I want virtual and outdoor Strava segments to count equally as destinations so the feature feels inclusive | Must | Eligibility depends on matching configured Strava segments, not whether a ride is virtual or outdoor |
-| US-07 | As an athlete, I want to know if I completed all destinations for the week so I can celebrate finishing the set | Must | Full completion state is visible when all destinations are matched |
+| US-07 | As an athlete, I want to know if I completed all destinations for the season so I can celebrate finishing the set | Must | Full completion state is visible when all campaign destinations are matched |
 
 ### 5.2 Club Visibility
 
 | ID | User Story | Priority | Acceptance Criteria |
 | --- | --- | --- | --- |
-| US-08 | As a club member, I want to know whether anyone completed all destinations this week so the feature feels communal | Must | Weekly view includes a completers summary showing all athlete names who completed the full set |
+| US-08 | As a club member, I want to know whether anyone completed the full season destination set so the feature feels communal | Must | Explorer view includes a completers summary showing all athlete names who completed the full set |
 | US-09 | As a club member, I do not want the Explorer hub to feel like another race leaderboard | Must | Weekly view emphasizes progress and completion, not rank ordering |
 
 ### 5.3 Admin Experience
 
 | ID | User Story | Priority | Acceptance Criteria |
 | --- | --- | --- | --- |
-| US-10 | As an admin, I want to create a dedicated Explorer week so the feature can run independently from race weeks | Must | Admin can create Explorer weeks with their own date range |
+| US-10 | As an admin, I want to create an Explorer campaign attached to a season so the feature can run for the entire season without depending on race weeks | Must | Admin can attach one Explorer campaign to a season and configure destinations for it |
 | US-11 | As an admin, I want to add destinations from Strava URLs so setup matches the regular admin panel workflow | Must | Admin can paste one Strava segment URL at a time and the system extracts the segment ID |
-| US-12 | As an admin, I want to add labels to destinations so the weekly challenge is presented clearly | Must | Destinations support optional labels in addition to the underlying segment metadata |
-| US-13 | As an admin, I want to reorder destinations so the weekly challenge is presented clearly | Should | Destinations support display order |
+| US-12 | As an admin, I want to add labels to destinations so the season campaign is presented clearly | Must | Destinations support optional labels in addition to the underlying segment metadata |
+| US-13 | As an admin, I want to reorder destinations so the season campaign is presented clearly | Should | Destinations support display order |
 | US-14 | As an admin, I want to refresh Explorer matching so I can recover missed or late-connected activities | Must | Admin can trigger a reprocess path for Explorer data |
 | US-15 | As an admin, I want Explorer setup to be separate from race week setup so the two products do not get mixed together | Must | Explorer management uses its own admin surface or clearly separated section |
-| US-16 | As an admin, I want Explorer weeks to require at least one destination before activation so athletes never see an empty challenge | Must | Explorer week cannot be activated without at least one configured destination |
+| US-16 | As an admin, I want to add new destinations during the season without resetting progress | Must | Newly added destinations become part of the current season campaign and existing completions remain intact |
 
 ## 6. MoSCoW Prioritization
 
@@ -90,18 +90,18 @@ WMV Explorer Destinations addresses these problems by adding a progress-first we
 | Item | User Stories | Rationale |
 | --- | --- | --- |
 | Separate Challenges hub | US-01, US-10 | Explorer must feel distinct from race competition |
-| Active Explorer week view | US-01, US-02 | Core weekly experience |
+| Active Explorer season campaign view | US-01, US-02 | Core season experience |
 | Progress bar + checklist UX | US-03, US-04 | Primary interaction model |
 | One point per matched destination | US-05 | Simple, explainable rule set |
 | Virtual and outdoor segment support | US-06 | Inclusion requirement |
-| Weekly completion state | US-07 | Key motivator for the feature |
+| Season completion state | US-07 | Key motivator for the feature |
 | Completers summary with all athlete names | US-08 | Light communal visibility without ranking |
-| Separate Explorer week admin flow | US-10, US-15 | Keeps data model and UI boundaries clear |
+| Separate Explorer season admin flow | US-10, US-15 | Keeps data model and UI boundaries clear |
 | Strava URL-based destination setup | US-11 | Matches existing admin workflow |
 | Destination labels | US-12 | Needed for flexible curation and presentation |
-| Activation requires at least one destination | US-16 | Prevents empty Explorer weeks from going live |
+| Add destinations before or during the season | US-16 | Supports real admin workflows without extra status complexity |
 | Refresh or backfill action | US-14 | Operational recovery and late joins |
-| Persistent Explorer history across weeks | — | Required for future season-wide Explorer support |
+| Persistent Explorer history across the season | — | Required for season progress and future optional sub-campaigns |
 | Delegated webhook ingestion path | — | Required to add Explorer without further overloading the webhook processor |
 
 ### Should Have (Enhanced Experience)
@@ -117,7 +117,7 @@ WMV Explorer Destinations addresses these problems by adding a progress-first we
 
 | Item | User Stories | Rationale |
 | --- | --- | --- |
-| Destination categories such as scenic, climb, or event | — | Adds editorial character to weekly Explorer sets |
+| Destination categories such as scenic, climb, or event | — | Adds editorial character to season Explorer campaigns |
 | Celebration treatment on full completion | US-07 | Reinforces motivation without adding competition |
 | Destination category chips or themed labels | US-12 | Adds editorial polish without changing core rules |
 
@@ -127,7 +127,7 @@ WMV Explorer Destinations addresses these problems by adding a progress-first we
 | --- | --- |
 | Rank-ordered Explorer leaderboard | Explorer is progress-first in v1 |
 | Bonus scoring beyond one point per destination | Keep the rules simple first |
-| Season-wide Explorer UI | Depends on weekly history first |
+| Weekly or mini-campaign Explorer UI | Deferred until the season campaign model is stable |
 | Shared-segment mini-races | Separate future feature |
 | Badge system | Defer until core Explorer behavior is validated |
 | Out-of-process worker or CLI handoff for webhooks | In-process delegated handlers are sufficient for v1 |
@@ -136,12 +136,12 @@ WMV Explorer Destinations addresses these problems by adding a progress-first we
 
 ### 7.1 Layout
 
-The Explorer hub should present one weekly challenge at a time, with a progress-first layout:
+The Explorer hub should present one season campaign at a time, with a progress-first layout:
 
-- Header area with Explorer week title, date range, and short rules summary.
+- Header area with Explorer campaign title, season context, and short rules summary.
 - Progress section with a visible progress bar showing completed destinations versus total destinations.
-- Destination checklist showing all weekly destinations with completed or remaining state for the current athlete.
-- Weekly completion summary showing all athletes who completed the full set.
+- Destination checklist showing all campaign destinations with completed or remaining state for the current athlete.
+- Completion summary showing all athletes who completed the full set.
 - Lightweight empty or disconnected states when the athlete has no data yet.
 
 ### 7.2 UX Principles
@@ -149,7 +149,7 @@ The Explorer hub should present one weekly challenge at a time, with a progress-
 | Principle | Description |
 | --- | --- |
 | Progress over ranking | The page should feel like a challenge checklist, not a leaderboard |
-| Clear weekly framing | Athletes should immediately understand what counts this week |
+| Clear season framing | Athletes should immediately understand what counts during the active season campaign |
 | Inclusive destination model | Virtual and outdoor destinations should be presented as equally valid |
 | Low cognitive load | Rules should be understandable in seconds |
 | Additive navigation | Explorer should feel like a new section, not a replacement for competition views |
@@ -176,9 +176,9 @@ The Explorer hub should present one weekly challenge at a time, with a progress-
 
 | Requirement | Target | Validation |
 | --- | --- | --- |
-| Durable weekly history | Explorer progress remains queryable after the week ends | Automated integration tests |
-| Correct weekly boundaries | Only activities inside the Explorer week count | Backend tests for start and end edge cases |
-| One completion per destination per athlete per week | Multiple visits do not overcount | Backend tests |
+| Durable season history | Explorer progress remains queryable after the season ends | Automated integration tests |
+| Correct season boundaries | Only activities inside the Explorer campaign's parent season count | Backend tests for start and end edge cases |
+| One completion per destination per athlete per season campaign | Multiple visits do not overcount | Backend tests |
 
 ### 8.3 Accessibility
 
@@ -201,7 +201,7 @@ The Explorer hub should present one weekly challenge at a time, with a progress-
 | --- | --- | --- | --- |
 | Webhook processor complexity grows further | Harder to add Explorer safely | High | Refactor to delegated in-process handlers before adding Explorer-specific logic |
 | Strava URLs may be pasted incorrectly or parse to invalid segments | Broken destination configuration | Medium | Validate pasted URLs, extract segment IDs safely, and cache segment metadata where possible |
-| Confusion between Explorer weeks and race weeks | Users or admins may mix the two concepts | Medium | Use distinct naming, routes, and admin sections |
+| Confusion between Explorer campaigns and race weeks | Users or admins may mix the two concepts | Medium | Use distinct naming, routes, and admin sections |
 | Missing activity matches for late connections or failures | Athlete progress appears incomplete | Medium | Provide explicit refresh or backfill actions |
 | Explorer drifts toward competition UX | Reduces inclusiveness and changes product intent | Medium | Avoid rank ordering and center progress/checklist UX |
 
@@ -209,22 +209,23 @@ The Explorer hub should present one weekly challenge at a time, with a progress-
 
 The v1 release is successful if:
 
-1. Admins can create an Explorer week and assign Strava segment destinations.
-2. Explorer weeks require at least one destination before they can be activated.
-3. Athletes can see a weekly progress bar and destination checklist in the Challenges hub.
-4. Each matched destination counts once per athlete per week.
+1. Admins can create an Explorer campaign for a season and assign Strava segment destinations.
+2. Admins can add destinations before or during the season without resetting campaign progress.
+3. Athletes can see a season progress bar and destination checklist in the Challenges hub.
+4. Each matched destination counts once per athlete per season campaign.
 5. Virtual and outdoor segment destinations both work when configured.
 6. The hub includes a completers summary showing all completer names without presenting a rank-ordered leaderboard.
-7. Explorer history persists across weeks and can support future season-wide aggregation.
+7. Explorer history persists across the season and can support future optional mini-campaigns or later rollups.
 8. Existing competition features continue to behave correctly.
 
 ## 11. Future Considerations (Post v1.0)
 
 | Future Item | Priority | Notes |
 | --- | --- | --- |
-| Season-wide Explorer rollups | Medium | Enabled by stored weekly history |
+| Optional mini-campaigns attached to a season | Medium | Deferred until the season campaign model is stable |
+| Season-wide Explorer rollups | Medium | Enabled by stored season campaign history |
 | Explorer badges and streaks | Medium | Depends on stable weekly participation data |
-| Themed destination campaigns | Medium | Adds editorial depth to weekly challenges |
+| Themed destination campaigns | Medium | Adds editorial depth to season campaigns |
 | Shared-segment mini-races | High | Requires broader segment aggregation strategy |
 | Destination search and richer admin tools | Medium | Improves authoring workflow after v1 |
 
@@ -240,20 +241,19 @@ The technical specification for Explorer Destinations is documented in [wmv-expl
 | --- | --- | --- |
 | Feature completeness | All Must Have PRD items are implemented and functional | Manual QA plus automated tests |
 | Architecture compliance | Explorer uses delegated webhook ingestion and separate Explorer data storage | Code review and backend tests |
-| Data integrity | Explorer progress is stored correctly across weeks without duplicate counting | Integration tests |
-| UX compliance | Weekly view uses progress bar, checklist, and completers summary without rank ordering | Product QA |
+| Data integrity | Explorer progress is stored correctly across the season without duplicate counting | Integration tests |
+| UX compliance | Season view uses progress bar, checklist, and completers summary without rank ordering | Product QA |
 | Regression safety | Existing race leaderboard and admin flows continue to work | Regression suite |
 
 ### 13.2 Launch Checklist
 
-- Explorer week creation works in admin UI.
+- Explorer campaign creation for a season works in admin UI.
 - Destination setup accepts and validates Strava segment URLs.
-- Explorer week activation is blocked until at least one destination exists.
-- Active Explorer week renders in the Challenges hub.
+- Active Explorer season campaign renders in the Challenges hub.
 - Athlete progress bar and checklist render correctly.
 - Completers summary is visible and shows names.
 - Manual refresh or backfill works.
-- Explorer history persists and can be queried after week end.
+- Explorer history persists and can be queried after season end.
 - Existing leaderboard and admin regression checks pass.
 - For a user-facing Explorer commit, `VERSION` and `CHANGELOG.md` are updated in the final pre-commit pass with a high-level summary of the shipped slice.
 - Explorer ideas backlog remains separate from the v1 scope.

--- a/docs/prds/wmv-explorer-destinations-tech-spec.md
+++ b/docs/prds/wmv-explorer-destinations-tech-spec.md
@@ -5,8 +5,8 @@
 This specification translates the Explorer Destinations PRD into an implementation-oriented design for the current WMV Cycling Series codebase. It preserves the key planning decisions:
 
 - Explorer is a separate product area from the current race leaderboard.
-- Explorer uses separate week and result storage rather than reusing the current competition week model.
-- Weekly UX is progress bar plus checklist plus completers summary.
+- Explorer uses a separate season-attached campaign model rather than overloading the current competition week model.
+- Season UX is progress bar plus checklist plus completers summary.
 - Strava segments are the canonical destination type, regardless of whether they represent outdoor or virtual riding.
 - Webhook ingestion remains in-process but is refactored into delegated handlers so Explorer can be added without further overloading the current webhook processor.
 
@@ -14,21 +14,21 @@ This specification translates the Explorer Destinations PRD into an implementati
 
 ### In Scope
 
-- Separate Explorer week model
+- Separate Explorer campaign model attached to an existing WMV season
 - Admin-defined Explorer destinations from Strava segment URLs or IDs
 - Explorer matching from ingested Strava activities
-- One completion per destination per athlete per Explorer week
-- Weekly athlete progress queries
-- Weekly completers summary queries with all completer names
-- Stored Explorer history across weeks
+- One completion per destination per athlete per Explorer campaign
+- Season athlete progress queries
+- Season completers summary queries with all completer names
+- Stored Explorer history across the season
 - Reusable refresh or backfill path
-- Explorer week activation rule requiring at least one destination
+- Allowing admins to add destinations during the season without resetting progress
 
 ### Out of Scope
 
 - Explorer rank-order leaderboard
 - Bonus scoring beyond one point per destination
-- Season-wide Explorer UI
+- Optional mini-campaigns inside a season
 - Shared-segment mini-races
 - Badge systems
 - Queue-backed or out-of-process worker model
@@ -40,6 +40,8 @@ This specification translates the Explorer Destinations PRD into an implementati
 - Strava auth and participant identity already exist.
 - Webhook ingestion already fetches and normalizes activity data in [server/src/webhooks/processor.ts](../../server/src/webhooks/processor.ts).
 - Batch or explicit activity processing already exists in [server/src/services/BatchFetchService.ts](../../server/src/services/BatchFetchService.ts).
+- The existing shared `segment` table already persists Strava segment metadata such as name, distance, grade, elevation, and location, and Competition already joins against it for read paths.
+- The current admin segment-validation flow already centralizes Strava segment fetch and persistence in [server/src/services/SegmentService.ts](../../server/src/services/SegmentService.ts).
 - App routing and top-level navigation patterns already exist in [src/App.tsx](../../src/App.tsx) and [src/components/NavBar.tsx](../../src/components/NavBar.tsx).
 - The regular admin panel already has a Strava URL input pattern worth mirroring for Explorer destination setup rather than exposing raw segment IDs only.
 
@@ -48,6 +50,7 @@ This specification translates the Explorer Destinations PRD into an implementati
 - Do not modify the canonical race scoring model in [docs/SCORING.md](../SCORING.md).
 - Do not overload current competition week records with Explorer semantics.
 - Keep Explorer additive so existing leaderboard, season, and admin flows remain intact.
+- Prefer attaching Explorer to the existing `season` concept rather than inventing a second top-level season model for MVP.
 
 ## 4. Recommended Architecture
 
@@ -87,26 +90,48 @@ Recommended direction:
 - Call that service from the Explorer ingestion handler.
 - Call that same service from an admin or participant-triggered refresh action.
 
+### 4.4 Shared segment-based matching seam
+
+The repository already has partially reusable building blocks for segment-based activity handling:
+
+- activity-window and lap-window selection in [server/src/activityProcessor.ts](../../server/src/activityProcessor.ts)
+- activity and effort persistence in [server/src/activityStorage.ts](../../server/src/activityStorage.ts)
+- webhook competition handling in [server/src/webhooks/handlers/competitionActivityHandler.ts](../../server/src/webhooks/handlers/competitionActivityHandler.ts)
+- batch refresh handling in [server/src/services/BatchFetchService.ts](../../server/src/services/BatchFetchService.ts)
+- late metric hydration in [server/src/services/HydrationService.ts](../../server/src/services/HydrationService.ts)
+
+Explorer should not introduce a second copy of this segment-based matching flow. The first corrected implementation slice should extract only the shared seam needed for a season campaign model while preserving current Competition behavior.
+
+### 4.3 MVP simplification
+
+For MVP, do not introduce a separate Explorer week lifecycle or explicit `draft` / `active` / `archived` workflow unless later implementation proves it is necessary.
+
+Use these simpler rules instead:
+
+- the Explorer campaign attaches to an existing WMV season
+- the campaign is considered active when the parent season is open
+- the athlete-facing Explorer surface should only render when the campaign has at least one destination
+- admins may add destinations before or during the season
+- optional mini-campaigns within a season are deferred until after the season-first model is stable
+
 ## 5. Proposed Data Model
 
 ### 5.1 New entities
 
 Recommended Explorer tables or equivalent schema concepts:
 
-- ExplorerWeek
+- ExplorerCampaign
   - id
-  - name
-  - startAt
-  - endAt
-  - status or active flag
+  - seasonId
+  - optional displayName or rules blurb if needed later
   - createdAt
   - updatedAt
 
-Activation rule: an ExplorerWeek cannot move to an active state unless it has at least one ExplorerDestination.
+MVP rule: an ExplorerCampaign is attached to one season. The campaign becomes athlete-visible only when its parent season is open and it has at least one ExplorerDestination.
 
 - ExplorerDestination
   - id
-  - explorerWeekId
+  - explorerCampaignId
   - stravaSegmentId
   - sourceUrl nullable
   - cachedSegmentName
@@ -119,33 +144,43 @@ Activation rule: an ExplorerWeek cannot move to an active state unless it has at
 
 - ExplorerDestinationMatch
   - id
-  - explorerWeekId
+  - explorerCampaignId
   - explorerDestinationId
   - stravaAthleteId
   - stravaActivityId
   - matchedAt or activityStartAt
   - createdAt
 
-- ExplorerAthleteWeekSummary
+- ExplorerAthleteCampaignSummary
   - optional derived or cached summary table if needed later
-  - explorerWeekId
+  - explorerCampaignId
   - stravaAthleteId
   - matchedDestinationCount
   - completedAll boolean
   - lastMatchedAt
 
-For v1, ExplorerAthleteWeekSummary can remain computed on read if query cost is modest. The durable source of truth should be ExplorerDestinationMatch.
+For v1, ExplorerAthleteCampaignSummary is computed on read. `ExplorerDestinationMatch` is the durable source of truth. Cached summary storage is deferred unless measured query cost justifies it later.
 
 ### 5.2 Key integrity rules
 
-- One athlete can match a given destination at most once per Explorer week.
-- Multiple rides over the same destination in the same Explorer week do not increase progress.
-- Matches are constrained to the Explorer week date range.
-- Explorer records must survive after the week ends so future season views can aggregate them.
+- One athlete can match a given destination at most once per Explorer campaign.
+- Multiple rides over the same destination in the same campaign do not increase progress.
+- Matches are constrained to the parent season date range.
+- Explorer records must survive after the season ends so future rollups or optional mini-campaigns can aggregate them.
 
 ### 5.3 Segment source model
 
 Admins should be able to configure destinations by pasting Strava segment URLs, following the same mental model as the regular admin panel. The system should extract the segment ID from the URL, validate it, and store the parsed segment ID plus the original source URL when available. If the segment is already known in the app's segment table, that data can be reused. If not, Explorer should still accept it and cache enough display metadata for a stable UI.
+
+Explorer uses a hybrid destination metadata strategy for v1. The preferred policy is database-first reuse of the shared `segment` table, plus Explorer-local cached display metadata and source URL values for stable rendering and setup. Segment metadata should be treated as comparatively durable. Optional short-lived in-memory caching can be used for segment metadata during setup workflows, but that should not be generalized to activity details or segment efforts.
+
+### 5.4 V1 decision lock
+
+- Primary product model: season-attached Explorer campaign
+- Summary model: computed on read
+- Destination metadata strategy: hybrid shared-segment reuse plus Explorer-local cached display metadata
+- Optional mini-campaigns within a season: deferred
+- Explicit Explorer publish-status workflow: deferred unless later implementation proves it is needed
 
 ## 6. Core Services
 
@@ -154,8 +189,8 @@ Admins should be able to configure destinations by pasting Strava segment URLs, 
 Responsibilities:
 
 - Receive normalized activity data plus athlete context.
-- Determine which Explorer weeks are active for the activity timestamp.
-- For each relevant Explorer week, compare activity segment efforts to configured Explorer destination segment IDs.
+- Determine which Explorer campaign is active for the activity timestamp by looking at the parent season.
+- Compare activity segment efforts to configured Explorer destination segment IDs for that campaign.
 - Create missing ExplorerDestinationMatch records idempotently.
 - Return summary information about newly matched destinations.
 
@@ -165,17 +200,17 @@ This service is the core reusable unit for both webhook-driven ingestion and exp
 
 Responsibilities:
 
-- Get active Explorer week for UI.
-- Get destination list for a given Explorer week.
-- Get current athlete progress for that week.
-- Get completers summary for that week, including all completer names.
+- Get active Explorer campaign for UI.
+- Get destination list for a given campaign.
+- Get current athlete progress for that campaign.
+- Get completers summary for that campaign, including all completer names.
 - Leave athlete profile aggregation out of the first implementation slice.
 
 ### 6.3 Explorer admin service
 
 Responsibilities:
 
-- Create and update Explorer weeks.
+- Create and update Explorer campaigns for a season.
 - Add, edit, remove, and reorder Explorer destinations.
 - Validate or enrich destination metadata from Strava where possible.
 - Trigger refresh or backfill actions.
@@ -184,16 +219,16 @@ Responsibilities:
 
 Recommended new tRPC surface areas:
 
-- explorer.getActiveWeek
-- explorer.getWeekProgress
-- explorer.getWeekCompleters
-- explorerAdmin.createWeek
-- explorerAdmin.updateWeek
+- explorer.getActiveCampaign
+- explorer.getCampaignProgress
+- explorer.getCampaignCompleters
+- explorerAdmin.createCampaign
+- explorerAdmin.updateCampaign
 - explorerAdmin.addDestination
 - explorerAdmin.updateDestination
 - explorerAdmin.removeDestination
 - explorerAdmin.reorderDestinations
-- explorerAdmin.refreshWeek
+- explorerAdmin.refreshCampaign
 - explorerAdmin.refreshAthlete
 
 These names are illustrative. Final naming should fit existing router conventions.
@@ -205,7 +240,7 @@ These names are illustrative. Final naming should fit existing router convention
 Recommended user-facing sections:
 
 - Challenges hub route
-- Active Explorer week header
+- Active Explorer season campaign header
 - Progress bar
 - Destination checklist
 - Completers summary
@@ -214,18 +249,18 @@ Recommended user-facing sections:
 
 Recommended initial admin capabilities:
 
-- Create Explorer week with date range
+- Attach Explorer campaign to a season
 - Add one destination at a time by pasting a Strava segment URL and parsing the segment ID
 - Edit destination display label and ordering
-- Prevent activation until at least one destination exists
-- Run refresh for a week or athlete
+- Allow adding destinations before or during the season
+- Run refresh for a campaign or athlete
 
 ## 9. Matching Rules
 
 ### V1 rules
 
-- A destination is a Strava segment configured on an Explorer week.
-- A destination counts when the athlete has a qualifying activity containing that segment during the Explorer week.
+- A destination is a Strava segment configured on an Explorer campaign attached to a season.
+- A destination counts when the athlete has a qualifying activity containing that segment during the parent season window.
 - Each destination is worth one point internally.
 - The athlete's visible progress is completed destinations divided by total destinations.
 - Repeated visits do not add progress beyond the first match.
@@ -236,6 +271,7 @@ Recommended initial admin capabilities:
 - Whether to display segment source labels like virtual or outdoor in the checklist
 - Whether a deleted activity should remove an Explorer match if it was the only source of completion
 - Whether to compute historical rollups on read or cache them incrementally
+- Whether optional mini-campaigns should later exist as freestanding season-attached sub-campaigns
 
 ## 10. Testing Strategy
 
@@ -243,9 +279,9 @@ Recommended initial admin capabilities:
 
 Add tests for:
 
-- Explorer week boundary handling
+- Explorer campaign boundary handling using the parent season dates
 - Destination match idempotency
-- Duplicate segment visits in one week
+- Duplicate segment visits in one season campaign
 - Multiple destinations in one activity
 - Virtual and outdoor segment parity
 - Strava URL parsing and validation
@@ -258,33 +294,34 @@ Add tests for:
 Add tests for:
 
 - Challenges hub navigation
-- Active Explorer week rendering
+- Active Explorer campaign rendering
 - Progress bar state
 - Checklist completion state
 - Completers summary rendering
-- Empty states for no active week or no progress yet
+- Empty states for no active campaign or no progress yet
 
 ### End-to-end
 
 Recommended E2E journeys:
 
-- Admin creates Explorer week and destinations
-- Explorer week cannot activate until at least one destination exists
-- Athlete views active Explorer week
+- Admin creates Explorer campaign for a season and destinations
+- Athlete views active Explorer campaign
 - Athlete completes one destination and sees progress update
-- Athlete completes full weekly set and sees completion state
+- Admin adds a new destination during the season and the checklist updates without resetting prior completions
+- Athlete completes full season set and sees completion state
 - Completers summary reflects at least one full completer
 
 ## 11. Migration and Rollout Sequence
 
 1. Refactor webhook processor toward delegated handlers without changing current competition behavior.
-2. Add Explorer schema and backend services.
-3. Implement Explorer matching handler and shared refresh path.
-4. Add Explorer tRPC routes.
-5. Add admin Explorer setup UI.
-6. Add Challenges hub UI with progress bar, checklist, and completers summary.
-7. Run regression checks on race and admin flows.
-8. If the slice is user-facing and ready to commit, update `VERSION` and `CHANGELOG.md` in the final pre-commit pass with a high-level summary.
+2. Correct the planning model to a season-attached Explorer campaign.
+3. Add Explorer schema and backend services for the campaign model.
+4. Implement Explorer matching handler and shared refresh path.
+5. Add Explorer tRPC routes.
+6. Add admin Explorer setup UI.
+7. Add Challenges hub UI with progress bar, checklist, and completers summary.
+8. Run regression checks on race and admin flows.
+9. If the slice is user-facing and ready to commit, update `VERSION` and `CHANGELOG.md` in the final pre-commit pass with a high-level summary.
 
 ## 12. Risks and Mitigations
 
@@ -295,18 +332,21 @@ Recommended E2E journeys:
   Mitigation: mirror the existing admin-panel parsing approach and test it directly.
 
 - Risk: Explorer begins to inherit competition UX by accident.
-  Mitigation: avoid ranked lists in the primary weekly surface.
+  Mitigation: avoid ranked lists in the primary season surface.
+
+- Risk: the MVP is overcomplicated by adding mini-campaigns or explicit status workflows too early.
+  Mitigation: keep the first model season-first, attach it to the existing season, and defer mini-campaigns plus explicit publish states until they solve a real problem.
 
 - Risk: Webhook processor becomes more complex during transition.
   Mitigation: refactor to delegated handlers before layering in Explorer logic.
 
 ## 13. Suggested Handoff Notes
 
-If this moves to implementation, the first engineering slice should be the delegated ingestion refactor plus Explorer schema design. That is the structural work that determines whether the rest of the feature can be added cleanly.
+If this moves to implementation after the planning correction, the first engineering slice should be the season-attached Explorer campaign schema plus matching and query corrections. That is the structural work that determines whether the rest of the feature can be added cleanly.
 
 The next slice should be the smallest end-to-end Explorer loop:
 
-- one Explorer week
+- one Explorer campaign attached to a season
 - one or more destinations
 - one athlete progress query
 - one completers summary query

--- a/docs/prds/wmv-explorer-readiness-checklist.md
+++ b/docs/prds/wmv-explorer-readiness-checklist.md
@@ -17,21 +17,21 @@ The ideas backlog is intentionally excluded from v1 implementation scope. It exi
 
 ## Current Go Decision
 
-**Status:** Phase 1 Complete; Ready For New Phase 2 Preparation PR
+**Status:** Phase 1 Complete; Season-Campaign Correction Landed; Ready For Narrow Corrected Implementation Slice
 
-Explorer has completed the narrow Phase 1 webhook-orchestration slice that preserves current competition behavior while introducing delegated in-process handlers. It is ready for a new, separate PR to start Phase 2 preparation work, but it is not yet ready for broad Phase 2+ implementation. The remaining gaps are technical-closure gaps, not product-intent gaps.
+Explorer has completed the narrow Phase 1 webhook-orchestration slice that preserves current competition behavior while introducing delegated in-process handlers. The planning set on this branch now corrects the MVP to a season-campaign-first model attached to an existing WMV season, with optional mini-campaigns and explicit publish-status workflows deferred. Explorer is ready for one bounded implementation PR that corrects the backend model from the earlier weekly-first shape.
 
 ## Current Status Summary
 
 | Area | Status | Notes |
 | --- | --- | --- |
 | Product framing | Ready | The PRD is clear on goals, users, must-haves, non-goals, and success criteria. |
-| Execution phasing | Ready | The phases doc already breaks work into a useful order. |
-| Architecture closure | Partial | The overall direction is clear, but several design decisions still need to be finalized. |
-| Open questions handling | Partial | Open questions exist, but they are not yet centralized in one review surface. |
-| Blocking research closure | Partial | Some validation work is still needed before safe implementation. |
-| Test planning | Partial | The spec outlines what to test, but the exact organization and execution strategy should be made explicit. |
-| Documentation impact plan | Partial | The likely doc surfaces are known, but the required updates are not yet tracked in one place. |
+| Execution phasing | Ready For Narrow Corrected Slice | The phases doc now treats season campaigns as the MVP model and defers mini-campaigns. |
+| Architecture closure | Ready For Narrow Corrected Slice | The technical spec now models a season-attached campaign and removes explicit status complexity from MVP. |
+| Open questions handling | Ready | The worklog now records the corrected model plus the remaining non-blocking questions. |
+| Blocking research closure | Ready For Narrow Corrected Slice | The product-intent correction is closed for this branch. |
+| Test planning | Ready For Narrow Corrected Slice | Test planning is now framed against campaign boundaries rather than week boundaries. |
+| Documentation impact plan | Partial | The likely doc surfaces are known, but the planning correction needs to land first. |
 
 ## Must Resolve Before Broad Implementation
 
@@ -50,32 +50,32 @@ Explorer has completed the narrow Phase 1 webhook-orchestration slice that prese
 
 | Field | Value |
 | --- | --- |
-| Status | Partial |
+| Status | Ready |
 | Gate | Must Resolve |
-| Why it matters | The tech spec leaves the `ExplorerAthleteWeekSummary` decision open for v1. Engineering should not start building around two competing models. |
-| Evidence | The current spec says the summary can remain computed on read if query cost is modest, but no v1 decision is locked yet. |
+| Why it matters | Engineering should not start building around two competing summary models. |
+| Evidence | The corrected technical spec now explicitly chooses computed on read for `ExplorerAthleteCampaignSummary`, with `ExplorerDestinationMatch` as the durable source of truth. |
 | Acceptance criteria | The tech spec explicitly chooses one v1 approach: computed on read or cached summary. It also states the reason for that choice and what is deferred. |
-| Next action | Add a design decision note to the technical spec and record the outcome in the worklog. |
+| Next action | Carry the locked decision into the corrected implementation brief and tests. |
 
 ### 3. Explorer Destination Metadata Strategy
 
 | Field | Value |
 | --- | --- |
-| Status | Partial |
+| Status | Ready |
 | Gate | Must Resolve |
 | Why it matters | Explorer destination setup depends on how segment data is validated, stored, and displayed over time. |
 | Evidence | The current UI already has real segment URL parsing and validation patterns in [src/components/SegmentInput.tsx](../../src/components/SegmentInput.tsx) and [src/components/ManageSegments.tsx](../../src/components/ManageSegments.tsx), but the Explorer spec still leaves room for multiple storage strategies. |
 | Acceptance criteria | The tech spec explicitly states whether Explorer reuses the existing segment table, stores Explorer-local cached metadata, or uses both with clear responsibilities for each. |
-| Next action | Finalize the storage and enrichment rules in the technical spec before Explorer schema work starts. |
+| Next action | Carry the locked storage responsibilities and DB-first segment reuse policy into the corrected implementation slice. |
 
 ### 4. Centralized Open Questions
 
 | Field | Value |
 | --- | --- |
-| Status | Missing |
+| Status | Ready |
 | Gate | Must Resolve |
 | Why it matters | Scattered uncertainty forces implementation chats to rediscover unresolved design choices. |
-| Evidence | Open items currently appear in narrative form across the technical spec rather than in one explicit decision list. |
+| Evidence | The worklog open-questions table now reflects the corrected campaign model and remaining non-blocking questions. |
 | Acceptance criteria | One section in the worklog or readiness checklist lists all unresolved questions, their current status, and whether they block implementation. |
 | Next action | Seed the worklog with a dedicated open-questions section and keep it current. |
 
@@ -85,10 +85,10 @@ Explorer has completed the narrow Phase 1 webhook-orchestration slice that prese
 | --- | --- |
 | Status | Ready |
 | Gate | Must Resolve |
-| Why it matters | The team needs a shared rule for what can proceed now versus what must wait for additional closure. |
-| Evidence | The phases doc, worklog, and implemented handler seam now all point to the same narrow boundary: structural webhook refactor only. |
-| Acceptance criteria | The readiness artifacts clearly state that Explorer is ready for the approved Phase 1 slice only, and they identify which unresolved items still block Phase 2+. |
-| Next action | Keep the current go decision updated as new slices are approved. |
+| Why it matters | The team needs a shared rule for what can proceed now versus what must wait for the season-model correction. |
+| Evidence | The implemented webhook seam remains valid, and the next slice is now re-approved against the corrected season campaign model. |
+| Acceptance criteria | The readiness artifacts clearly state that Explorer is ready for one narrow corrected implementation slice and identify what remains out of scope. |
+| Next action | Keep the current go decision updated as additional corrected Explorer slices are approved or deferred. |
 
 ## Should Resolve Before Phase 2 Starts
 
@@ -96,12 +96,12 @@ Explorer has completed the narrow Phase 1 webhook-orchestration slice that prese
 
 | Field | Value |
 | --- | --- |
-| Status | Partial |
+| Status | Ready For Narrow Corrected Slice |
 | Gate | Should Resolve |
 | Why it matters | The repo already has a strong backend test pattern. Explorer should fit it rather than improvise. |
 | Evidence | Existing tests under `server/src/__tests__` use the in-memory [setupTestDb](../../server/src/__tests__/setupTestDb.ts) pattern and helper utilities. |
-| Acceptance criteria | The implementation plan names where Explorer service, router, and integration tests will live and states that they will use the existing in-memory SQLite setup unless a stronger reason appears. |
-| Next action | Record the intended test layout in the worklog before Phase 2 begins. |
+| Acceptance criteria | The implementation plan names where Explorer service, router, and integration tests will live and states that they will use the existing in-memory SQLite setup against campaign boundaries unless a stronger reason appears. |
+| Next action | Use the existing in-memory backend test pattern for corrected campaign service and router coverage. |
 
 ### 2. E2E Data Strategy
 
@@ -112,13 +112,13 @@ Explorer has completed the narrow Phase 1 webhook-orchestration slice that prese
 | Why it matters | Explorer UI and admin flows will need end-to-end coverage, and the repository already enforces a separate E2E database model. |
 | Evidence | [AGENTS.md](../../AGENTS.md) defines `wmv_e2e.db` as the dedicated E2E environment and warns against mixing databases. |
 | Acceptance criteria | The implementation plan explains how Explorer E2E scenarios will be created and validated without relying on accidental shared state. |
-| Next action | Decide whether Explorer test data will be created during test setup or introduced through intentional E2E fixtures. |
+| Next action | Provision Explorer campaign E2E data intentionally during setup or controlled fixtures. |
 
 ### 3. Documentation Impact Plan
 
 | Field | Value |
 | --- | --- |
-| Status | Partial |
+| Status | Ready For Narrow Corrected Slice |
 | Gate | Should Resolve |
 | Why it matters | Explorer touches admin, athlete, API, database, and release-note surfaces. That work should be visible before coding. |
 | Evidence | Likely doc surfaces already exist in `ADMIN_GUIDE.md`, `docs/API.md`, `docs/DATABASE_DESIGN.md`, `docs-site/`, `CHANGELOG.md`, and `VERSION`, but the release-note files should wait for the final pre-commit pass of a user-facing slice. |
@@ -134,7 +134,7 @@ Explorer has completed the narrow Phase 1 webhook-orchestration slice that prese
 | Why it matters | Explorer should not start with a multi-surface implementation burst. |
 | Evidence | The worklog now records the completed Phase 1 webhook-orchestrator slice, including validation expectations and explicit out-of-scope items. |
 | Acceptance criteria | One narrow slice was named, bounded, tied to Phase 1, and validated through the focused webhook regression tests. |
-| Next action | Keep later slices equally narrow and tie the next PR to Phase 2 preparation instead of reopening Phase 1. |
+| Next action | Keep later slices equally narrow and tie the next PR to the corrected campaign model instead of proceeding with the weekly-first plan. |
 
 ## Safe To Defer If Recorded Explicitly
 
@@ -142,7 +142,7 @@ Explorer has completed the narrow Phase 1 webhook-orchestration slice that prese
 | --- | --- | --- | --- |
 | Virtual versus outdoor labels in the checklist | Deferred | Safe To Defer | Not required for v1 matching correctness. |
 | Match retraction when a source activity is deleted | Partial | Safe To Defer | Can remain an explicit unresolved rule if v1 behavior is documented. |
-| Season-wide rollup caching strategy | Deferred | Safe To Defer | Weekly history durability matters first. |
+| Season-wide rollup caching strategy | Deferred | Safe To Defer | Campaign history durability matters first. |
 | Post-MVP ideas from the ideas backlog | Deferred | Safe To Defer | Keep them isolated in the ideas file. |
 
 ## Execution Preconditions For The Next Slice
@@ -160,7 +160,8 @@ Before any Explorer implementation slice starts, it should explicitly reference:
 | Decision | Current State |
 | --- | --- |
 | Phase 1 Complete | Yes |
-| Ready For New Phase 2 Preparation PR | Yes |
+| Season-Campaign Correction Landed | Yes |
+| Ready For Narrow Corrected Implementation Slice | Yes |
 | Ready For Broad Feature Implementation | No |
 
-If this file says anything stronger than **Phase 1 Complete; Ready For New Phase 2 Preparation PR**, the linked worklog should show exactly what changed to justify that shift.
+If this file says anything stronger than **Phase 1 Complete; Season-Campaign Correction Landed; Ready For Narrow Corrected Implementation Slice**, the linked worklog should show exactly what changed to justify that shift.

--- a/docs/prds/wmv-explorer-worklog.md
+++ b/docs/prds/wmv-explorer-worklog.md
@@ -4,15 +4,15 @@ This worklog is the active operating log for Explorer. The readiness checklist i
 
 ## Current Focus
 
-- Close Phase 1 cleanly and keep the branch ready for a dedicated PR.
-- Mark the webhook seam complete without quietly expanding into Phase 2 work.
-- Prepare the next Explorer PR to focus on Phase 2 preparation decisions.
+- Correct the planning set from a weekly-first Explorer model to a season-campaign-first MVP.
+- Remove optional mini-campaign and status-workflow complexity from MVP planning.
+- Produce the smallest safe implementation slice against the corrected season campaign model.
 
 ## Current Go State
 
-- **Readiness:** Phase 1 Complete; Ready For New Phase 2 Preparation PR
-- **Immediate scope:** close this branch as the Phase 1 PR and begin the next branch with Phase 2 preparation decisions only
-- **Not yet in scope:** broad Phase 2 schema or UI implementation until the remaining design blockers are closed
+- **Readiness:** Phase 1 Complete; Season-Campaign Correction Landed; Ready For Narrow Corrected Implementation Slice
+- **Immediate scope:** one bounded implementation PR correcting the Explorer data model and matching/query paths to a season-attached campaign
+- **Not yet in scope:** mini-campaigns, explicit publish-status workflows, full admin UI, or full athlete hub UI
 
 ## Decisions Made
 
@@ -24,13 +24,21 @@ This worklog is the active operating log for Explorer. The readiness checklist i
 - GitHub issues remain secondary for now; local planning docs stay primary until slices are stable enough to externalize cleanly.
 - Phase 1 is approved only as a structural webhook slice: preserve current behavior first, add Explorer matching later.
 - Phase 1 is complete on this branch: the shared activity-ingestion context, sequential delegated handlers, explicit handler order, and preservation tests are in place.
+- The previous Explorer planning set and PR #23 used the wrong primary model: weekly Explorer challenges first, with season-wide support deferred.
+- MVP should instead be season-campaign-first, attached to an existing WMV season, with optional mini-campaigns deferred.
+- MVP does not currently justify explicit Explorer `draft` / `active` / `archived` workflow complexity; season dates and destination presence should control visibility unless later implementation proves otherwise.
+- V1 athlete campaign summary is computed on read, with `ExplorerDestinationMatch` as the durable source of truth.
+- V1 destination metadata uses a hybrid strategy: reuse shared segment data when present, while storing Explorer-local cached display metadata and source URL values for stable setup and rendering.
 
 ## Open Questions
 
 | Question | Status | Blocks Implementation | Notes |
 | --- | --- | --- | --- |
-| Should athlete week summaries be computed on read or stored in a cached summary table for v1? | Open | Yes | Tech spec currently leaves this as conditional. |
-| Should Explorer reuse the existing segment table, store Explorer-local cached metadata, or do both? | Open | Yes | Existing UI parsing is proven, but final storage rules are not. |
+| Should Explorer be season-campaign-first or weekly-first in MVP? | Closed | Yes | Closed in favor of season-campaign-first attached to the existing season model. |
+| Should optional mini-campaigns within a season remain in MVP? | Closed | Yes | Closed in favor of removing them from MVP and deferring them to later planning. |
+| Does MVP need an explicit Explorer status workflow such as `draft` or `archived`? | Closed For MVP | Yes | Closed in favor of no explicit status field unless later implementation proves it is needed. |
+| Should athlete campaign summaries be computed on read or stored in a cached summary table for v1? | Closed For v1 | No | V1 uses computed-on-read summaries with `ExplorerDestinationMatch` as the durable source of truth. |
+| Should Explorer reuse the existing segment table, store Explorer-local cached metadata, or do both? | Closed For v1 | No | V1 uses a hybrid strategy: shared segment reuse when present plus Explorer-local cached display metadata. |
 | How should webhook regression protection be documented for the delegated-handler refactor? | Closed For Phase 1 | No | The preservation target now lives in this worklog and the handler seam is covered by focused webhook tests. |
 | What is the exact E2E data strategy for Explorer flows? | Open | No | Should be defined before Phase 2 starts. |
 | Should deleted source activities retract Explorer completions in v1? | Open | No | Safe to defer if behavior is documented. |
@@ -39,15 +47,19 @@ This worklog is the active operating log for Explorer. The readiness checklist i
 
 ### Must Resolve Before Broad Implementation
 
-1. Decide the v1 summary model.
-2. Decide the v1 destination metadata strategy.
-3. Keep unresolved questions centralized rather than scattered across planning docs.
+1. Correct the primary Explorer model to season-campaign-first across the planning set.
+2. Re-scope MVP so optional mini-campaigns are explicitly deferred.
+3. Re-approve the next implementation slice against the corrected model before more Explorer coding continues.
+
+Resolution:
+
+- These planning blockers are now closed on this branch.
 
 ### Should Resolve Before Phase 2
 
-1. Name Explorer backend test locations and test shape.
-2. Define the E2E data approach.
-3. List documentation surfaces expected to change when Explorer slices land.
+1. Resolved for the next slice: Explorer backend tests should live under `server/src/__tests__` and use the existing in-memory SQLite pattern.
+2. Resolved for the next slice: Explorer E2E scenarios should provision their own campaign data intentionally.
+3. Resolved for the next slice: Planning and implementation docs touched by the corrected slice should be listed explicitly before coding starts.
 
 ## Ready-Next Slices
 
@@ -95,29 +107,32 @@ The current preservation target is backed by:
 3. [server/src/__tests__/webhookProcessor.segmentEffortsRetry.test.ts](../../server/src/__tests__/webhookProcessor.segmentEffortsRetry.test.ts)
 4. [server/src/__tests__/webhookAdminRouter.replayEvent.test.ts](../../server/src/__tests__/webhookAdminRouter.replayEvent.test.ts)
 
-### Slice Candidate B: Summary Model Decision
+### Planning Correction: Season Campaign Model
 
-- Phase: Phase 2 preparation
-- Goal: choose computed-on-read versus cached-summary for v1 and update the technical spec accordingly
-- Why this matters: it stabilizes query-service design and schema decisions
-
-### Slice Candidate C: Destination Metadata Strategy
-
-- Phase: Phase 2 preparation
-- Goal: define how Explorer destination setup reuses segment validation and metadata from the current admin flow
-- Why this matters: it stabilizes admin-service and schema direction
+- Phase: Phase 2
+- Goal: change the source-of-truth planning set so Explorer is a season-attached campaign, not a weekly-first challenge model
+- Why this matters: the current implementation branch and planning docs were shaped around the wrong primary concept
 
 ### Recommended Next PR
 
-- Start a fresh Phase 2 preparation branch from updated `main` after this Phase 1 branch lands.
-- Keep the next PR focused on the athlete summary model, destination metadata strategy, test layout, and E2E data approach.
-- Do not mix those decisions with schema or UI implementation unless the blockers are explicitly closed in the same PR.
+- Start from updated `main` on a dedicated implementation branch only after this planning correction lands.
+- Keep the next implementation PR scoped to the corrected campaign model only:
+	- campaign schema attached to `season`
+	- destination and match schema keyed to the campaign
+	- matching service correction from week windows to season windows
+	- corrected query routes for active campaign and athlete progress
+	- backend tests for campaign boundaries, idempotency, and add-destination behavior
+- Keep out of scope for that PR:
+	- mini-campaigns inside a season
+	- explicit Explorer publish-status workflows
+	- full admin UI
+	- full athlete hub UI
 
 ## Issue Candidates
 
-- Decide and document Explorer athlete week summary strategy
-- Decide and document Explorer destination metadata strategy
-- Define Explorer test layout and E2E data plan
+- Correct Explorer planning set to season-campaign-first MVP
+- Implement corrected Explorer campaign schema and matching service
+- Re-scope Explorer admin and hub work to the corrected campaign model
 
 ## Documentation Impact Checklist
 


### PR DESCRIPTION
## Summary
- correct the Explorer planning set from a weekly-first model to a season-attached campaign model
- defer mini-campaigns and explicit Explorer status workflows from MVP
- update readiness, phases, and worklog to approve the next narrow corrected implementation slice
- restore planner-agent self-sufficiency for planning branch maintenance

## Why
The existing Explorer implementation PR was built around the wrong primary product model. This planning PR establishes the corrected source of truth before more Explorer coding continues.

## Validation
- pre-commit typecheck
- pre-commit lint