### PR TITLE
feat: add Explorer season campaign backend slice

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -1,7 +1,7 @@
 # API reference
 
 **NOTE: The project is migrating to tRPC. The REST endpoints below are legacy or specific to Auth/Webhooks.**
-**For all data fetching (Week, Season, Leaderboard, Segments, Participants, Webhook Admin), refer to the tRPC routers in `server/src/routers`.**
+**For all data fetching (Week, Season, Leaderboard, Segments, Participants, Webhook Admin, Explorer), refer to the tRPC routers in `server/src/routers`.**
 
 Base URL (dev): http://localhost:3001
 
@@ -188,6 +188,13 @@ The `webhookAdminRouter` provides procedures for monitoring and managing Strava 
 - `trpc.webhookAdmin.getStatus` — Returns current webhook subscription status and statistics.
 - `trpc.webhookAdmin.getEvents` — Returns a paginated list of recently logged webhook events.
 - `trpc.webhookAdmin.getEnrichedEventDetails` — Returns detailed metadata for a specific activity mentioned in a webhook event (uses `ActivityService` for summary and classification).
+
+## Explorer (tRPC)
+
+The `explorerRouter` provides the read paths for the season-attached Explorer campaign MVP.
+
+- `trpc.explorer.getActiveCampaign` — Returns the currently active Explorer campaign for the open season, including ordered destinations. Campaigns without destinations are hidden from the athlete-facing surface.
+- `trpc.explorer.getCampaignProgress` — Returns the authenticated athlete's completion state for a campaign, including completed destinations and the source Strava activity IDs for recorded matches.
 
 ## Error responses
 

--- a/docs/DATABASE_DESIGN.md
+++ b/docs/DATABASE_DESIGN.md
@@ -1,7 +1,7 @@
 # Database Design
 
 ## Overview
-This document describes the SQLite database schema for tracking weekly cycling competition results based on Strava activities.
+This document describes the SQLite database schema for tracking weekly cycling competition results and the season-attached Explorer campaign feature based on Strava activities.
 
 **Scale:** Designed for <100 participants. SQLite is perfect for this - simple, fast, no separate database server needed.
 
@@ -18,6 +18,9 @@ The database is managed using **Drizzle ORM**. The source of truth for the schem
 - **`activity`**: The best qualifying Strava activity for a participant in a given week.
 - **`segment_effort`**: Individual laps/efforts extracted from a qualifying activity.
 - **`result`**: Calculated rankings and times (points are computed on-read).
+- **`explorer_campaign`**: A season-attached Explorer campaign that becomes athlete-visible when its parent season is open and the campaign has at least one destination.
+- **`explorer_destination`**: Ordered campaign destinations keyed to Strava segment IDs, with Explorer-local cached display metadata.
+- **`explorer_destination_match`**: Durable per-athlete destination completions within a campaign.
 - **`participant_token`**: Encrypted OAuth tokens for Strava API access.
 - **`webhook_event`**: Log of received Strava webhook events for monitoring.
 
@@ -126,6 +129,13 @@ GROUP BY strava_athlete_id
 ORDER BY total_points DESC;
 ```
 
+### Explorer Campaign Matching
+1. A webhook or refresh path hydrates activity segment efforts.
+2. The system finds Explorer campaigns whose parent season contains the activity timestamp.
+3. Activity segment IDs are compared against configured `explorer_destination.strava_segment_id` values.
+4. Each matching destination inserts at most one `explorer_destination_match` row per athlete per campaign.
+5. Explorer progress is computed on read from `explorer_destination_match` rather than a cached summary table in v1.
+
 ## Migration from Current Schema
 
 ### Current (v1.0)
@@ -152,6 +162,9 @@ CREATE INDEX idx_activity_week_participant ON activities(week_id, strava_athlete
 CREATE INDEX idx_segment_effort_activity ON segment_efforts(activity_id);
 CREATE INDEX idx_result_week ON results(week_id);
 CREATE INDEX idx_result_participant ON results(strava_athlete_id);
+CREATE INDEX idx_explorer_campaign_season ON explorer_campaign(season_id);
+CREATE INDEX idx_explorer_destination_campaign ON explorer_destination(explorer_campaign_id);
+CREATE INDEX idx_explorer_match_campaign_athlete ON explorer_destination_match(explorer_campaign_id, strava_athlete_id);
 ```
 
 ## Example Queries

--- a/docs/prds/wmv-explorer-destinations-tech-spec.md
+++ b/docs/prds/wmv-explorer-destinations-tech-spec.md
@@ -134,7 +134,7 @@ MVP rule: an ExplorerCampaign is attached to one season. The campaign becomes at
   - explorerCampaignId
   - stravaSegmentId
   - sourceUrl nullable
-  - cachedSegmentName
+  - cachedName
   - displayLabel nullable
   - displayOrder
   - surfaceType nullable such as virtual or outdoor

--- a/server/drizzle/0009_explorer_campaign_slice_a.sql
+++ b/server/drizzle/0009_explorer_campaign_slice_a.sql
@@ -15,7 +15,7 @@ CREATE TABLE `explorer_destination` (
 	`explorer_campaign_id` integer NOT NULL,
 	`strava_segment_id` text NOT NULL,
 	`source_url` text,
-	`cached_segment_name` text,
+	`cached_name` text,
 	`display_label` text,
 	`display_order` integer DEFAULT 0 NOT NULL,
 	`surface_type` text,

--- a/server/drizzle/0009_explorer_campaign_slice_a.sql
+++ b/server/drizzle/0009_explorer_campaign_slice_a.sql
@@ -1,0 +1,49 @@
+CREATE TABLE `explorer_campaign` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`season_id` integer NOT NULL,
+	`display_name` text,
+	`rules_blurb` text,
+	`created_at` text DEFAULT (CURRENT_TIMESTAMP),
+	`updated_at` text DEFAULT (CURRENT_TIMESTAMP),
+	FOREIGN KEY (`season_id`) REFERENCES `season`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `idx_explorer_campaign_season` ON `explorer_campaign` (`season_id`);
+--> statement-breakpoint
+CREATE TABLE `explorer_destination` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`explorer_campaign_id` integer NOT NULL,
+	`strava_segment_id` text NOT NULL,
+	`source_url` text,
+	`cached_segment_name` text,
+	`display_label` text,
+	`display_order` integer DEFAULT 0 NOT NULL,
+	`surface_type` text,
+	`category` text,
+	`created_at` text DEFAULT (CURRENT_TIMESTAMP),
+	`updated_at` text DEFAULT (CURRENT_TIMESTAMP),
+	FOREIGN KEY (`explorer_campaign_id`) REFERENCES `explorer_campaign`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `idx_explorer_destination_campaign` ON `explorer_destination` (`explorer_campaign_id`);
+--> statement-breakpoint
+CREATE INDEX `idx_explorer_destination_segment` ON `explorer_destination` (`strava_segment_id`);
+--> statement-breakpoint
+CREATE TABLE `explorer_destination_match` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`explorer_campaign_id` integer NOT NULL,
+	`explorer_destination_id` integer NOT NULL,
+	`strava_athlete_id` text NOT NULL,
+	`strava_activity_id` text NOT NULL,
+	`matched_at` integer NOT NULL,
+	`created_at` text DEFAULT (CURRENT_TIMESTAMP),
+	FOREIGN KEY (`explorer_campaign_id`) REFERENCES `explorer_campaign`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`explorer_destination_id`) REFERENCES `explorer_destination`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`strava_athlete_id`) REFERENCES `participant`(`strava_athlete_id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `idx_explorer_match_campaign_athlete` ON `explorer_destination_match` (`explorer_campaign_id`,`strava_athlete_id`);
+--> statement-breakpoint
+CREATE INDEX `idx_explorer_match_activity` ON `explorer_destination_match` (`strava_activity_id`);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `idx_explorer_match_unique` ON `explorer_destination_match` (`explorer_campaign_id`,`explorer_destination_id`,`strava_athlete_id`);

--- a/server/drizzle/meta/_journal.json
+++ b/server/drizzle/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1774190400000,
       "tag": "0008_drop_season_is_active",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "6",
+      "when": 1776000000000,
+      "tag": "0009_explorer_campaign_slice_a",
+      "breakpoints": true
     }
   ]
 }

--- a/server/src/__tests__/ExplorerMatchingService.test.ts
+++ b/server/src/__tests__/ExplorerMatchingService.test.ts
@@ -52,7 +52,7 @@ describe('ExplorerMatchingService', () => {
     const destination = createExplorerDestination(drizzleDb, {
       explorerCampaignId: campaign.id,
       stravaSegmentId: 'seg-100',
-      cachedSegmentName: 'Summit Road',
+      cachedName: 'Summit Road',
     });
 
     const service = new ExplorerMatchingService(drizzleDb);

--- a/server/src/__tests__/ExplorerMatchingService.test.ts
+++ b/server/src/__tests__/ExplorerMatchingService.test.ts
@@ -1,0 +1,213 @@
+import { Database } from 'better-sqlite3';
+import { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+import { eq } from 'drizzle-orm';
+import {
+  clearAllData,
+  createExplorerCampaign,
+  createExplorerDestination,
+  createParticipant,
+  createSeason,
+  setupTestDb,
+  teardownTestDb,
+} from './testDataHelpers';
+import { explorerDestinationMatch } from '../db/schema';
+import { ExplorerMatchingService } from '../services/ExplorerMatchingService';
+import * as stravaClient from '../stravaClient';
+
+jest.mock('../stravaClient', () => ({
+  listAthleteActivities: jest.fn(),
+  getActivity: jest.fn(),
+}));
+
+describe('ExplorerMatchingService', () => {
+  let db: Database;
+  let drizzleDb: BetterSQLite3Database;
+
+  beforeAll(() => {
+    const testDb = setupTestDb();
+    db = testDb.db;
+    drizzleDb = testDb.drizzleDb;
+  });
+
+  afterAll(() => {
+    teardownTestDb(db);
+  });
+
+  beforeEach(() => {
+    clearAllData(drizzleDb);
+    jest.clearAllMocks();
+  });
+
+  it('records one match per destination even when a ride repeats the same segment', async () => {
+    createParticipant(drizzleDb, '2001', 'Explorer Rider');
+    const seasonRecord = createSeason(drizzleDb, 'Explorer Season', true, {
+      startAt: 1748736000,
+      endAt: 1751327999,
+    });
+    const campaign = createExplorerCampaign(drizzleDb, {
+      seasonId: seasonRecord.id,
+      displayName: 'Summer Explorer',
+    });
+
+    const destination = createExplorerDestination(drizzleDb, {
+      explorerCampaignId: campaign.id,
+      stravaSegmentId: 'seg-100',
+      cachedSegmentName: 'Summit Road',
+    });
+
+    const service = new ExplorerMatchingService(drizzleDb);
+    const result = await service.matchActivity(
+      {
+        id: 'activity-1',
+        name: 'Big Climb',
+        start_date: '2025-06-03T10:00:00Z',
+        segment_efforts: [
+          {
+            id: 'effort-1',
+            elapsed_time: 300,
+            start_date: '2025-06-03T10:05:00Z',
+            segment: { id: 'seg-100' },
+          },
+          {
+            id: 'effort-2',
+            elapsed_time: 320,
+            start_date: '2025-06-03T10:12:00Z',
+            segment: { id: 'seg-100' },
+          },
+        ],
+      },
+      '2001'
+    );
+
+    expect(result.processedCampaigns).toBe(1);
+    expect(result.matchedDestinations).toBe(1);
+    expect(result.newMatches).toBe(1);
+
+    const matches = drizzleDb
+      .select()
+      .from(explorerDestinationMatch)
+      .where(eq(explorerDestinationMatch.explorer_destination_id, destination.id))
+      .all();
+
+    expect(matches).toHaveLength(1);
+    expect(matches[0]?.strava_activity_id).toBe('activity-1');
+  });
+
+  it('is idempotent when the same activity is processed more than once', async () => {
+    createParticipant(drizzleDb, '2002', 'Repeat Rider');
+    const seasonRecord = createSeason(drizzleDb, 'Explorer Season', true, {
+      startAt: 1748736000,
+      endAt: 1751327999,
+    });
+    const campaign = createExplorerCampaign(drizzleDb, {
+      seasonId: seasonRecord.id,
+    });
+
+    createExplorerDestination(drizzleDb, {
+      explorerCampaignId: campaign.id,
+      stravaSegmentId: 'seg-200',
+    });
+
+    const service = new ExplorerMatchingService(drizzleDb);
+    const activity = {
+      id: 'activity-2',
+      name: 'Evening Ride',
+      start_date: '2025-06-04T18:30:00Z',
+      segment_efforts: [
+        {
+          id: 'effort-3',
+          elapsed_time: 220,
+          start_date: '2025-06-04T18:35:00Z',
+          segment: { id: 'seg-200' },
+        },
+      ],
+    };
+
+    const firstPass = await service.matchActivity(activity, '2002');
+    const secondPass = await service.matchActivity(activity, '2002');
+
+    expect(firstPass.newMatches).toBe(1);
+    expect(secondPass.newMatches).toBe(0);
+
+    const matches = drizzleDb.select().from(explorerDestinationMatch).all();
+    expect(matches).toHaveLength(1);
+  });
+
+  it('hydrates missing segment efforts during campaign refresh and matches newly added destinations', async () => {
+    createParticipant(drizzleDb, '2003', 'Refresh Rider');
+    const seasonRecord = createSeason(drizzleDb, 'Explorer Season', true, {
+      startAt: 1749513600,
+      endAt: 1750118399,
+    });
+    const campaign = createExplorerCampaign(drizzleDb, {
+      seasonId: seasonRecord.id,
+    });
+
+    createExplorerDestination(drizzleDb, {
+      explorerCampaignId: campaign.id,
+      stravaSegmentId: 'seg-300',
+    });
+
+    const service = new ExplorerMatchingService(drizzleDb);
+    await service.matchActivity(
+      {
+        id: 'activity-3',
+        name: 'Existing Match',
+        start_date: '2025-06-12T07:00:00Z',
+        segment_efforts: [
+          {
+            id: 'effort-4',
+            elapsed_time: 260,
+            start_date: '2025-06-12T07:05:00Z',
+            segment: { id: 'seg-300' },
+          },
+        ],
+      },
+      '2003'
+    );
+
+    createExplorerDestination(drizzleDb, {
+      explorerCampaignId: campaign.id,
+      stravaSegmentId: 'seg-301',
+    });
+
+    const listAthleteActivitiesMock = jest.mocked(stravaClient.listAthleteActivities);
+    const getActivityMock = jest.mocked(stravaClient.getActivity);
+
+    listAthleteActivitiesMock.mockResolvedValue([
+      {
+        id: 'activity-3',
+        name: 'Summary Activity',
+        start_date: '2025-06-12T07:00:00Z',
+        segment_efforts: [],
+      },
+    ]);
+
+    getActivityMock.mockResolvedValue({
+      id: 'activity-3',
+      name: 'Detailed Activity',
+      start_date: '2025-06-12T07:00:00Z',
+      segment_efforts: [
+        {
+          id: 'effort-4',
+          elapsed_time: 260,
+          start_date: '2025-06-12T07:05:00Z',
+          segment: { id: 'seg-300' },
+        },
+        {
+          id: 'effort-5',
+          elapsed_time: 295,
+          start_date: '2025-06-12T07:15:00Z',
+          segment: { id: 'seg-301' },
+        },
+      ],
+    });
+
+    const result = await service.refreshAthleteCampaign(campaign.id, '2003', 'test-token');
+
+    expect(result.activitiesProcessed).toBe(1);
+    expect(result.activitiesMatched).toBe(1);
+    expect(result.newMatches).toBe(1);
+    expect(getActivityMock).toHaveBeenCalledWith('activity-3', 'test-token');
+  });
+});

--- a/server/src/__tests__/explorerActivityHandler.test.ts
+++ b/server/src/__tests__/explorerActivityHandler.test.ts
@@ -1,0 +1,99 @@
+import { Database } from 'better-sqlite3';
+import { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+import {
+  clearAllData,
+  createExplorerCampaign,
+  createExplorerDestination,
+  createParticipant,
+  createSeason,
+  setupTestDb,
+  teardownTestDb,
+} from './testDataHelpers';
+import { explorerDestinationMatch } from '../db/schema';
+import { createDefaultActivityHandlers } from '../webhooks/activityHandlers';
+import { createExplorerActivityHandler } from '../webhooks/handlers/explorerActivityHandler';
+
+describe('explorerActivityHandler', () => {
+  let db: Database;
+  let drizzleDb: BetterSQLite3Database;
+
+  beforeAll(() => {
+    const testDb = setupTestDb();
+    db = testDb.db;
+    drizzleDb = testDb.drizzleDb;
+  });
+
+  afterAll(() => {
+    teardownTestDb(db);
+  });
+
+  beforeEach(() => {
+    clearAllData(drizzleDb);
+  });
+
+  it('is included in the default handler pipeline', () => {
+    const handlerNames = createDefaultActivityHandlers().map((handler) => handler.name);
+    expect(handlerNames).toContain('explorer');
+  });
+
+  it('records Explorer matches from webhook activity data', async () => {
+    createParticipant(drizzleDb, '4001', 'Webhook Rider');
+    const seasonRecord = createSeason(drizzleDb, 'Explorer Season', true, {
+      startAt: 1748736000,
+      endAt: 1751327999,
+    });
+    const campaign = createExplorerCampaign(drizzleDb, {
+      seasonId: seasonRecord.id,
+    });
+
+    createExplorerDestination(drizzleDb, {
+      explorerCampaignId: campaign.id,
+      stravaSegmentId: 'seg-601',
+    });
+
+    const handler = createExplorerActivityHandler();
+    await handler.handle({
+      db: drizzleDb,
+      event: {
+        aspect_type: 'create',
+        event_time: 0,
+        object_id: 601,
+        object_type: 'activity',
+        owner_id: 4001,
+        subscription_id: 1,
+      },
+      activityId: 'activity-601',
+      athleteId: '4001',
+      participantRecord: {
+        strava_athlete_id: '4001',
+        name: 'Webhook Rider',
+      },
+      accessToken: 'unused',
+      athleteWeight: null,
+      initialActivityData: {
+        id: 'activity-601',
+        name: 'Webhook Ride',
+        start_date: '2025-06-03T09:00:00Z',
+        segment_efforts: [],
+      },
+      validationService: {} as any,
+      getActivityWithSegmentEfforts: async () => ({
+        id: 'activity-601',
+        name: 'Webhook Ride',
+        start_date: '2025-06-03T09:00:00Z',
+        segment_efforts: [
+          {
+            id: 'effort-601',
+            elapsed_time: 190,
+            start_date: '2025-06-03T09:05:00Z',
+            segment: { id: 'seg-601' },
+          },
+        ],
+      }),
+    });
+
+    const matches = drizzleDb.select().from(explorerDestinationMatch).all();
+    expect(matches).toHaveLength(1);
+    expect(matches[0]?.strava_athlete_id).toBe('4001');
+  });
+});

--- a/server/src/__tests__/setupTestDb.ts
+++ b/server/src/__tests__/setupTestDb.ts
@@ -125,6 +125,9 @@ export function teardownTestDb(db: Database.Database) {
       DELETE FROM participant_token;
       DELETE FROM deletion_request;
       DELETE FROM schema_migrations;
+      DELETE FROM explorer_destination_match;
+      DELETE FROM explorer_destination;
+      DELETE FROM explorer_campaign;
       DELETE FROM segment_effort;
       DELETE FROM result;
       DELETE FROM activity;

--- a/server/src/__tests__/testDataHelpers.ts
+++ b/server/src/__tests__/testDataHelpers.ts
@@ -104,7 +104,7 @@ interface CreateExplorerDestinationOptions {
   explorerCampaignId: number;
   stravaSegmentId?: string;
   sourceUrl?: string | null;
-  cachedSegmentName?: string | null;
+  cachedName?: string | null;
   displayLabel?: string | null;
   displayOrder?: number;
   surfaceType?: string | null;
@@ -294,7 +294,7 @@ export function createExplorerDestination(
     explorerCampaignId,
     stravaSegmentId = 'explorer-segment-1',
     sourceUrl = null,
-    cachedSegmentName = null,
+    cachedName = null,
     displayLabel = null,
     displayOrder = 0,
     surfaceType = null,
@@ -307,15 +307,15 @@ export function createExplorerDestination(
     .where(eq(segment.strava_segment_id, stravaSegmentId))
     .get();
 
-  if (!existingSegment && cachedSegmentName) {
-    createSegment(db, stravaSegmentId, cachedSegmentName);
+  if (!existingSegment && cachedName) {
+    createSegment(db, stravaSegmentId, cachedName);
   }
 
   const newDestinationData: InsertExplorerDestination = {
     explorer_campaign_id: explorerCampaignId,
     strava_segment_id: stravaSegmentId,
     source_url: sourceUrl,
-    cached_segment_name: cachedSegmentName,
+    cached_name: cachedName,
     display_label: displayLabel,
     display_order: displayOrder,
     surface_type: surfaceType,

--- a/server/src/__tests__/testDataHelpers.ts
+++ b/server/src/__tests__/testDataHelpers.ts
@@ -1,6 +1,6 @@
 import { BetterSQLite3Database as DrizzleBetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
 import { isoToUnix } from '../dateUtils';
-import { season, activity, participant, participantToken, result, segment, segmentEffort, week, deletionRequest } from '../db/schema';
+import { season, activity, participant, participantToken, result, segment, segmentEffort, week, deletionRequest, explorerCampaign, explorerDestination, explorerDestinationMatch } from '../db/schema';
 import { eq } from 'drizzle-orm';
 import { InferInsertModel, InferSelectModel } from 'drizzle-orm';
 
@@ -13,6 +13,12 @@ export type InsertSegment = InferInsertModel<typeof segment>;     // Exported
 export type SelectSegment = InferSelectModel<typeof segment>;
 export type InsertWeek = InferInsertModel<typeof week>;           // Exported
 export type SelectWeek = InferSelectModel<typeof week>;
+export type InsertExplorerCampaign = InferInsertModel<typeof explorerCampaign>;
+export type SelectExplorerCampaign = InferSelectModel<typeof explorerCampaign>;
+export type InsertExplorerDestination = InferInsertModel<typeof explorerDestination>;
+export type SelectExplorerDestination = InferSelectModel<typeof explorerDestination>;
+export type InsertExplorerDestinationMatch = InferInsertModel<typeof explorerDestinationMatch>;
+export type SelectExplorerDestinationMatch = InferSelectModel<typeof explorerDestinationMatch>;
 export type InsertActivity = InferInsertModel<typeof activity>;   // Exported
 export type SelectActivity = InferSelectModel<typeof activity>;
 export type InsertResult = InferInsertModel<typeof result>;       // Exported
@@ -86,6 +92,31 @@ interface CreateWeekWithResultsOptions {
   weekName?: string;
   participantIds?: string[];
   times?: number[];
+}
+
+interface CreateExplorerCampaignOptions {
+  seasonId?: number;
+  displayName?: string | null;
+  rulesBlurb?: string | null;
+}
+
+interface CreateExplorerDestinationOptions {
+  explorerCampaignId: number;
+  stravaSegmentId?: string;
+  sourceUrl?: string | null;
+  cachedSegmentName?: string | null;
+  displayLabel?: string | null;
+  displayOrder?: number;
+  surfaceType?: string | null;
+  category?: string | null;
+}
+
+interface CreateExplorerMatchOptions {
+  explorerCampaignId: number;
+  explorerDestinationId: number;
+  stravaAthleteId: string;
+  stravaActivityId?: string;
+  matchedAt?: number;
 }
 
 /**
@@ -228,6 +259,93 @@ export function createWeek(db: TestDb, options: CreateWeekOptions = {}): SelectW
   const newWeek = db.insert(week).values(newWeekData).returning().get();
   console.log(`[TEST_HELPER] Created Week: id=${newWeek.id}, name=${newWeek.week_name}, seasonId=${newWeek.season_id}, segmentId=${newWeek.strava_segment_id}`);
   return newWeek;
+}
+
+export function createExplorerCampaign(
+  db: TestDb,
+  options: CreateExplorerCampaignOptions = {}
+): SelectExplorerCampaign {
+  const {
+    seasonId,
+    displayName = 'Explorer Campaign',
+    rulesBlurb = null,
+  } = options;
+
+  let finalSeasonId = seasonId;
+  if (!finalSeasonId) {
+    const defaultSeason = createSeason(db, 'Explorer Season');
+    finalSeasonId = defaultSeason.id;
+  }
+
+  const newCampaignData: InsertExplorerCampaign = {
+    season_id: finalSeasonId,
+    display_name: displayName,
+    rules_blurb: rulesBlurb,
+  };
+
+  return db.insert(explorerCampaign).values(newCampaignData).returning().get();
+}
+
+export function createExplorerDestination(
+  db: TestDb,
+  options: CreateExplorerDestinationOptions
+): SelectExplorerDestination {
+  const {
+    explorerCampaignId,
+    stravaSegmentId = 'explorer-segment-1',
+    sourceUrl = null,
+    cachedSegmentName = null,
+    displayLabel = null,
+    displayOrder = 0,
+    surfaceType = null,
+    category = null,
+  } = options;
+
+  const existingSegment = db
+    .select()
+    .from(segment)
+    .where(eq(segment.strava_segment_id, stravaSegmentId))
+    .get();
+
+  if (!existingSegment && cachedSegmentName) {
+    createSegment(db, stravaSegmentId, cachedSegmentName);
+  }
+
+  const newDestinationData: InsertExplorerDestination = {
+    explorer_campaign_id: explorerCampaignId,
+    strava_segment_id: stravaSegmentId,
+    source_url: sourceUrl,
+    cached_segment_name: cachedSegmentName,
+    display_label: displayLabel,
+    display_order: displayOrder,
+    surface_type: surfaceType,
+    category,
+  };
+
+  return db.insert(explorerDestination).values(newDestinationData).returning().get();
+}
+
+export function createExplorerMatch(
+  db: TestDb,
+  options: CreateExplorerMatchOptions
+): SelectExplorerDestinationMatch {
+  const {
+    explorerCampaignId,
+    explorerDestinationId,
+    stravaAthleteId,
+    stravaActivityId = String(Math.floor(Math.random() * 1000000000)),
+    matchedAt = isoToUnix('2025-06-01T12:00:00Z') || 0,
+  } = options;
+
+  const newMatchData: InsertExplorerDestinationMatch = {
+    explorer_campaign_id: explorerCampaignId,
+    explorer_destination_id: explorerDestinationId,
+    strava_athlete_id: stravaAthleteId,
+    strava_activity_id: stravaActivityId,
+    matched_at: matchedAt,
+  };
+
+  return db.insert(explorerDestinationMatch).values(newMatchData).returning().get();
 }
 
 /**
@@ -407,6 +525,9 @@ export function createFullUserWithActivity(db: TestDb, options: CreateFullUserOp
 export function clearAllData(db: TestDb) {
   // Use Drizzle to delete from tables
   db.delete(deletionRequest).run();
+  db.delete(explorerDestinationMatch).run();
+  db.delete(explorerDestination).run();
+  db.delete(explorerCampaign).run();
   db.delete(segmentEffort).run();
   db.delete(result).run();
   db.delete(activity).run();

--- a/server/src/__tests__/trpc/explorerRouter.test.ts
+++ b/server/src/__tests__/trpc/explorerRouter.test.ts
@@ -78,7 +78,7 @@ describe('explorerRouter', () => {
     createExplorerDestination(drizzleDb, {
       explorerCampaignId: campaign.id,
       stravaSegmentId: 'seg-402',
-      cachedSegmentName: 'Cached Name',
+      cachedName: 'Cached Name',
       displayOrder: 2,
     });
     createExplorerDestination(drizzleDb, {
@@ -128,13 +128,13 @@ describe('explorerRouter', () => {
     const completedDestination = createExplorerDestination(drizzleDb, {
       explorerCampaignId: campaign.id,
       stravaSegmentId: 'seg-501',
-      cachedSegmentName: 'Forest Road',
+      cachedName: 'Forest Road',
       displayOrder: 1,
     });
     createExplorerDestination(drizzleDb, {
       explorerCampaignId: campaign.id,
       stravaSegmentId: 'seg-502',
-      cachedSegmentName: 'River Road',
+      cachedName: 'River Road',
       displayOrder: 2,
     });
 

--- a/server/src/__tests__/trpc/explorerRouter.test.ts
+++ b/server/src/__tests__/trpc/explorerRouter.test.ts
@@ -1,0 +1,165 @@
+import { Database } from 'better-sqlite3';
+import { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+import { eq } from 'drizzle-orm';
+import { appRouter } from '../../routers';
+import { createContext } from '../../trpc/context';
+import { participant } from '../../db/schema';
+import {
+  clearAllData,
+  createExplorerCampaign,
+  createExplorerDestination,
+  createExplorerMatch,
+  createParticipant,
+  createSeason,
+  createSegment,
+  setupTestDb,
+  teardownTestDb,
+} from '../testDataHelpers';
+
+describe('explorerRouter', () => {
+  let db: Database;
+  let drizzleDb: BetterSQLite3Database;
+
+  beforeAll(() => {
+    const testDb = setupTestDb();
+    db = testDb.db;
+    drizzleDb = testDb.drizzleDb;
+  });
+
+  afterAll(() => {
+    teardownTestDb(db);
+  });
+
+  beforeEach(() => {
+    clearAllData(drizzleDb);
+  });
+
+  const getCaller = (athleteId?: string) => {
+    const existingParticipant = athleteId
+      ? drizzleDb
+        .select({ stravaAthleteId: participant.strava_athlete_id })
+        .from(participant)
+        .where(eq(participant.strava_athlete_id, athleteId))
+        .get()
+      : null;
+
+    if (athleteId && !existingParticipant) {
+      createParticipant(drizzleDb, athleteId, 'Explorer Athlete');
+    }
+
+    return appRouter.createCaller(createContext({
+      req: {
+        session: {
+          stravaAthleteId: athleteId,
+        },
+      } as any,
+      res: {} as any,
+      dbOverride: db,
+      drizzleDbOverride: drizzleDb,
+    }));
+  };
+
+  it('returns null when there is no active Explorer campaign', async () => {
+    const caller = getCaller();
+    await expect(caller.explorer.getActiveCampaign()).resolves.toBeNull();
+  });
+
+  it('returns the active campaign with ordered destinations and resolved labels', async () => {
+    createSegment(drizzleDb, 'seg-401', 'Segment Name From DB');
+    const seasonRecord = createSeason(drizzleDb, '2025 Explorer Season', true, {
+      startAt: 1748736000,
+      endAt: 4102444799,
+    });
+    const campaign = createExplorerCampaign(drizzleDb, {
+      seasonId: seasonRecord.id,
+      displayName: 'Explorer Launch',
+    });
+
+    createExplorerDestination(drizzleDb, {
+      explorerCampaignId: campaign.id,
+      stravaSegmentId: 'seg-402',
+      cachedSegmentName: 'Cached Name',
+      displayOrder: 2,
+    });
+    createExplorerDestination(drizzleDb, {
+      explorerCampaignId: campaign.id,
+      stravaSegmentId: 'seg-401',
+      displayLabel: 'Custom Label',
+      displayOrder: 1,
+    });
+
+    const caller = getCaller();
+    const result = await caller.explorer.getActiveCampaign();
+
+    expect(result?.name).toBe('Explorer Launch');
+    expect(result?.seasonName).toBe('2025 Explorer Season');
+    expect(result?.destinations).toHaveLength(2);
+    expect(result?.destinations[0]).toMatchObject({
+      stravaSegmentId: 'seg-401',
+      displayLabel: 'Custom Label',
+      displayOrder: 1,
+    });
+    expect(result?.destinations[1]).toMatchObject({
+      stravaSegmentId: 'seg-402',
+      displayLabel: 'Cached Name',
+      displayOrder: 2,
+    });
+  });
+
+  it('requires auth for getCampaignProgress', async () => {
+    const seasonRecord = createSeason(drizzleDb, 'Explorer Season');
+    const campaign = createExplorerCampaign(drizzleDb, { seasonId: seasonRecord.id });
+    const caller = getCaller();
+    await expect(caller.explorer.getCampaignProgress({ campaignId: campaign.id })).rejects.toThrow('UNAUTHORIZED');
+  });
+
+  it('returns athlete progress for a campaign', async () => {
+    createParticipant(drizzleDb, '3001', 'Progress Rider');
+    createSegment(drizzleDb, 'seg-501', 'Forest Road');
+    const seasonRecord = createSeason(drizzleDb, 'Explorer Season', true, {
+      startAt: 1751328000,
+      endAt: 1751932799,
+    });
+    const campaign = createExplorerCampaign(drizzleDb, {
+      seasonId: seasonRecord.id,
+      displayName: 'Weekless Explorer',
+    });
+
+    const completedDestination = createExplorerDestination(drizzleDb, {
+      explorerCampaignId: campaign.id,
+      stravaSegmentId: 'seg-501',
+      cachedSegmentName: 'Forest Road',
+      displayOrder: 1,
+    });
+    createExplorerDestination(drizzleDb, {
+      explorerCampaignId: campaign.id,
+      stravaSegmentId: 'seg-502',
+      cachedSegmentName: 'River Road',
+      displayOrder: 2,
+    });
+
+    createExplorerMatch(drizzleDb, {
+      explorerCampaignId: campaign.id,
+      explorerDestinationId: completedDestination.id,
+      stravaAthleteId: '3001',
+      stravaActivityId: 'activity-501',
+    });
+
+    const caller = getCaller('3001');
+    const result = await caller.explorer.getCampaignProgress({ campaignId: campaign.id });
+
+    expect(result?.completedDestinations).toBe(1);
+    expect(result?.totalDestinations).toBe(2);
+    expect(result?.destinations[0]).toMatchObject({
+      stravaSegmentId: 'seg-501',
+      completed: true,
+      stravaActivityId: 'activity-501',
+      displayLabel: 'Forest Road',
+    });
+    expect(result?.destinations[1]).toMatchObject({
+      stravaSegmentId: 'seg-502',
+      completed: false,
+      displayLabel: 'River Road',
+    });
+  });
+});

--- a/server/src/db/schema.ts
+++ b/server/src/db/schema.ts
@@ -152,6 +152,51 @@ export const webhookSubscription = sqliteTable('webhook_subscription', {
   last_refreshed_at: text('last_refreshed_at'),
 });
 
+export const explorerCampaign = sqliteTable('explorer_campaign', {
+  id: integer().primaryKey({ autoIncrement: true }),
+  season_id: integer('season_id').notNull().references(() => season.id, { onDelete: 'cascade' }),
+  display_name: text('display_name'),
+  rules_blurb: text('rules_blurb'),
+  created_at: text('created_at').default('sql`(CURRENT_TIMESTAMP)`'),
+  updated_at: text('updated_at').default('sql`(CURRENT_TIMESTAMP)`'),
+},
+(t) => [
+  index('idx_explorer_campaign_season').on(t.season_id),
+]);
+
+export const explorerDestination = sqliteTable('explorer_destination', {
+  id: integer().primaryKey({ autoIncrement: true }),
+  explorer_campaign_id: integer('explorer_campaign_id').notNull().references(() => explorerCampaign.id, { onDelete: 'cascade' }),
+  strava_segment_id: text('strava_segment_id').notNull(),
+  source_url: text('source_url'),
+  cached_segment_name: text('cached_segment_name'),
+  display_label: text('display_label'),
+  display_order: integer('display_order').default(0).notNull(),
+  surface_type: text('surface_type'),
+  category: text('category'),
+  created_at: text('created_at').default('sql`(CURRENT_TIMESTAMP)`'),
+  updated_at: text('updated_at').default('sql`(CURRENT_TIMESTAMP)`'),
+},
+(t) => [
+  index('idx_explorer_destination_campaign').on(t.explorer_campaign_id),
+  index('idx_explorer_destination_segment').on(t.strava_segment_id),
+]);
+
+export const explorerDestinationMatch = sqliteTable('explorer_destination_match', {
+  id: integer().primaryKey({ autoIncrement: true }),
+  explorer_campaign_id: integer('explorer_campaign_id').notNull().references(() => explorerCampaign.id, { onDelete: 'cascade' }),
+  explorer_destination_id: integer('explorer_destination_id').notNull().references(() => explorerDestination.id, { onDelete: 'cascade' }),
+  strava_athlete_id: text('strava_athlete_id').notNull().references(() => participant.strava_athlete_id, { onDelete: 'cascade' }),
+  strava_activity_id: text('strava_activity_id').notNull(),
+  matched_at: integer('matched_at').notNull(),
+  created_at: text('created_at').default('sql`(CURRENT_TIMESTAMP)`'),
+},
+(t) => [
+  index('idx_explorer_match_campaign_athlete').on(t.explorer_campaign_id, t.strava_athlete_id),
+  index('idx_explorer_match_activity').on(t.strava_activity_id),
+  index('idx_explorer_match_unique').on(t.explorer_campaign_id, t.explorer_destination_id, t.strava_athlete_id),
+]);
+
 // Chain Wax Tracking tables
 export const chainWaxPeriod = sqliteTable('chain_wax_period', {
   id: integer().primaryKey({ autoIncrement: true }),
@@ -201,6 +246,15 @@ export type NewWeek = typeof week.$inferInsert;
 
 export type Segment = typeof segment.$inferSelect;
 export type NewSegment = typeof segment.$inferInsert;
+
+export type ExplorerCampaign = typeof explorerCampaign.$inferSelect;
+export type NewExplorerCampaign = typeof explorerCampaign.$inferInsert;
+
+export type ExplorerDestination = typeof explorerDestination.$inferSelect;
+export type NewExplorerDestination = typeof explorerDestination.$inferInsert;
+
+export type ExplorerDestinationMatch = typeof explorerDestinationMatch.$inferSelect;
+export type NewExplorerDestinationMatch = typeof explorerDestinationMatch.$inferInsert;
 
 export type Participant = typeof participant.$inferSelect;
 export type NewParticipant = typeof participant.$inferInsert;

--- a/server/src/db/schema.ts
+++ b/server/src/db/schema.ts
@@ -1,4 +1,4 @@
-import { sqliteTable, text, numeric, integer, index, real } from 'drizzle-orm/sqlite-core';
+import { sqliteTable, text, numeric, integer, index, real, uniqueIndex } from 'drizzle-orm/sqlite-core';
 // import { relations } from "drizzle-orm"
 
 export const sessions = sqliteTable('sessions', {
@@ -194,7 +194,7 @@ export const explorerDestinationMatch = sqliteTable('explorer_destination_match'
 (t) => [
   index('idx_explorer_match_campaign_athlete').on(t.explorer_campaign_id, t.strava_athlete_id),
   index('idx_explorer_match_activity').on(t.strava_activity_id),
-  index('idx_explorer_match_unique').on(t.explorer_campaign_id, t.explorer_destination_id, t.strava_athlete_id),
+  uniqueIndex('idx_explorer_match_unique').on(t.explorer_campaign_id, t.explorer_destination_id, t.strava_athlete_id),
 ]);
 
 // Chain Wax Tracking tables

--- a/server/src/db/schema.ts
+++ b/server/src/db/schema.ts
@@ -169,7 +169,7 @@ export const explorerDestination = sqliteTable('explorer_destination', {
   explorer_campaign_id: integer('explorer_campaign_id').notNull().references(() => explorerCampaign.id, { onDelete: 'cascade' }),
   strava_segment_id: text('strava_segment_id').notNull(),
   source_url: text('source_url'),
-  cached_segment_name: text('cached_segment_name'),
+  cached_name: text('cached_name'),
   display_label: text('display_label'),
   display_order: integer('display_order').default(0).notNull(),
   surface_type: text('surface_type'),

--- a/server/src/routers/explorer.ts
+++ b/server/src/routers/explorer.ts
@@ -1,0 +1,22 @@
+import { TRPCError } from '@trpc/server';
+import { z } from 'zod';
+import { router, publicProcedure } from '../trpc/init';
+import { ExplorerQueryService } from '../services/ExplorerQueryService';
+
+export const explorerRouter = router({
+  getActiveCampaign: publicProcedure.query(async ({ ctx }) => {
+    const service = new ExplorerQueryService(ctx.orm);
+    return await service.getActiveCampaign();
+  }),
+
+  getCampaignProgress: publicProcedure
+    .input(z.object({ campaignId: z.number().int().positive() }))
+    .query(async ({ ctx, input }) => {
+      if (!ctx.userId) {
+        throw new TRPCError({ code: 'UNAUTHORIZED' });
+      }
+
+      const service = new ExplorerQueryService(ctx.orm);
+      return await service.getCampaignProgress(input.campaignId, ctx.userId);
+    }),
+});

--- a/server/src/routers/index.ts
+++ b/server/src/routers/index.ts
@@ -9,6 +9,7 @@ import { clubRouter } from './club';
 import { profileRouter } from './profile';
 import { chatRouter } from './chat';
 import { chainWaxRouter } from './chainWax';
+import { explorerRouter } from './explorer';
 
 export const appRouter = router({
   health: publicProcedure.query(() => 'ok'),
@@ -22,6 +23,7 @@ export const appRouter = router({
   profile: profileRouter,
   chat: chatRouter,
   chainWax: chainWaxRouter,
+  explorer: explorerRouter,
 });
 
 export type AppRouter = typeof appRouter;

--- a/server/src/services/ExplorerMatchingService.ts
+++ b/server/src/services/ExplorerMatchingService.ts
@@ -1,0 +1,239 @@
+import { and, eq, gte, lte } from 'drizzle-orm';
+import { type BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+import {
+  explorerCampaign,
+  explorerDestination,
+  explorerDestinationMatch,
+  season,
+} from '../db/schema';
+import {
+  getActivity,
+  listAthleteActivities,
+  type Activity as StravaActivity,
+} from '../stravaClient';
+import { isoToUnix } from '../dateUtils';
+
+interface MatchActivityResult {
+  processedCampaigns: number;
+  matchedDestinations: number;
+  newMatches: number;
+}
+
+interface RefreshAthleteCampaignResult {
+  activitiesProcessed: number;
+  activitiesMatched: number;
+  newMatches: number;
+}
+
+interface CampaignWindowRecord {
+  id: number;
+  season_id: number;
+  display_name: string | null;
+  rules_blurb: string | null;
+  season_start_at: number;
+  season_end_at: number;
+}
+
+function getActivityTimestamp(activityData: StravaActivity): number | null {
+  return isoToUnix(activityData.start_date);
+}
+
+function getSegmentIdsFromActivity(activityData: StravaActivity): Set<string> {
+  const segmentIds = new Set<string>();
+
+  for (const effort of activityData.segment_efforts || []) {
+    if (effort.segment?.id !== undefined && effort.segment?.id !== null) {
+      segmentIds.add(String(effort.segment.id));
+    }
+  }
+
+  return segmentIds;
+}
+
+async function ensureSegmentEfforts(
+  activityData: StravaActivity,
+  accessToken: string
+): Promise<StravaActivity> {
+  if (Array.isArray(activityData.segment_efforts) && activityData.segment_efforts.length > 0) {
+    return activityData;
+  }
+
+  return await getActivity(String(activityData.id), accessToken);
+}
+
+export class ExplorerMatchingService {
+  constructor(private readonly db: BetterSQLite3Database) {}
+
+  async matchActivity(
+    activityData: StravaActivity,
+    athleteId: string
+  ): Promise<MatchActivityResult> {
+    const activityTimestamp = getActivityTimestamp(activityData);
+    if (activityTimestamp === null) {
+      return {
+        processedCampaigns: 0,
+        matchedDestinations: 0,
+        newMatches: 0,
+      };
+    }
+
+    const activeCampaigns = this.db
+      .select({
+        id: explorerCampaign.id,
+        season_id: explorerCampaign.season_id,
+        display_name: explorerCampaign.display_name,
+        rules_blurb: explorerCampaign.rules_blurb,
+        season_start_at: season.start_at,
+        season_end_at: season.end_at,
+      })
+      .from(explorerCampaign)
+      .innerJoin(season, eq(explorerCampaign.season_id, season.id))
+      .where(
+        and(
+          lte(season.start_at, activityTimestamp),
+          gte(season.end_at, activityTimestamp)
+        )
+      )
+      .all();
+
+    return this.matchActivityAgainstCampaigns(activityData, athleteId, activeCampaigns);
+  }
+
+  async refreshAthleteCampaign(
+    explorerCampaignId: number,
+    athleteId: string,
+    accessToken: string
+  ): Promise<RefreshAthleteCampaignResult> {
+    const campaignRecord = this.db
+      .select({
+        id: explorerCampaign.id,
+        season_id: explorerCampaign.season_id,
+        display_name: explorerCampaign.display_name,
+        rules_blurb: explorerCampaign.rules_blurb,
+        season_start_at: season.start_at,
+        season_end_at: season.end_at,
+      })
+      .from(explorerCampaign)
+      .innerJoin(season, eq(explorerCampaign.season_id, season.id))
+      .where(eq(explorerCampaign.id, explorerCampaignId))
+      .get();
+
+    if (!campaignRecord) {
+      return {
+        activitiesProcessed: 0,
+        activitiesMatched: 0,
+        newMatches: 0,
+      };
+    }
+
+    const activities = await listAthleteActivities(
+      accessToken,
+      campaignRecord.season_start_at,
+      campaignRecord.season_end_at,
+      {
+        includeAllEfforts: true,
+      }
+    );
+
+    let activitiesMatched = 0;
+    let newMatches = 0;
+
+    for (const activity of activities) {
+      const hydratedActivity = await ensureSegmentEfforts(activity, accessToken);
+      const result = await this.matchActivityAgainstCampaigns(hydratedActivity, athleteId, [campaignRecord]);
+
+      if (result.matchedDestinations > 0) {
+        activitiesMatched += 1;
+      }
+
+      newMatches += result.newMatches;
+    }
+
+    return {
+      activitiesProcessed: activities.length,
+      activitiesMatched,
+      newMatches,
+    };
+  }
+
+  private async matchActivityAgainstCampaigns(
+    activityData: StravaActivity,
+    athleteId: string,
+    campaigns: CampaignWindowRecord[]
+  ): Promise<MatchActivityResult> {
+    if (campaigns.length === 0) {
+      return {
+        processedCampaigns: 0,
+        matchedDestinations: 0,
+        newMatches: 0,
+      };
+    }
+
+    const activityTimestamp = getActivityTimestamp(activityData);
+    if (activityTimestamp === null) {
+      return {
+        processedCampaigns: campaigns.length,
+        matchedDestinations: 0,
+        newMatches: 0,
+      };
+    }
+
+    const segmentIds = getSegmentIdsFromActivity(activityData);
+    if (segmentIds.size === 0) {
+      return {
+        processedCampaigns: campaigns.length,
+        matchedDestinations: 0,
+        newMatches: 0,
+      };
+    }
+
+    let matchedDestinations = 0;
+    let newMatches = 0;
+
+    for (const campaignRecord of campaigns) {
+      const destinations = this.db
+        .select()
+        .from(explorerDestination)
+        .where(eq(explorerDestination.explorer_campaign_id, campaignRecord.id))
+        .all();
+
+      for (const destination of destinations) {
+        if (!segmentIds.has(destination.strava_segment_id)) {
+          continue;
+        }
+
+        matchedDestinations += 1;
+
+        const inserted = this.db
+          .insert(explorerDestinationMatch)
+          .values({
+            explorer_campaign_id: campaignRecord.id,
+            explorer_destination_id: destination.id,
+            strava_athlete_id: athleteId,
+            strava_activity_id: String(activityData.id),
+            matched_at: activityTimestamp,
+          })
+          .onConflictDoNothing({
+            target: [
+              explorerDestinationMatch.explorer_campaign_id,
+              explorerDestinationMatch.explorer_destination_id,
+              explorerDestinationMatch.strava_athlete_id,
+            ],
+          })
+          .run();
+
+        if (inserted.changes > 0) {
+          newMatches += 1;
+        }
+      }
+    }
+
+    return {
+      processedCampaigns: campaigns.length,
+      matchedDestinations,
+      newMatches,
+    };
+  }
+}
+
+export type { MatchActivityResult, RefreshAthleteCampaignResult };

--- a/server/src/services/ExplorerQueryService.ts
+++ b/server/src/services/ExplorerQueryService.ts
@@ -1,0 +1,236 @@
+import { and, asc, desc, eq, gte, lte } from 'drizzle-orm';
+import { type BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+import {
+  explorerCampaign,
+  explorerDestination,
+  explorerDestinationMatch,
+  season,
+  segment,
+} from '../db/schema';
+
+interface ExplorerDestinationView {
+  id: number;
+  stravaSegmentId: string;
+  displayLabel: string;
+  sourceUrl: string | null;
+  surfaceType: string | null;
+  category: string | null;
+  displayOrder: number;
+}
+
+interface ActiveExplorerCampaignView {
+  id: number;
+  seasonId: number;
+  name: string;
+  seasonName: string;
+  startAt: number;
+  endAt: number;
+  rulesBlurb: string | null;
+  destinations: ExplorerDestinationView[];
+}
+
+interface ExplorerProgressDestinationView extends ExplorerDestinationView {
+  completed: boolean;
+  matchedAt: number | null;
+  stravaActivityId: string | null;
+}
+
+interface ExplorerCampaignProgressView {
+  campaign: {
+    id: number;
+    seasonId: number;
+    name: string;
+    seasonName: string;
+    startAt: number;
+    endAt: number;
+    rulesBlurb: string | null;
+  };
+  completedDestinations: number;
+  totalDestinations: number;
+  destinations: ExplorerProgressDestinationView[];
+}
+
+function resolveDestinationLabel(destination: {
+  strava_segment_id: string;
+  display_label: string | null;
+  cached_segment_name: string | null;
+  segment_name: string | null;
+}): string {
+  return (
+    destination.display_label ||
+    destination.cached_segment_name ||
+    destination.segment_name ||
+    `Segment ${destination.strava_segment_id}`
+  );
+}
+
+function resolveCampaignName(displayName: string | null, seasonName: string): string {
+  return displayName || seasonName;
+}
+
+export class ExplorerQueryService {
+  constructor(private readonly db: BetterSQLite3Database) {}
+
+  async getActiveCampaign(
+    nowTimestamp: number = Math.floor(Date.now() / 1000)
+  ): Promise<ActiveExplorerCampaignView | null> {
+    const campaignRecords = this.db
+      .select({
+        id: explorerCampaign.id,
+        season_id: explorerCampaign.season_id,
+        display_name: explorerCampaign.display_name,
+        rules_blurb: explorerCampaign.rules_blurb,
+        season_name: season.name,
+        season_start_at: season.start_at,
+        season_end_at: season.end_at,
+      })
+      .from(explorerCampaign)
+      .innerJoin(season, eq(explorerCampaign.season_id, season.id))
+      .where(
+        and(
+          lte(season.start_at, nowTimestamp),
+          gte(season.end_at, nowTimestamp)
+        )
+      )
+      .orderBy(desc(season.start_at))
+      .all();
+
+    for (const campaignRecord of campaignRecords) {
+      const destinations = this.db
+        .select({
+          id: explorerDestination.id,
+          strava_segment_id: explorerDestination.strava_segment_id,
+          display_label: explorerDestination.display_label,
+          cached_segment_name: explorerDestination.cached_segment_name,
+          source_url: explorerDestination.source_url,
+          surface_type: explorerDestination.surface_type,
+          category: explorerDestination.category,
+          display_order: explorerDestination.display_order,
+          segment_name: segment.name,
+        })
+        .from(explorerDestination)
+        .leftJoin(segment, eq(explorerDestination.strava_segment_id, segment.strava_segment_id))
+        .where(eq(explorerDestination.explorer_campaign_id, campaignRecord.id))
+        .orderBy(asc(explorerDestination.display_order), asc(explorerDestination.id))
+        .all();
+
+      if (destinations.length === 0) {
+        continue;
+      }
+
+      return {
+        id: campaignRecord.id,
+        seasonId: campaignRecord.season_id,
+        name: resolveCampaignName(campaignRecord.display_name, campaignRecord.season_name),
+        seasonName: campaignRecord.season_name,
+        startAt: campaignRecord.season_start_at,
+        endAt: campaignRecord.season_end_at,
+        rulesBlurb: campaignRecord.rules_blurb,
+        destinations: destinations.map((destination) => ({
+          id: destination.id,
+          stravaSegmentId: destination.strava_segment_id,
+          displayLabel: resolveDestinationLabel(destination),
+          sourceUrl: destination.source_url,
+          surfaceType: destination.surface_type,
+          category: destination.category,
+          displayOrder: destination.display_order,
+        })),
+      };
+    }
+
+    return null;
+  }
+
+  async getCampaignProgress(
+    explorerCampaignId: number,
+    athleteId: string
+  ): Promise<ExplorerCampaignProgressView | null> {
+    const campaignRecord = this.db
+      .select({
+        id: explorerCampaign.id,
+        season_id: explorerCampaign.season_id,
+        display_name: explorerCampaign.display_name,
+        rules_blurb: explorerCampaign.rules_blurb,
+        season_name: season.name,
+        season_start_at: season.start_at,
+        season_end_at: season.end_at,
+      })
+      .from(explorerCampaign)
+      .innerJoin(season, eq(explorerCampaign.season_id, season.id))
+      .where(eq(explorerCampaign.id, explorerCampaignId))
+      .get();
+
+    if (!campaignRecord) {
+      return null;
+    }
+
+    const destinations = this.db
+      .select({
+        id: explorerDestination.id,
+        strava_segment_id: explorerDestination.strava_segment_id,
+        display_label: explorerDestination.display_label,
+        cached_segment_name: explorerDestination.cached_segment_name,
+        source_url: explorerDestination.source_url,
+        surface_type: explorerDestination.surface_type,
+        category: explorerDestination.category,
+        display_order: explorerDestination.display_order,
+        segment_name: segment.name,
+      })
+      .from(explorerDestination)
+      .leftJoin(segment, eq(explorerDestination.strava_segment_id, segment.strava_segment_id))
+      .where(eq(explorerDestination.explorer_campaign_id, explorerCampaignId))
+      .orderBy(asc(explorerDestination.display_order), asc(explorerDestination.id))
+      .all();
+
+    const matches = this.db
+      .select({
+        explorer_destination_id: explorerDestinationMatch.explorer_destination_id,
+        matched_at: explorerDestinationMatch.matched_at,
+        strava_activity_id: explorerDestinationMatch.strava_activity_id,
+      })
+      .from(explorerDestinationMatch)
+      .where(
+        and(
+          eq(explorerDestinationMatch.explorer_campaign_id, explorerCampaignId),
+          eq(explorerDestinationMatch.strava_athlete_id, athleteId)
+        )
+      )
+      .all();
+
+    const matchesByDestinationId = new Map(matches.map((match) => [match.explorer_destination_id, match]));
+
+    const progressDestinations = destinations.map((destination) => {
+      const match = matchesByDestinationId.get(destination.id);
+
+      return {
+        id: destination.id,
+        stravaSegmentId: destination.strava_segment_id,
+        displayLabel: resolveDestinationLabel(destination),
+        sourceUrl: destination.source_url,
+        surfaceType: destination.surface_type,
+        category: destination.category,
+        displayOrder: destination.display_order,
+        completed: Boolean(match),
+        matchedAt: match?.matched_at || null,
+        stravaActivityId: match?.strava_activity_id || null,
+      };
+    });
+
+    return {
+      campaign: {
+        id: campaignRecord.id,
+        seasonId: campaignRecord.season_id,
+        name: resolveCampaignName(campaignRecord.display_name, campaignRecord.season_name),
+        seasonName: campaignRecord.season_name,
+        startAt: campaignRecord.season_start_at,
+        endAt: campaignRecord.season_end_at,
+        rulesBlurb: campaignRecord.rules_blurb,
+      },
+      completedDestinations: progressDestinations.filter((destination) => destination.completed).length,
+      totalDestinations: progressDestinations.length,
+      destinations: progressDestinations,
+    };
+  }
+}
+
+export type { ActiveExplorerCampaignView, ExplorerCampaignProgressView };

--- a/server/src/services/ExplorerQueryService.ts
+++ b/server/src/services/ExplorerQueryService.ts
@@ -53,12 +53,12 @@ interface ExplorerCampaignProgressView {
 function resolveDestinationLabel(destination: {
   strava_segment_id: string;
   display_label: string | null;
-  cached_segment_name: string | null;
+  cached_name: string | null;
   segment_name: string | null;
 }): string {
   return (
     destination.display_label ||
-    destination.cached_segment_name ||
+    destination.cached_name ||
     destination.segment_name ||
     `Segment ${destination.strava_segment_id}`
   );
@@ -101,7 +101,7 @@ export class ExplorerQueryService {
           id: explorerDestination.id,
           strava_segment_id: explorerDestination.strava_segment_id,
           display_label: explorerDestination.display_label,
-          cached_segment_name: explorerDestination.cached_segment_name,
+          cached_name: explorerDestination.cached_name,
           source_url: explorerDestination.source_url,
           surface_type: explorerDestination.surface_type,
           category: explorerDestination.category,
@@ -169,7 +169,7 @@ export class ExplorerQueryService {
         id: explorerDestination.id,
         strava_segment_id: explorerDestination.strava_segment_id,
         display_label: explorerDestination.display_label,
-        cached_segment_name: explorerDestination.cached_segment_name,
+        cached_name: explorerDestination.cached_name,
         source_url: explorerDestination.source_url,
         surface_type: explorerDestination.surface_type,
         category: explorerDestination.category,

--- a/server/src/webhooks/activityHandlers.ts
+++ b/server/src/webhooks/activityHandlers.ts
@@ -8,11 +8,17 @@ export {
 } from './activityHandlerRunner';
 export { createChainWaxActivityHandler } from './handlers/chainWaxActivityHandler';
 export { createCompetitionActivityHandler } from './handlers/competitionActivityHandler';
+export { createExplorerActivityHandler } from './handlers/explorerActivityHandler';
 
 import { type ActivityWebhookHandler } from './activityHandlerRunner';
 import { createChainWaxActivityHandler } from './handlers/chainWaxActivityHandler';
 import { createCompetitionActivityHandler } from './handlers/competitionActivityHandler';
+import { createExplorerActivityHandler } from './handlers/explorerActivityHandler';
 
 export function createDefaultActivityHandlers(): ActivityWebhookHandler[] {
-  return [createChainWaxActivityHandler(), createCompetitionActivityHandler()];
+  return [
+    createChainWaxActivityHandler(),
+    createCompetitionActivityHandler(),
+    createExplorerActivityHandler(),
+  ];
 }

--- a/server/src/webhooks/handlers/explorerActivityHandler.ts
+++ b/server/src/webhooks/handlers/explorerActivityHandler.ts
@@ -1,0 +1,24 @@
+import { ExplorerMatchingService } from '../../services/ExplorerMatchingService';
+import { type ActivityWebhookHandler } from '../activityHandlerRunner';
+
+export function createExplorerActivityHandler(): ActivityWebhookHandler {
+  return {
+    name: 'explorer',
+    isolateErrors: true,
+    async handle(context) {
+      const activityData = await context.getActivityWithSegmentEfforts();
+      if (!activityData) {
+        return;
+      }
+
+      const explorerMatchingService = new ExplorerMatchingService(context.db);
+      const result = await explorerMatchingService.matchActivity(activityData, context.athleteId);
+
+      if (result.newMatches > 0) {
+        console.log(
+          `[Webhook:Explorer] Recorded ${result.newMatches} new Explorer destination matches for athlete ${context.athleteId}`
+        );
+      }
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- add the Explorer season-campaign schema, migration, and router/service layer
- wire Explorer matching into the delegated webhook activity handler pipeline
- add focused backend tests for campaign matching, progress queries, and webhook ingestion
- document the new Explorer tRPC and database surfaces

## Scope
This PR implements the corrected backend slice approved by the Explorer planning docs:
- campaign schema attached to `season`
- destination and match schema keyed to the campaign
- matching and query paths corrected from week windows to season windows
- backend-only validation coverage

## Validation
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run build`

## Notes
- `VERSION` and `CHANGELOG.md` were left unchanged because this slice is not being treated as a user-facing release commit.
- This PR follows the planning correction from PR #24 and replaces the superseded weekly-first backend direction from closed PR #23.
