### PR TITLE
docs: align Explorer 4A planning state

### DIFF
--- a/.github/agents/dev-agent.md
+++ b/.github/agents/dev-agent.md
@@ -39,6 +39,7 @@ Use the shared repo instructions rather than restating them here:
 
 1. Check `git status` and `git branch --show-current` before substantial work.
 2. If the task is a new phase or feature slice, start from updated `main` on a dedicated feature branch.
-3. Implement with minimal, focused changes that match the existing architecture.
-4. Validate with `npm run lint`, `npm run typecheck`, `npm test`, and `npm run build` before calling the work complete.
-5. Stage files explicitly with `git add <file>` rather than broad staging.
+3. For pull requests, review comments, issue lookups, labels, and repository metadata, prefer GitHub MCP and workspace-integrated GitHub tools first; use `gh` only when that path is blocked or incomplete.
+4. Implement with minimal, focused changes that match the existing architecture.
+5. Validate with `npm run lint`, `npm run typecheck`, `npm test`, and `npm run build` before calling the work complete.
+6. Stage files explicitly with `git add <file>` rather than broad staging.

--- a/.github/agents/explorer-planner.agent.md
+++ b/.github/agents/explorer-planner.agent.md
@@ -31,6 +31,7 @@ Primary sources:
 - Before substantial planning or handoff for a new slice, check whether the current branch is appropriate.
 - If the work is not a tiny follow-up to the active branch, require the user or implementation agent to move onto updated `main` and create a dedicated feature branch before substantial work continues.
 - You may use shell execution for branch checks and for switching onto a dedicated planning branch from updated `main` when the current branch is an active implementation or PR branch and the task is a substantial planning correction.
+- For pull requests, review comments, issue lookups, labels, and repository metadata, prefer GitHub MCP and workspace-integrated GitHub tools first; use `gh` only when that path is blocked or incomplete.
 - You may edit planning artifacts and agent-planning configuration files when the task is readiness closure, slice preparation, or planning-state maintenance.
 - Do not edit product code.
 - Do not edit `VERSION` or `CHANGELOG.md`; those are final pre-commit release notes for implementation work, not planning artifacts.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -115,6 +115,8 @@ Use [AGENTS.md](./AGENTS.md) as the source of truth for:
 - branch discipline and working-tree transplant rules
 - validation and pre-commit flow
 
+For GitHub operations such as pull request review, issue lookup, labels, search, and repository metadata, prefer GitHub MCP and workspace-integrated GitHub tools first. Use `gh` only as a fallback when the MCP path is unavailable or cannot provide the required data.
+
 ## Code Patterns & Standards
 
 ### Backend (TypeScript Only)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,6 +115,11 @@ npm run audit        # Security audit (frontend + backend)
    - Do not update either file during planning or mid-implementation
    - Keep changelog entries high-level rather than a play-by-play of intermediate edits
 
+8. **GitHub workflow tools:**
+   - For pull requests, review comments, issues, labels, searches, and repository metadata, prefer GitHub MCP and workspace-integrated GitHub tools first
+   - Fall back to `gh` only when the MCP path is unavailable, missing a needed capability, or returning incomplete results
+   - When falling back to `gh`, keep the usage targeted and explain the blocker or gap that required the fallback
+
 ## Special Tasks
 
 | Task | Purpose | When to Use |

--- a/docs/prds/wmv-explorer-destinations-phases.md
+++ b/docs/prds/wmv-explorer-destinations-phases.md
@@ -40,6 +40,8 @@ Out of scope:
 
 Goal: correct Explorer from a weekly-first design to a season-attached campaign model, and remove optional mini-campaign complexity from MVP planning.
 
+Status: complete in the current planning set. Future work should build on the corrected model rather than reopen the weekly-first design unless product intent changes again.
+
 Entry condition: start from a new planning PR from updated `main` because the current planning set and implementation branch were built around the wrong weekly-first model.
 
 Scope:
@@ -53,6 +55,8 @@ Scope:
 
 Goal: add Explorer campaign, destination, and match storage plus the shared matching service used by both webhooks and refresh actions.
 
+Status: complete on the merged backend slice. Schema, matching, webhook integration, and the initial read routes now exist and should be treated as the base for later Explorer work.
+
 Scope:
 
 - Schema additions for a season-attached campaign model
@@ -62,18 +66,47 @@ Scope:
 
 ## Phase 4: Explorer Admin Setup
 
-Goal: let admins create or manage the season campaign, add destinations from Strava URLs one at a time, label them, order them, and manage additions during the season.
+Goal: let admins create or manage the season campaign without exposing Explorer to end users before release.
+
+### Slice 4A: Admin Backend
+
+Goal: add the minimal Explorer admin service and tRPC surface needed to create a campaign for a season and add destinations safely.
 
 Scope:
 
-- Explorer admin routes and service layer
+- Explorer admin service and router surface for campaign creation and add-destination flow
+- Enforce one Explorer campaign per season without constraining future multi-season operation
+- Strava segment URL parsing and validation for destination setup; do not expose raw segment-ID authoring in 4A
+- Explorer-local source URL and cached metadata persistence needed for stable authoring and display
+- Allow destination creation to proceed when URL parsing succeeds but live metadata enrichment is unavailable
+- Add-destination behavior that works before or during the season without resetting prior progress
+- Backend tests for auth, validation, campaign creation, destination creation, and in-season additions
+
+Out of scope:
+
+- Admin UI
+- Public athlete-facing Explorer UI
+- Public navigation to Explorer surfaces
+- Reorder, remove, and edit flows unless one is required to keep the backend contract coherent
+- Refresh or backfill mutations
+- Release-note bookkeeping files
+
+### Slice 4B: Admin UI (Admin-Gated)
+
+Goal: expose the approved admin backend capabilities through an admin-only WMV surface.
+
+Scope:
+
+- Admin-only route or section for Explorer campaign setup
+- Create-campaign and add-destination flows using the approved 4A backend contract
+- Keep all Explorer entry points hidden from non-admin users until there is an explicit release decision for the athlete-facing hub
 - Explorer admin UI
 - Campaign setup attached to a season
 - Add-destination workflow that works before or during the season
 
 ## Phase 5: Explorer Hub MVP
 
-Goal: ship the athlete-facing season Explorer view.
+Goal: ship the athlete-facing season Explorer view only after the admin flow is stable and Explorer is approved for end-user release.
 
 Scope:
 

--- a/docs/prds/wmv-explorer-destinations-phases.md
+++ b/docs/prds/wmv-explorer-destinations-phases.md
@@ -42,7 +42,7 @@ Goal: correct Explorer from a weekly-first design to a season-attached campaign 
 
 Status: complete in the current planning set. Future work should build on the corrected model rather than reopen the weekly-first design unless product intent changes again.
 
-Entry condition: start from a new planning PR from updated `main` because the current planning set and implementation branch were built around the wrong weekly-first model.
+Historical note: this planning correction was necessary because an earlier planning set and implementation branch had been built around the wrong weekly-first model.
 
 Scope:
 

--- a/docs/prds/wmv-explorer-destinations-tech-spec.md
+++ b/docs/prds/wmv-explorer-destinations-tech-spec.md
@@ -232,14 +232,17 @@ Responsibilities:
 
 ## 7. API Surface
 
-Recommended new tRPC surface areas:
+Recommended tRPC surface areas for 4A:
+
+- explorerAdmin.createCampaign
+- explorerAdmin.addDestination
+
+Recommended later tRPC surface areas after 4A:
 
 - explorer.getActiveCampaign
 - explorer.getCampaignProgress
 - explorer.getCampaignCompleters
-- explorerAdmin.createCampaign
 - explorerAdmin.updateCampaign
-- explorerAdmin.addDestination
 - explorerAdmin.updateDestination
 - explorerAdmin.removeDestination
 - explorerAdmin.reorderDestinations

--- a/docs/prds/wmv-explorer-destinations-tech-spec.md
+++ b/docs/prds/wmv-explorer-destinations-tech-spec.md
@@ -129,6 +129,8 @@ Recommended Explorer tables or equivalent schema concepts:
 
 MVP rule: an ExplorerCampaign is attached to one season. The campaign becomes athlete-visible only when its parent season is open and it has at least one ExplorerDestination.
 
+For v1 admin authoring, enforce one campaign per season. This should not block future support for multiple seasons each having their own campaign, but it should prevent multiple campaigns competing within the same season.
+
 - ExplorerDestination
   - id
   - explorerCampaignId
@@ -172,15 +174,23 @@ For v1, ExplorerAthleteCampaignSummary is computed on read. `ExplorerDestination
 
 Admins should be able to configure destinations by pasting Strava segment URLs, following the same mental model as the regular admin panel. The system should extract the segment ID from the URL, validate it, and store the parsed segment ID plus the original source URL when available. If the segment is already known in the app's segment table, that data can be reused. If not, Explorer should still accept it and cache enough display metadata for a stable UI.
 
+For 4A, the admin backend contract should accept validated Strava segment URLs rather than raw segment IDs. This keeps the initial write surface aligned with the intended paste-and-add authoring workflow and avoids expanding the first slice with a second authoring mode.
+
 Explorer uses a hybrid destination metadata strategy for v1. The preferred policy is database-first reuse of the shared `segment` table, plus Explorer-local cached display metadata and source URL values for stable rendering and setup. Segment metadata should be treated as comparatively durable. Optional short-lived in-memory caching can be used for segment metadata during setup workflows, but that should not be generalized to activity details or segment efforts.
+
+If URL parsing succeeds but live Strava metadata enrichment fails, 4A should still allow destination creation as long as the parsed segment ID and original source URL are preserved. Missing or stale metadata can be repaired in a later slice without blocking initial authoring.
 
 ### 5.4 V1 decision lock
 
 - Primary product model: season-attached Explorer campaign
 - Summary model: computed on read
 - Destination metadata strategy: hybrid shared-segment reuse plus Explorer-local cached display metadata
+- Campaign cardinality per season: exactly one Explorer campaign per season in v1
+- Admin destination authoring input for 4A: validated Strava segment URLs only
+- Metadata enrichment failure policy: allow creation when parsing succeeds and preserve segment ID plus source URL
 - Optional mini-campaigns within a season: deferred
 - Explicit Explorer publish-status workflow: deferred unless later implementation proves it is needed
+- Refresh or backfill admin mutations: deferred out of 4A
 
 ## 6. Core Services
 
@@ -215,6 +225,11 @@ Responsibilities:
 - Validate or enrich destination metadata from Strava where possible.
 - Trigger refresh or backfill actions.
 
+4A boundary:
+
+- Include campaign creation and add-destination authoring only.
+- Defer refresh or backfill mutations until a later admin slice.
+
 ## 7. API Surface
 
 Recommended new tRPC surface areas:
@@ -233,9 +248,17 @@ Recommended new tRPC surface areas:
 
 These names are illustrative. Final naming should fit existing router conventions.
 
+Pre-release exposure rule:
+
+- `explorerAdmin.*` belongs behind admin authorization.
+- If Explorer UI ships before the athlete-facing hub is approved for release, keep all Explorer UI entry points admin-only and do not add public navigation.
+- Existing Explorer read APIs may exist before launch, but their presence alone should not drive early end-user exposure.
+
 ## 8. UI Surface
 
 ### 8.1 User-facing hub
+
+This surface remains deferred until Explorer is approved for end-user release.
 
 Recommended user-facing sections:
 
@@ -247,6 +270,8 @@ Recommended user-facing sections:
 
 ### 8.2 Admin surface
 
+During early admin slices, any Explorer UI should remain admin-gated and should not make the feature visible to non-admin users.
+
 Recommended initial admin capabilities:
 
 - Attach Explorer campaign to a season
@@ -254,6 +279,8 @@ Recommended initial admin capabilities:
 - Edit destination display label and ordering
 - Allow adding destinations before or during the season
 - Run refresh for a campaign or athlete
+
+The first admin UI should optimize for repeated paste-and-add authoring sessions rather than heavy per-destination form filling, but that UX work belongs to 4B rather than 4A.
 
 ## 9. Matching Rules
 

--- a/docs/prds/wmv-explorer-execution-briefing.md
+++ b/docs/prds/wmv-explorer-execution-briefing.md
@@ -122,7 +122,7 @@ Any Explorer task sent to a cloud agent should include:
 
 Good first cloud-agent tasks for Explorer would look like this:
 
-- `Implement the approved Explorer admin backend slice for createCampaign and addDestination, following the tech spec API surface and the current readiness checklist.`
+- `Implement only the approved Explorer admin backend 4A procedures: createCampaign and addDestination. Do not add any other explorerAdmin endpoints. Follow the 4A slice requirements and the current readiness checklist.`
 - `Make the requested follow-up changes on an existing Explorer PR after review comments, keeping the scope to the listed files and tests.`
 
 Bad first cloud-agent tasks would look like this:

--- a/docs/prds/wmv-explorer-execution-briefing.md
+++ b/docs/prds/wmv-explorer-execution-briefing.md
@@ -122,7 +122,7 @@ Any Explorer task sent to a cloud agent should include:
 
 Good first cloud-agent tasks for Explorer would look like this:
 
-- `Implement the approved Explorer query router for getActiveWeek and its tests, following the tech spec section on API surface and the current readiness checklist.`
+- `Implement the approved Explorer admin backend slice for createCampaign and addDestination, following the tech spec API surface and the current readiness checklist.`
 - `Make the requested follow-up changes on an existing Explorer PR after review comments, keeping the scope to the listed files and tests.`
 
 Bad first cloud-agent tasks would look like this:
@@ -176,6 +176,12 @@ Prompts should remain narrow and convenient.
 - Hand off to `dev-agent` for coding work.
 - Run local validation.
 - Update docs if the slice changes visible behavior or planning state.
+
+### Slice completion discipline
+
+- If an approved implementation slice only requires narrow planning-state maintenance, such as marking the slice complete, updating the recommended next slice, or aligning readiness wording with merged code, the implementation PR should include those planning doc edits before it is considered done.
+- Hand back to `explorer-planner` when closing the slice requires new product decisions, broader readiness re-evaluation, or reshaping later slice boundaries rather than simply recording the completed state.
+- This keeps implementation PRs from leaving stale planning guidance behind while still reserving real planning work for the planning agent.
 
 ### 4. CLI support if needed
 

--- a/docs/prds/wmv-explorer-readiness-checklist.md
+++ b/docs/prds/wmv-explorer-readiness-checklist.md
@@ -17,21 +17,21 @@ The ideas backlog is intentionally excluded from v1 implementation scope. It exi
 
 ## Current Go Decision
 
-**Status:** Phase 1 Complete; Season-Campaign Correction Landed; Ready For Narrow Corrected Implementation Slice
+**Status:** Phase 1 Complete; Season-Campaign Correction Landed; Backend Campaign Slice Merged; Ready For Phase 4A Admin Backend Slice
 
-Explorer has completed the narrow Phase 1 webhook-orchestration slice that preserves current competition behavior while introducing delegated in-process handlers. The planning set on this branch now corrects the MVP to a season-campaign-first model attached to an existing WMV season, with optional mini-campaigns and explicit publish-status workflows deferred. Explorer is ready for one bounded implementation PR that corrects the backend model from the earlier weekly-first shape.
+Explorer has completed the narrow Phase 1 webhook-orchestration slice that preserves current competition behavior while introducing delegated in-process handlers. The planning set on this branch now corrects the MVP to a season-campaign-first model attached to an existing WMV season, with optional mini-campaigns and explicit publish-status workflows deferred. The backend campaign slice is merged, so the next approved implementation work should move to Phase 4A admin backend setup rather than redoing the campaign model.
 
 ## Current Status Summary
 
 | Area | Status | Notes |
 | --- | --- | --- |
 | Product framing | Ready | The PRD is clear on goals, users, must-haves, non-goals, and success criteria. |
-| Execution phasing | Ready For Narrow Corrected Slice | The phases doc now treats season campaigns as the MVP model and defers mini-campaigns. |
-| Architecture closure | Ready For Narrow Corrected Slice | The technical spec now models a season-attached campaign and removes explicit status complexity from MVP. |
+| Execution phasing | Ready For Phase 4A | The phases doc now treats the backend campaign slice as complete and makes admin backend the next bounded step. |
+| Architecture closure | Ready For Phase 4A | The technical spec now models a season-attached campaign, records the merged backend slice, and defines admin-only pre-release UI gating. |
 | Open questions handling | Ready | The worklog now records the corrected model plus the remaining non-blocking questions. |
-| Blocking research closure | Ready For Narrow Corrected Slice | The product-intent correction is closed for this branch. |
-| Test planning | Ready For Narrow Corrected Slice | Test planning is now framed against campaign boundaries rather than week boundaries. |
-| Documentation impact plan | Partial | The likely doc surfaces are known, but the planning correction needs to land first. |
+| Blocking research closure | Ready For Phase 4A | The product-intent correction is closed for this branch. |
+| Test planning | Ready For Phase 4A | Test planning is now framed against admin backend contracts as the next slice. |
+| Documentation impact plan | Ready For Phase 4A | The likely doc surfaces are known for the next admin backend slice, including slice-local planning closure when readiness state changes. |
 
 ## Must Resolve Before Broad Implementation
 
@@ -86,22 +86,22 @@ Explorer has completed the narrow Phase 1 webhook-orchestration slice that prese
 | Status | Ready |
 | Gate | Must Resolve |
 | Why it matters | The team needs a shared rule for what can proceed now versus what must wait for the season-model correction. |
-| Evidence | The implemented webhook seam remains valid, and the next slice is now re-approved against the corrected season campaign model. |
-| Acceptance criteria | The readiness artifacts clearly state that Explorer is ready for one narrow corrected implementation slice and identify what remains out of scope. |
-| Next action | Keep the current go decision updated as additional corrected Explorer slices are approved or deferred. |
+| Evidence | The implemented webhook seam remains valid, the backend campaign slice is merged, and the next slice is now re-approved as Phase 4A admin backend work against the corrected season campaign model. |
+| Acceptance criteria | The readiness artifacts clearly state that Explorer is ready for one bounded admin-backend slice next and identify what remains out of scope. |
+| Next action | Keep the current go decision updated as additional corrected Explorer slices are approved or deferred, and close slice-local planning state in the implementation PR when the slice changes readiness or phase status. |
 
-## Should Resolve Before Phase 2 Starts
+## Should Resolve Before 4A And 4B Expand
 
 ### 1. Backend Test Organization
 
 | Field | Value |
 | --- | --- |
-| Status | Ready For Narrow Corrected Slice |
+| Status | Ready For Phase 4A |
 | Gate | Should Resolve |
 | Why it matters | The repo already has a strong backend test pattern. Explorer should fit it rather than improvise. |
 | Evidence | Existing tests under `server/src/__tests__` use the in-memory [setupTestDb](../../server/src/__tests__/setupTestDb.ts) pattern and helper utilities. |
-| Acceptance criteria | The implementation plan names where Explorer service, router, and integration tests will live and states that they will use the existing in-memory SQLite setup against campaign boundaries unless a stronger reason appears. |
-| Next action | Use the existing in-memory backend test pattern for corrected campaign service and router coverage. |
+| Acceptance criteria | The implementation plan names where Explorer admin service, router, and integration tests will live and states that they will use the existing in-memory SQLite setup unless a stronger reason appears. |
+| Next action | Use the existing in-memory backend test pattern for 4A service and router coverage. |
 
 ### 2. E2E Data Strategy
 
@@ -112,18 +112,18 @@ Explorer has completed the narrow Phase 1 webhook-orchestration slice that prese
 | Why it matters | Explorer UI and admin flows will need end-to-end coverage, and the repository already enforces a separate E2E database model. |
 | Evidence | [AGENTS.md](../../AGENTS.md) defines `wmv_e2e.db` as the dedicated E2E environment and warns against mixing databases. |
 | Acceptance criteria | The implementation plan explains how Explorer E2E scenarios will be created and validated without relying on accidental shared state. |
-| Next action | Provision Explorer campaign E2E data intentionally during setup or controlled fixtures. |
+| Next action | Provision Explorer campaign E2E data intentionally during setup or controlled fixtures before admin UI or athlete-facing E2E coverage starts. |
 
 ### 3. Documentation Impact Plan
 
 | Field | Value |
 | --- | --- |
-| Status | Ready For Narrow Corrected Slice |
+| Status | Ready For Phase 4A |
 | Gate | Should Resolve |
 | Why it matters | Explorer touches admin, athlete, API, database, and release-note surfaces. That work should be visible before coding. |
 | Evidence | Likely doc surfaces already exist in `ADMIN_GUIDE.md`, `docs/API.md`, `docs/DATABASE_DESIGN.md`, `docs-site/`, `CHANGELOG.md`, and `VERSION`, but the release-note files should wait for the final pre-commit pass of a user-facing slice. |
-| Acceptance criteria | The worklog or implementation slice names the docs expected to change when the slice lands. |
-| Next action | Add a documentation-impact checklist to the worklog. |
+| Acceptance criteria | The worklog or implementation slice names the docs expected to change when the slice lands, including any slice-local planning docs needed to close the state transition. |
+| Next action | Keep the documentation-impact checklist current and let implementation PRs carry the minimal planning updates needed to reflect completed slice state. |
 
 ### 4. Smallest End-To-End Slice
 
@@ -134,7 +134,7 @@ Explorer has completed the narrow Phase 1 webhook-orchestration slice that prese
 | Why it matters | Explorer should not start with a multi-surface implementation burst. |
 | Evidence | The worklog now records the completed Phase 1 webhook-orchestrator slice, including validation expectations and explicit out-of-scope items. |
 | Acceptance criteria | One narrow slice was named, bounded, tied to Phase 1, and validated through the focused webhook regression tests. |
-| Next action | Keep later slices equally narrow and tie the next PR to the corrected campaign model instead of proceeding with the weekly-first plan. |
+| Next action | Keep later slices equally narrow and tie the next PR to 4A admin backend instead of reopening already-merged backend work. |
 
 ## Safe To Defer If Recorded Explicitly
 
@@ -155,13 +155,16 @@ Before any Explorer implementation slice starts, it should explicitly reference:
 4. The expected validation path, such as backend tests, E2E checks, linting, typechecking, build verification, or documentation updates.
 5. The documentation surfaces expected to change for that slice.
 
+If a slice is expected to change the approved next step, readiness wording, or phase completion state, its implementation brief should also say whether the dev-agent is expected to update those planning docs before the PR is complete.
+
 ## Sign-Off
 
 | Decision | Current State |
 | --- | --- |
 | Phase 1 Complete | Yes |
 | Season-Campaign Correction Landed | Yes |
-| Ready For Narrow Corrected Implementation Slice | Yes |
+| Backend Campaign Slice Merged | Yes |
+| Ready For Phase 4A Admin Backend Slice | Yes |
 | Ready For Broad Feature Implementation | No |
 
-If this file says anything stronger than **Phase 1 Complete; Season-Campaign Correction Landed; Ready For Narrow Corrected Implementation Slice**, the linked worklog should show exactly what changed to justify that shift.
+If this file says anything stronger than **Phase 1 Complete; Season-Campaign Correction Landed; Backend Campaign Slice Merged; Ready For Phase 4A Admin Backend Slice**, the linked worklog should show exactly what changed to justify that shift.

--- a/docs/prds/wmv-explorer-readiness-checklist.md
+++ b/docs/prds/wmv-explorer-readiness-checklist.md
@@ -79,7 +79,7 @@ Explorer has completed the narrow Phase 1 webhook-orchestration slice that prese
 | Acceptance criteria | One section in the worklog or readiness checklist lists all unresolved questions, their current status, and whether they block implementation. |
 | Next action | Seed the worklog with a dedicated open-questions section and keep it current. |
 
-### 5. Phase 1 And Phase 2 Boundary
+### 5. Phase 1 To Phase 4A Boundary
 
 | Field | Value |
 | --- | --- |

--- a/docs/prds/wmv-explorer-worklog.md
+++ b/docs/prds/wmv-explorer-worklog.md
@@ -4,15 +4,15 @@ This worklog is the active operating log for Explorer. The readiness checklist i
 
 ## Current Focus
 
-- Correct the planning set from a weekly-first Explorer model to a season-campaign-first MVP.
-- Remove optional mini-campaign and status-workflow complexity from MVP planning.
-- Produce the smallest safe implementation slice against the corrected season campaign model.
+- Prepare Phase 4A as a narrow admin-backend slice.
+- Keep any pre-release Explorer UI admin-gated until there is an explicit end-user release decision.
+- Keep the next handoff and implementation brief aligned with the merged backend state.
 
 ## Current Go State
 
-- **Readiness:** Phase 1 Complete; Season-Campaign Correction Landed; Ready For Narrow Corrected Implementation Slice
-- **Immediate scope:** one bounded implementation PR correcting the Explorer data model and matching/query paths to a season-attached campaign
-- **Not yet in scope:** mini-campaigns, explicit publish-status workflows, full admin UI, or full athlete hub UI
+- **Readiness:** Phase 1 Complete; Season-Campaign Correction Landed; Backend Campaign Slice Merged; Ready For Phase 4A Admin Backend Slice
+- **Immediate scope:** one bounded implementation PR for Explorer admin backend setup against the existing season-attached campaign model
+- **Not yet in scope:** public athlete-facing Explorer release, full admin UI, mini-campaigns, or explicit publish-status workflows
 
 ## Decisions Made
 
@@ -29,6 +29,11 @@ This worklog is the active operating log for Explorer. The readiness checklist i
 - MVP does not currently justify explicit Explorer `draft` / `active` / `archived` workflow complexity; season dates and destination presence should control visibility unless later implementation proves otherwise.
 - V1 athlete campaign summary is computed on read, with `ExplorerDestinationMatch` as the durable source of truth.
 - V1 destination metadata uses a hybrid strategy: reuse shared segment data when present, while storing Explorer-local cached display metadata and source URL values for stable setup and rendering.
+- If Explorer UI is touched before public release, it stays admin-only and does not add public navigation.
+- V1 permits exactly one Explorer campaign per season; this should be enforced in the admin backend without blocking future multi-season support.
+- 4A destination authoring accepts validated Strava segment URLs, not raw segment IDs.
+- If URL parsing succeeds but live Strava metadata enrichment fails, destination creation still succeeds with stored segment ID and source URL.
+- Refresh and backfill admin mutations are deferred out of 4A.
 
 ## Open Questions
 
@@ -40,8 +45,13 @@ This worklog is the active operating log for Explorer. The readiness checklist i
 | Should athlete campaign summaries be computed on read or stored in a cached summary table for v1? | Closed For v1 | No | V1 uses computed-on-read summaries with `ExplorerDestinationMatch` as the durable source of truth. |
 | Should Explorer reuse the existing segment table, store Explorer-local cached metadata, or do both? | Closed For v1 | No | V1 uses a hybrid strategy: shared segment reuse when present plus Explorer-local cached display metadata. |
 | How should webhook regression protection be documented for the delegated-handler refactor? | Closed For Phase 1 | No | The preservation target now lives in this worklog and the handler seam is covered by focused webhook tests. |
-| What is the exact E2E data strategy for Explorer flows? | Open | No | Should be defined before Phase 2 starts. |
+| What is the exact E2E data strategy for Explorer flows? | Open | No | Should be defined before athlete-facing or admin UI E2E coverage starts. |
 | Should deleted source activities retract Explorer completions in v1? | Open | No | Safe to defer if behavior is documented. |
+| Should pre-release Explorer UI remain admin-gated until launch approval? | Closed | No | Yes. Do not expose Explorer UI to non-admin users before a viable release decision. |
+| Should there be more than one Explorer campaign per season in v1? | Closed | No | No. Enforce one campaign per season in 4A while leaving room for future multi-season support. |
+| Should 4A accept raw segment IDs as an admin authoring input? | Closed | No | No. Use validated Strava segment URLs only in the 4A backend contract. |
+| What happens if URL parsing succeeds but live metadata enrichment fails? | Closed | No | Allow creation and preserve segment ID plus source URL for later repair. |
+| Do refresh and backfill admin mutations belong in 4A? | Closed | No | No. Defer them to a later admin slice. |
 
 ## Blockers
 
@@ -55,7 +65,7 @@ Resolution:
 
 - These planning blockers are now closed on this branch.
 
-### Should Resolve Before Phase 2
+### Should Resolve Before 4A And 4B Grow Broader
 
 1. Resolved for the next slice: Explorer backend tests should live under `server/src/__tests__` and use the existing in-memory SQLite pattern.
 2. Resolved for the next slice: Explorer E2E scenarios should provision their own campaign data intentionally.
@@ -107,32 +117,44 @@ The current preservation target is backed by:
 3. [server/src/__tests__/webhookProcessor.segmentEffortsRetry.test.ts](../../server/src/__tests__/webhookProcessor.segmentEffortsRetry.test.ts)
 4. [server/src/__tests__/webhookAdminRouter.replayEvent.test.ts](../../server/src/__tests__/webhookAdminRouter.replayEvent.test.ts)
 
-### Planning Correction: Season Campaign Model
+### Completed Backend Campaign Slice
 
-- Phase: Phase 2
-- Goal: change the source-of-truth planning set so Explorer is a season-attached campaign, not a weekly-first challenge model
-- Why this matters: the current implementation branch and planning docs were shaped around the wrong primary concept
+- Phase: Phase 3
+- Goal: establish the season-attached Explorer campaign backend model, matching flow, and initial read surface as the base for later admin and hub work
+- Why this matters: 4A should now build on the merged backend slice rather than reopening campaign-model work
 
 ### Recommended Next PR
 
-- Start from updated `main` on a dedicated implementation branch only after this planning correction lands.
-- Keep the next implementation PR scoped to the corrected campaign model only:
-	- campaign schema attached to `season`
-	- destination and match schema keyed to the campaign
-	- matching service correction from week windows to season windows
-	- corrected query routes for active campaign and athlete progress
-	- backend tests for campaign boundaries, idempotency, and add-destination behavior
+- Start from updated `main` on a dedicated implementation branch.
+- Keep the next implementation PR scoped to Phase 4A admin backend only:
+	- `explorerAdmin` service and router surface for campaign creation and add-destination authoring
+	- service and database enforcement for one campaign per season
+	- Strava segment URL parsing and validation for destination setup
+	- stable source URL plus cached metadata persistence needed for authoring
+	- metadata-enrichment fallback that still allows creation when parsing succeeds
+	- backend tests for auth, validation, campaign creation, and in-season destination additions
 - Keep out of scope for that PR:
+	- full admin UI
+	- public athlete hub UI
+	- public navigation to Explorer
 	- mini-campaigns inside a season
 	- explicit Explorer publish-status workflows
-	- full admin UI
-	- full athlete hub UI
+	- refresh and backfill mutations
+
+## 4A Planning Inputs Closed
+
+These decisions are now closed for the 4A implementation handoff.
+
+1. Enforce one campaign per season in 4A. Prefer database protection plus service-layer validation.
+2. Accept validated Strava segment URLs only in 4A.
+3. Allow creation when URL parsing succeeds even if live metadata enrichment fails.
+4. Defer refresh and backfill mutations to a later admin slice.
 
 ## Issue Candidates
 
-- Correct Explorer planning set to season-campaign-first MVP
-- Implement corrected Explorer campaign schema and matching service
-- Re-scope Explorer admin and hub work to the corrected campaign model
+- Implement Explorer admin backend setup
+- Add admin-gated Explorer setup UI
+- Prepare the athlete-facing Explorer hub for a later release gate
 
 ## Documentation Impact Checklist
 
@@ -154,3 +176,4 @@ Only in the final pre-commit pass for a user-facing implementation commit, also 
 - Use the readiness checklist as the gate.
 - Use the execution briefing as the operational guide for VS Code, Copilot CLI, and cloud agents.
 - Promote items from this worklog into GitHub issues only when they are stable, bounded, and ready to be worked independently.
+- When an approved implementation slice changes the readiness state, phase status, or recommended next slice, the implementation PR should include the narrow planning-doc updates needed to close that slice. Hand back to `explorer-planner` only if closing the slice requires new product decisions, new slice boundaries, or broader planning reconciliation.


### PR DESCRIPTION
## Summary
- align the Explorer planning set with the merged backend campaign slice
- define Phase 4A as the next admin-backend slice and Phase 4B as admin-gated UI
- record the approved 4A decisions for campaign cardinality, URL-only authoring, metadata fallback, and deferred refresh
- clarify that implementation PRs should close narrow planning-state updates when a slice changes readiness or next-step guidance

## Validation
- pre-commit hook ran lint and typecheck successfully during commit
