### PR TITLE
feat: add Explorer admin setup UI

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -277,6 +277,7 @@ npm run test:e2e:ui        # Interactive debugging
 
 1. **Run checks:**
    ```bash
+  npm run audit      # Audit frontend + backend dependencies
    npm run lint       # Lint both frontend + backend
    npm run typecheck  # Typecheck both
    npm test           # Run frontend + backend tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,11 +22,8 @@ jobs:
         run: |
           npm ci
 
-      - name: Audit dependencies (frontend)
-        run: npm audit --audit-level critical
-
-      - name: Audit dependencies (backend)
-        run: cd server && npm audit --audit-level critical
+      - name: Audit dependencies
+        run: npm run audit
 
       - name: Typecheck (frontend + server)
         run: npm run typecheck

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
           cache-dependency-path: 'docs-site/package.json'
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,8 @@ npm run test:e2e:ui      # Playwright UI mode (interactive debugging)
 
 **Important:** Treat Playwright as a dedicated E2E environment, not as an implicit extension of normal local development. `npm run test:e2e` sets `ENV_FILE` for the Playwright process, but the frontend and backend still need to be started with the intended E2E wiring; the harness should declare that wiring explicitly and fail fast when it is missing.
 
+For UI work, prefer focused unit tests first and add Playwright only where browser integration is the point of the change. Use the hardened E2E harness for auth, route wiring, and full-stack mutation flows that unit tests cannot prove reliably.
+
 ### Building & Deployment
 
 ```bash
@@ -39,6 +41,8 @@ npm run lint         # Lint both frontend + backend
 npm run typecheck    # Typecheck both frontend + backend
 npm run audit        # Security audit (frontend + backend)
 ```
+
+Before merging or opening a substantive PR, run `npm run audit` locally alongside lint, typecheck, tests, and build so CI is not the first place dependency vulnerabilities are discovered.
 
 ## Database Files & Environments
 

--- a/docs/prds/wmv-explorer-destinations-phases.md
+++ b/docs/prds/wmv-explorer-destinations-phases.md
@@ -123,7 +123,7 @@ Implementation notes:
 
 Goal: expose the approved admin backend capabilities through an admin-only WMV surface once the E2E harness is portable enough to support repeatable regression coverage.
 
-Status: next approved slice after the 4B-1 harness-only PR or commit set is separated cleanly from the mixed working tree.
+Status: complete in the current local implementation work as a minimal admin-gated setup surface. The next step should return to planning for a follow-on admin UX refinement slice rather than continue broadening this implementation branch opportunistically.
 
 Scope:
 
@@ -133,6 +133,10 @@ Scope:
 - Keep all Explorer entry points hidden from non-admin users until there is an explicit release decision for the athlete-facing hub
 - Campaign setup attached to a season
 - Add-destination workflow that works before or during the season
+
+Follow-on planning note:
+
+- Treat richer admin guidance, stronger client-side segment validation, and broader card or component-system refinement as the next planning surface, not as open-ended scope creep inside 4B-2.
 
 ## Phase 5: Explorer Hub MVP
 

--- a/docs/prds/wmv-explorer-readiness-checklist.md
+++ b/docs/prds/wmv-explorer-readiness-checklist.md
@@ -17,21 +17,21 @@ The ideas backlog is intentionally excluded from v1 implementation scope. It exi
 
 ## Current Go Decision
 
-**Status:** Phase 1 Complete; Season-Campaign Correction Landed; Backend Campaign Slice Merged; Phase 4A Admin Backend Complete; Phase 4B-1 E2E Harness Hardening Validated Locally; Ready For Phase 4B-2 Admin UI
+**Status:** Phase 1 Complete; Season-Campaign Correction Landed; Backend Campaign Slice Merged; Phase 4A Admin Backend Complete; Phase 4B-1 E2E Harness Hardening Merged; Phase 4B-2 Minimal Admin UI Implemented Locally; Ready For Admin UX Refinement Planning
 
-Explorer has completed the narrow Phase 1 webhook-orchestration slice that preserves current competition behavior while introducing delegated in-process handlers. The planning set on this branch now corrects the MVP to a season-campaign-first model attached to an existing WMV season, with optional mini-campaigns and explicit publish-status workflows deferred. The backend campaign slice is merged, the 4A admin backend slice is landed, and the 4B-1 portable harness work is now validated locally with full tests, build, lint, typecheck, and Playwright coverage green. The next approved implementation work is the admin-gated 4B-2 UI slice, but the current mixed working tree should be separated so the harness changes land as their own coherent PR or commit set first.
+Explorer has completed the narrow Phase 1 webhook-orchestration slice that preserves current competition behavior while introducing delegated in-process handlers. The planning set on this branch now corrects the MVP to a season-campaign-first model attached to an existing WMV season, with optional mini-campaigns and explicit publish-status workflows deferred. The backend campaign slice is merged, the 4A admin backend slice is landed, the 4B-1 portable harness work is merged, and the 4B-2 admin-gated UI now exists as a minimal setup surface with local unit, backend, E2E, lint, typecheck, build, and audit validation. The next recommended work is to return to planning for a bounded admin UX refinement slice rather than continue broadening 4B-2 ad hoc.
 
 ## Current Status Summary
 
 | Area | Status | Notes |
 | --- | --- | --- |
 | Product framing | Ready | The PRD is clear on goals, users, must-haves, non-goals, and success criteria. |
-| Execution phasing | Ready For Phase 4B-2 | The phases doc now treats 4B-1 harness hardening as validated locally and makes the admin-gated UI the next bounded step after the harness-only changes are separated cleanly. |
-| Architecture closure | Ready For Phase 4B-2 | The technical spec now models a season-attached campaign, records the merged backend and 4A admin contracts, and the harness-first hardening work is complete enough to support the admin-only UI broadening next. |
+| Execution phasing | Ready For Next Planning Slice | The phases doc now treats 4B-2 as the minimal admin-gated UI completion point and sends the next work back through planning for admin UX refinement. |
+| Architecture closure | Ready For Next Planning Slice | The technical spec and landed slices are sufficient for a planning pass on the next admin UX improvement slice without reopening the campaign model or harness work. |
 | Open questions handling | Ready | The worklog now records the corrected model plus the remaining non-blocking questions. |
-| Blocking research closure | Ready For Phase 4B-2 | The product-intent correction is closed for this branch. |
-| Test planning | Ready For Phase 4B-2 | Portable harness hardening is now validated locally, so test planning can move back to the admin-gated UI slice on top of the stabilized harness. |
-| Documentation impact plan | Ready For Phase 4B-2 | The harness docs are updated, and the next doc surfaces are the admin UI follow-on plus the harness/UI branch split note. |
+| Blocking research closure | Ready For Next Planning Slice | The product-intent correction is closed for this branch. |
+| Test planning | Ready For Next Planning Slice | The minimal admin UI is now validated, so the next test-planning work should attach to the separate admin UX refinement slice. |
+| Documentation impact plan | Ready For Next Planning Slice | The next documentation impact is the planning handoff for admin UX refinement rather than more broadening of the current implementation slice. |
 
 ## Must Resolve Before Broad Implementation
 

--- a/docs/prds/wmv-explorer-worklog.md
+++ b/docs/prds/wmv-explorer-worklog.md
@@ -4,15 +4,15 @@ This worklog is the active operating log for Explorer. The readiness checklist i
 
 ## Current Focus
 
-- Preserve the completed 4B-1 harness work as its own clean commit or PR slice.
-- Resume Phase 4B-2 as the next coding slice only after the harness-only file set is separated from the current mixed working tree.
+- Close out Phase 4B-2 as the minimal admin-gated Explorer setup surface.
+- Prepare a planning handoff for the next admin UX refinement slice instead of broadening 4B-2 in-place.
 - Keep any pre-release Explorer UI admin-gated until there is an explicit end-user release decision.
 - Keep the next handoff and implementation brief aligned with the landed backend authoring contract.
 
 ## Current Go State
 
-- **Readiness:** Phase 1 Complete; Season-Campaign Correction Landed; Backend Campaign Slice Merged; Phase 4A Admin Backend Complete; Phase 4B-1 E2E Harness Hardening Validated Locally; Ready For Phase 4B-2 Admin UI
-- **Immediate scope:** separate the current mixed work tree into a harness-only 4B-1 commit or PR set, then continue the admin-gated setup UI as 4B-2
+- **Readiness:** Phase 1 Complete; Season-Campaign Correction Landed; Backend Campaign Slice Merged; Phase 4A Admin Backend Complete; Phase 4B-1 E2E Harness Hardening Merged; Phase 4B-2 Minimal Admin UI Implemented Locally; Ready For Admin UX Refinement Planning
+- **Immediate scope:** land the minimal 4B-2 admin-gated setup surface, then return to planning for the next bounded admin UX slice
 - **Not yet in scope:** public athlete-facing Explorer release, public navigation to Explorer, mini-campaigns, or explicit publish-status workflows
 
 ## Decisions Made
@@ -139,19 +139,16 @@ The current preservation target is backed by:
 ### Recommended Next PR
 
 - Start from updated `main` on a dedicated implementation branch.
-- First preserve the completed Phase 4B-1 harness hardening changes as their own clean commit or PR set.
-- After that, keep the next implementation PR scoped to Phase 4B-2 admin-gated UI:
+- Keep the current implementation PR scoped to the minimal 4B-2 admin-gated UI surface:
 	- create-campaign and add-destination admin flows on top of the stabilized harness
 	- targeted browser coverage for the admin surface
 	- no public athlete-facing Explorer exposure
-	- slice-local planning updates only if 4B-2 changes readiness or the recommended next slice again
-- Keep out of scope for that PR:
-	- public athlete hub UI
-	- public navigation to Explorer
-	- mini-campaigns inside a season
-	- explicit Explorer publish-status workflows
-	- refresh and backfill mutations
-	- destination reorder, edit, or remove flows unless one proves necessary to keep the UI coherent
+	- slice-local planning updates that mark 4B-2 complete and hand back to planning for the next slice
+- The next planning pass should define a separate admin UX refinement slice for:
+	- clearer setup guidance and validation feedback
+	- stronger client-side segment URL assistance
+	- more intentional component reuse and card hierarchy aligned with the existing WMV surfaces
+	- any workflow changes beyond the minimal 4A contract exposure
 
 ### 4B-1 Harness Recommendation
 

--- a/e2e/tests/explorer-admin.authenticated.spec.ts
+++ b/e2e/tests/explorer-admin.authenticated.spec.ts
@@ -1,0 +1,78 @@
+import { test, expect, type Page } from '@playwright/test';
+import { loginAsE2EUser } from '../fixtures/test-helpers';
+
+async function selectFirstSeason(page: Page) {
+  const seasonSelect = page.getByTestId('season-select');
+  await expect(seasonSelect).toBeVisible();
+
+  const firstSeasonValue = await seasonSelect.locator('option').first().getAttribute('value');
+  expect(firstSeasonValue).not.toBeNull();
+
+  await seasonSelect.selectOption(firstSeasonValue!);
+}
+
+async function ensureCampaignExists(page: Page) {
+  if (await page.getByTestId('explorer-create-campaign-form').isVisible()) {
+    await page.getByTestId('explorer-create-campaign-button').click();
+  }
+
+  await expect(page.getByTestId('explorer-campaign-summary-card')).toBeVisible();
+}
+
+test.describe('Explorer Admin Setup', () => {
+  test.beforeEach(async ({ page }) => {
+    await loginAsE2EUser(page);
+  });
+
+  test('admin can open Explorer admin from the navbar menu', async ({ page }) => {
+    await page.goto('/leaderboard');
+    await page.getByRole('button', { name: 'Menu' }).click();
+    await page.locator('.dropdown-menu').getByRole('link', { name: 'Manage Explorer' }).click();
+
+    await expect(page).toHaveURL(/\/explorer-admin/);
+    await expect(page.getByTestId('explorer-admin-panel')).toBeVisible();
+  });
+
+  test('admin can create a campaign and add a destination', async ({ page }) => {
+    await page.goto('/explorer-admin');
+
+    await selectFirstSeason(page);
+
+    await expect(page.getByTestId('explorer-create-campaign-form')).toBeVisible();
+
+    await page.getByTestId('explorer-display-name-input').fill('Fall 2025 Explorer');
+    await page.getByTestId('explorer-rules-blurb-input').fill('Ride each featured segment once.');
+    await page.getByTestId('explorer-create-campaign-button').click();
+
+    await expect(page.getByTestId('explorer-admin-message')).toContainText('Explorer campaign created');
+    await expect(page.getByTestId('explorer-campaign-name')).toContainText('Fall 2025 Explorer');
+
+    await page.getByTestId('explorer-source-url-input').fill('https://www.strava.com/segments/2234642');
+    await page.getByTestId('explorer-display-label-input').fill('Box Hill opener');
+    await page.getByTestId('explorer-add-destination-button').click();
+
+    await expect(page.getByTestId('explorer-admin-message')).toContainText('Destination added');
+    await expect(page.getByTestId('explorer-destination-list')).toContainText('Box Hill opener');
+    await expect(page.getByTestId('explorer-destination-list')).toContainText('Segment 2234642');
+  });
+
+  test('admin sees invalid URL and duplicate destination states', async ({ page }) => {
+    await page.goto('/explorer-admin');
+
+    await selectFirstSeason(page);
+
+    await ensureCampaignExists(page);
+
+    await page.getByTestId('explorer-source-url-input').fill('https://www.strava.com/routes/2234642');
+    await page.getByTestId('explorer-add-destination-button').click();
+    await expect(page.getByTestId('explorer-admin-message')).toContainText('valid Strava segment URL');
+
+    await page.getByTestId('explorer-source-url-input').fill('https://www.strava.com/segments/12345');
+    await page.getByTestId('explorer-add-destination-button').click();
+    await expect(page.getByTestId('explorer-admin-message')).toContainText('Destination added');
+
+    await page.getByTestId('explorer-source-url-input').fill('https://www.strava.com/segments/12345');
+    await page.getByTestId('explorer-add-destination-button').click();
+    await expect(page.getByTestId('explorer-admin-message')).toContainText('already exists');
+  });
+});

--- a/server/jest.config.js
+++ b/server/jest.config.js
@@ -40,6 +40,9 @@ module.exports = {
     '/server/src/routes/seasons\\.ts$' // Not a test file
   ],
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
+  modulePathIgnorePatterns: [
+    '<rootDir>/dist/'
+  ],
   // Transform ESM packages (don't ignore them in node_modules)
   transformIgnorePatterns: [
     'node_modules/(?!(@google/genai|p-retry|is-network-error)/)'

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -5599,9 +5599,9 @@
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
@@ -8096,9 +8096,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
-      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
+      "integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {

--- a/server/package.json
+++ b/server/package.json
@@ -25,6 +25,10 @@
   "engines": {
     "node": ">=24 <25"
   },
+  "overrides": {
+    "protobufjs": "7.5.5",
+    "follow-redirects": "1.16.0"
+  },
   "dependencies": {
     "@google/genai": "^1.49.0",
     "@trpc/server": "^11.16.0",

--- a/server/src/__tests__/trpc/explorerAdminRouter.test.ts
+++ b/server/src/__tests__/trpc/explorerAdminRouter.test.ts
@@ -61,6 +61,24 @@ describe('explorerAdminRouter', () => {
     ).rejects.toThrow('UNAUTHORIZED');
   });
 
+  it('requires admin auth to read a season campaign', async () => {
+    const seasonRecord = createSeason(drizzleDb, 'Explorer Season');
+    const caller = getCaller(false);
+
+    await expect(
+      caller.explorerAdmin.getCampaignForSeason({ seasonId: seasonRecord.id })
+    ).rejects.toThrow('UNAUTHORIZED');
+  });
+
+  it('returns null when a season has no explorer campaign', async () => {
+    const seasonRecord = createSeason(drizzleDb, 'Explorer Season');
+    const caller = getCaller(true);
+
+    await expect(
+      caller.explorerAdmin.getCampaignForSeason({ seasonId: seasonRecord.id })
+    ).resolves.toBeNull();
+  });
+
   it('creates a campaign when called by an admin', async () => {
     const seasonRecord = createSeason(drizzleDb, 'Explorer Season');
     const caller = getCaller(true);
@@ -141,6 +159,34 @@ describe('explorerAdminRouter', () => {
       .where(eq(explorerDestination.id, result.id))
       .get();
     expect(stored?.display_order).toBe(0);
+  });
+
+  it('returns an admin campaign view with destinations for the selected season', async () => {
+    const seasonRecord = createSeason(drizzleDb, 'Explorer Season');
+    const campaign = createExplorerCampaign(drizzleDb, {
+      seasonId: seasonRecord.id,
+      displayName: 'Explorer 2026',
+      rulesBlurb: 'Ride every destination once.',
+    });
+    const caller = getCaller(true);
+    jest.spyOn(SegmentService.prototype, 'fetchAndStoreSegmentMetadata').mockResolvedValue({
+      strava_segment_id: '12744502',
+      name: 'Mocked Segment',
+    } as any);
+
+    await caller.explorerAdmin.addDestination({
+      explorerCampaignId: campaign.id,
+      sourceUrl: 'https://www.strava.com/segments/12744502',
+      displayLabel: 'Hilltown opener',
+    });
+
+    const result = await caller.explorerAdmin.getCampaignForSeason({ seasonId: seasonRecord.id });
+
+    expect(result).not.toBeNull();
+    expect(result?.name).toBe('Explorer 2026');
+    expect(result?.rulesBlurb).toBe('Ride every destination once.');
+    expect(result?.destinations).toHaveLength(1);
+    expect(result?.destinations[0]?.displayLabel).toBe('Hilltown opener');
   });
 
   it('allows destination creation when metadata enrichment falls back to placeholder data', async () => {

--- a/server/src/routers/explorerAdmin.ts
+++ b/server/src/routers/explorerAdmin.ts
@@ -2,6 +2,7 @@ import { TRPCError } from '@trpc/server';
 import { z } from 'zod';
 import { router, adminProcedure } from '../trpc/init';
 import { ExplorerAdminService } from '../services/ExplorerAdminService';
+import { ExplorerQueryService } from '../services/ExplorerQueryService';
 
 function mapExplorerAdminError(error: unknown): TRPCError {
   const message = error instanceof Error ? error.message : 'Explorer admin operation failed';
@@ -30,6 +31,15 @@ function mapExplorerAdminError(error: unknown): TRPCError {
 }
 
 export const explorerAdminRouter = router({
+  getCampaignForSeason: adminProcedure
+    .input(z.object({
+      seasonId: z.number().int().positive(),
+    }))
+    .query(({ ctx, input }) => {
+      const service = new ExplorerQueryService(ctx.orm);
+      return service.getCampaignForSeason(input.seasonId);
+    }),
+
   createCampaign: adminProcedure
     .input(z.object({
       seasonId: z.number().int().positive(),

--- a/server/src/routers/explorerAdmin.ts
+++ b/server/src/routers/explorerAdmin.ts
@@ -35,9 +35,14 @@ export const explorerAdminRouter = router({
     .input(z.object({
       seasonId: z.number().int().positive(),
     }))
-    .query(({ ctx, input }) => {
+    .query(async ({ ctx, input }) => {
       const service = new ExplorerQueryService(ctx.orm);
-      return service.getCampaignForSeason(input.seasonId);
+
+      try {
+        return await service.getCampaignForSeason(input.seasonId);
+      } catch (error) {
+        throw mapExplorerAdminError(error);
+      }
     }),
 
   createCampaign: adminProcedure

--- a/server/src/services/ExplorerAdminService.ts
+++ b/server/src/services/ExplorerAdminService.ts
@@ -25,6 +25,17 @@ interface AddDestinationInput {
   preferredAthleteId?: string;
 }
 
+interface AddDestinationResult {
+  id: number;
+  explorer_campaign_id: number;
+  strava_segment_id: string;
+  source_url: string | null;
+  cached_name: string | null;
+  display_label: string | null;
+  display_order: number;
+  usedPlaceholderMetadata: boolean;
+}
+
 function normalizeNullableText(value?: string | null): string | null {
   const trimmed = value?.trim();
   return trimmed ? trimmed : null;
@@ -91,7 +102,7 @@ export class ExplorerAdminService {
       .get();
   }
 
-  async addDestination(input: AddDestinationInput) {
+  async addDestination(input: AddDestinationInput): Promise<AddDestinationResult> {
     const campaignRecord = this.db
       .select({
         id: explorerCampaign.id,
@@ -137,7 +148,7 @@ export class ExplorerAdminService {
 
     const nextDisplayOrder = (orderRecord?.maxDisplayOrder ?? -1) + 1;
 
-    return this.db
+    const createdDestination = this.db
       .insert(explorerDestination)
       .values({
         explorer_campaign_id: input.explorerCampaignId,
@@ -149,7 +160,12 @@ export class ExplorerAdminService {
       })
       .returning()
       .get();
+
+    return {
+      ...createdDestination,
+      usedPlaceholderMetadata: !metadata?.name,
+    };
   }
 }
 
-export type { CreateCampaignInput, AddDestinationInput, ExplorerSegmentMetadataService };
+export type { CreateCampaignInput, AddDestinationInput, AddDestinationResult, ExplorerSegmentMetadataService };

--- a/server/src/services/ExplorerQueryService.ts
+++ b/server/src/services/ExplorerQueryService.ts
@@ -29,6 +29,10 @@ interface ActiveExplorerCampaignView {
   destinations: ExplorerDestinationView[];
 }
 
+interface ExplorerAdminCampaignView extends ActiveExplorerCampaignView {
+  seasonId: number;
+}
+
 interface ExplorerProgressDestinationView extends ExplorerDestinationView {
   completed: boolean;
   matchedAt: number | null;
@@ -70,6 +74,64 @@ function resolveCampaignName(displayName: string | null, seasonName: string): st
 
 export class ExplorerQueryService {
   constructor(private readonly db: BetterSQLite3Database) {}
+
+  getCampaignForSeason(seasonId: number): ExplorerAdminCampaignView | null {
+    const campaignRecord = this.db
+      .select({
+        id: explorerCampaign.id,
+        season_id: explorerCampaign.season_id,
+        display_name: explorerCampaign.display_name,
+        rules_blurb: explorerCampaign.rules_blurb,
+        season_name: season.name,
+        season_start_at: season.start_at,
+        season_end_at: season.end_at,
+      })
+      .from(explorerCampaign)
+      .innerJoin(season, eq(explorerCampaign.season_id, season.id))
+      .where(eq(explorerCampaign.season_id, seasonId))
+      .get();
+
+    if (!campaignRecord) {
+      return null;
+    }
+
+    const destinations = this.db
+      .select({
+        id: explorerDestination.id,
+        strava_segment_id: explorerDestination.strava_segment_id,
+        display_label: explorerDestination.display_label,
+        cached_name: explorerDestination.cached_name,
+        source_url: explorerDestination.source_url,
+        surface_type: explorerDestination.surface_type,
+        category: explorerDestination.category,
+        display_order: explorerDestination.display_order,
+        segment_name: segment.name,
+      })
+      .from(explorerDestination)
+      .leftJoin(segment, eq(explorerDestination.strava_segment_id, segment.strava_segment_id))
+      .where(eq(explorerDestination.explorer_campaign_id, campaignRecord.id))
+      .orderBy(asc(explorerDestination.display_order), asc(explorerDestination.id))
+      .all();
+
+    return {
+      id: campaignRecord.id,
+      seasonId: campaignRecord.season_id,
+      name: resolveCampaignName(campaignRecord.display_name, campaignRecord.season_name),
+      seasonName: campaignRecord.season_name,
+      startAt: campaignRecord.season_start_at,
+      endAt: campaignRecord.season_end_at,
+      rulesBlurb: campaignRecord.rules_blurb,
+      destinations: destinations.map((destination) => ({
+        id: destination.id,
+        stravaSegmentId: destination.strava_segment_id,
+        displayLabel: resolveDestinationLabel(destination),
+        sourceUrl: destination.source_url,
+        surfaceType: destination.surface_type,
+        category: destination.category,
+        displayOrder: destination.display_order,
+      })),
+    };
+  }
 
   async getActiveCampaign(
     nowTimestamp: number = Math.floor(Date.now() / 1000)
@@ -233,4 +295,4 @@ export class ExplorerQueryService {
   }
 }
 
-export type { ActiveExplorerCampaignView, ExplorerCampaignProgressView };
+export type { ActiveExplorerCampaignView, ExplorerAdminCampaignView, ExplorerCampaignProgressView };

--- a/server/src/services/ExplorerQueryService.ts
+++ b/server/src/services/ExplorerQueryService.ts
@@ -29,9 +29,7 @@ interface ActiveExplorerCampaignView {
   destinations: ExplorerDestinationView[];
 }
 
-interface ExplorerAdminCampaignView extends ActiveExplorerCampaignView {
-  seasonId: number;
-}
+type ExplorerAdminCampaignView = ActiveExplorerCampaignView;
 
 interface ExplorerProgressDestinationView extends ExplorerDestinationView {
   completed: boolean;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import ParticipantStatus from './components/ParticipantStatus';
 import ManageSegments from './components/ManageSegments';
 import SeasonManager from './components/SeasonManager';
 import WebhookManagementPanel from './components/WebhookManagementPanel';
+import ExplorerAdminPanel from './components/ExplorerAdminPanel';
 import StravaConnectInfoBox from './components/StravaConnectInfoBox';
 import StravaClubJoinPrompt from './components/StravaClubJoinPrompt';
 import AboutPage from './components/AboutPage';
@@ -28,7 +29,7 @@ import { httpBatchLink } from '@trpc/client';
 import { trpc } from './utils/trpc';
 import { Season, Week } from './types'; // Import shared types
 
-type ViewMode = 'leaderboard' | 'admin' | 'roles' | 'participants' | 'segments' | 'seasons' | 'webhooks' | 'about' | 'profile' | 'chat' | 'chain-checker';
+type ViewMode = 'leaderboard' | 'admin' | 'explorer-admin' | 'roles' | 'participants' | 'segments' | 'seasons' | 'webhooks' | 'about' | 'profile' | 'chat' | 'chain-checker';
 
 interface LeaderboardViewProps {
   seasons: Season[];
@@ -187,6 +188,7 @@ function AppContent() {
   const viewMode = useMemo((): ViewMode => {
     const path = location.pathname;
     if (path.startsWith('/admin')) return 'admin';
+    if (path.startsWith('/explorer-admin')) return 'explorer-admin';
     if (path.startsWith('/roles')) return 'roles';
     if (path.startsWith('/participants')) return 'participants';
     if (path.startsWith('/segments')) return 'segments';
@@ -206,6 +208,7 @@ function AppContent() {
   const getPageTitle = (mode: ViewMode) => {
     switch (mode) {
       case 'admin': return 'Manage Competition';
+      case 'explorer-admin': return 'Manage Explorer';
       case 'roles': return 'Manage Roles';
       case 'participants': return 'Participant Status';
       case 'segments': return 'Manage Segments';
@@ -256,6 +259,14 @@ function AppContent() {
           <Route path="/admin" element={
             <AdminPanel 
               onFetchResults={() => utils.leaderboard.getWeekLeaderboard.invalidate()}
+              seasons={seasons}
+              selectedSeasonId={adminSeasonId}
+              onSeasonChange={setAdminSeasonId}
+            />
+          } />
+          <Route path="/explorer-admin" element={
+            <ExplorerAdminPanel
+              isAdmin={isAdmin}
               seasons={seasons}
               selectedSeasonId={adminSeasonId}
               onSeasonChange={setAdminSeasonId}

--- a/src/components/ExplorerAdminPanel.css
+++ b/src/components/ExplorerAdminPanel.css
@@ -1,0 +1,189 @@
+.explorer-admin-panel {
+  width: 100%;
+  max-width: 1080px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.explorer-admin-access-denied,
+.explorer-empty-state,
+.explorer-card,
+.explorer-season-summary {
+  background: #fff;
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  padding: 1.5rem;
+  box-shadow: 0 10px 28px rgba(15, 23, 42, 0.06);
+}
+
+.explorer-admin-access-denied {
+  text-align: center;
+}
+
+.explorer-admin-access-denied h2,
+.explorer-empty-state h2,
+.explorer-card h3,
+.explorer-season-summary h2 {
+  margin: 0 0 0.5rem;
+  color: #1f2937;
+}
+
+.explorer-message {
+  padding: 0.9rem 1rem;
+  border-radius: 10px;
+  font-weight: 600;
+}
+
+.explorer-message.success {
+  background: #dcfce7;
+  border: 1px solid #86efac;
+  color: #166534;
+}
+
+.explorer-message.error {
+  background: #fee2e2;
+  border: 1px solid #fca5a5;
+  color: #991b1b;
+}
+
+.explorer-message.info {
+  background: #fff7ed;
+  border: 1px solid #fdba74;
+  color: #9a3412;
+}
+
+.explorer-season-summary,
+.explorer-card-header,
+.explorer-destination-item {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.explorer-section-label {
+  margin: 0 0 0.35rem;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #f56004;
+}
+
+.explorer-season-window,
+.explorer-card-header p,
+.explorer-muted-copy,
+.explorer-rules-blurb,
+.explorer-destination-meta {
+  margin: 0;
+  color: #6b7280;
+}
+
+.explorer-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.explorer-form-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.explorer-form-group label {
+  font-weight: 700;
+  color: #1f2937;
+}
+
+.explorer-form-group input,
+.explorer-form-group textarea {
+  width: 100%;
+  padding: 0.8rem 0.95rem;
+  border: 1px solid #d1d5db;
+  border-radius: 10px;
+  font-size: 0.95rem;
+  color: #111827;
+  background: #fff;
+}
+
+.explorer-form-group input:focus,
+.explorer-form-group textarea:focus {
+  outline: none;
+  border-color: #f56004;
+  box-shadow: 0 0 0 3px rgba(245, 96, 4, 0.12);
+}
+
+.explorer-form-actions {
+  display: flex;
+  justify-content: flex-start;
+}
+
+.explorer-submit-button {
+  border: none;
+  background: #f56004;
+  color: #fff;
+  padding: 0.85rem 1.25rem;
+  border-radius: 999px;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.explorer-submit-button:hover {
+  background: #d9480f;
+}
+
+.explorer-submit-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.7;
+}
+
+.explorer-destination-list {
+  margin: 1rem 0 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+}
+
+.explorer-destination-item {
+  padding: 0.95rem 1rem;
+  border: 1px solid #e5e7eb;
+  border-radius: 10px;
+  background: #fafaf9;
+}
+
+.explorer-destination-label {
+  margin: 0 0 0.25rem;
+  font-weight: 700;
+  color: #111827;
+}
+
+.explorer-destination-order {
+  flex-shrink: 0;
+  border-radius: 999px;
+  background: rgba(245, 96, 4, 0.12);
+  color: #c2410c;
+  padding: 0.35rem 0.7rem;
+  font-weight: 700;
+}
+
+.explorer-error-card {
+  border-color: #fca5a5;
+}
+
+@media (max-width: 768px) {
+  .explorer-season-summary,
+  .explorer-card-header,
+  .explorer-destination-item {
+    flex-direction: column;
+  }
+
+  .explorer-submit-button {
+    width: 100%;
+  }
+}

--- a/src/components/ExplorerAdminPanel.tsx
+++ b/src/components/ExplorerAdminPanel.tsx
@@ -1,0 +1,348 @@
+import { useEffect, useRef, useState } from 'react';
+import type { Season } from '../types';
+import { trpc } from '../utils/trpc';
+import { formatUnixDate } from '../utils/dateUtils';
+import SeasonSelector from './SeasonSelector';
+import './AdminPanel.css';
+import './ExplorerAdminPanel.css';
+
+interface ExplorerAdminPanelProps {
+  isAdmin: boolean;
+  seasons: Season[];
+  selectedSeasonId: number | null;
+  onSeasonChange: (seasonId: number) => void;
+}
+
+interface FlashMessage {
+  type: 'success' | 'error' | 'info';
+  text: string;
+}
+
+function ExplorerAdminPanel({
+  isAdmin,
+  seasons,
+  selectedSeasonId,
+  onSeasonChange,
+}: ExplorerAdminPanelProps) {
+  const utils = trpc.useUtils();
+  const messageTimeoutRef = useRef<number | null>(null);
+  const [campaignForm, setCampaignForm] = useState({
+    displayName: '',
+    rulesBlurb: '',
+  });
+  const [destinationForm, setDestinationForm] = useState({
+    sourceUrl: '',
+    displayLabel: '',
+  });
+  const [message, setMessage] = useState<FlashMessage | null>(null);
+
+  const resolvedSeasonId = selectedSeasonId ?? seasons[0]?.id ?? null;
+  const selectedSeason = seasons.find((season) => season.id === resolvedSeasonId) || null;
+
+  useEffect(() => {
+    return () => {
+      if (messageTimeoutRef.current !== null) {
+        window.clearTimeout(messageTimeoutRef.current);
+      }
+    };
+  }, []);
+
+  const campaignQuery = trpc.explorerAdmin.getCampaignForSeason.useQuery(
+    { seasonId: resolvedSeasonId ?? 0 },
+    {
+      enabled: isAdmin && resolvedSeasonId !== null,
+      refetchOnWindowFocus: false,
+    }
+  );
+
+  const setTimedMessage = (nextMessage: FlashMessage, timeoutMs: number = 5000) => {
+    setMessage(nextMessage);
+
+    if (messageTimeoutRef.current !== null) {
+      window.clearTimeout(messageTimeoutRef.current);
+    }
+
+    messageTimeoutRef.current = window.setTimeout(() => {
+      setMessage(null);
+      messageTimeoutRef.current = null;
+    }, timeoutMs);
+  };
+
+  const createCampaignMutation = trpc.explorerAdmin.createCampaign.useMutation({
+    onSuccess: async () => {
+      await utils.explorerAdmin.getCampaignForSeason.invalidate({ seasonId: resolvedSeasonId ?? 0 });
+      setCampaignForm({ displayName: '', rulesBlurb: '' });
+      setTimedMessage({ type: 'success', text: 'Explorer campaign created for the selected season.' });
+    },
+    onError: (error) => {
+      setTimedMessage({ type: 'error', text: error.message });
+    },
+  });
+
+  const addDestinationMutation = trpc.explorerAdmin.addDestination.useMutation({
+    onSuccess: async (destination) => {
+      await utils.explorerAdmin.getCampaignForSeason.invalidate({ seasonId: resolvedSeasonId ?? 0 });
+      setDestinationForm({ sourceUrl: '', displayLabel: '' });
+
+      const isMetadataFallback = destination.cached_name === `Segment ${destination.strava_segment_id}`;
+      setTimedMessage({
+        type: isMetadataFallback ? 'info' : 'success',
+        text: isMetadataFallback
+          ? 'Destination added with placeholder metadata because live segment enrichment was unavailable.'
+          : 'Destination added to the Explorer campaign.',
+      });
+    },
+    onError: (error) => {
+      setTimedMessage({ type: 'error', text: error.message });
+    },
+  });
+
+  const handleCreateCampaign = async (event: React.FormEvent) => {
+    event.preventDefault();
+
+    if (!resolvedSeasonId) {
+      setTimedMessage({ type: 'error', text: 'Select a season before creating an Explorer campaign.' });
+      return;
+    }
+
+    await createCampaignMutation.mutateAsync({
+      seasonId: resolvedSeasonId,
+      displayName: campaignForm.displayName.trim() || null,
+      rulesBlurb: campaignForm.rulesBlurb.trim() || null,
+    });
+  };
+
+  const handleAddDestination = async (event: React.FormEvent) => {
+    event.preventDefault();
+
+    if (!campaignQuery.data) {
+      setTimedMessage({ type: 'error', text: 'Create a campaign before adding Explorer destinations.' });
+      return;
+    }
+
+    await addDestinationMutation.mutateAsync({
+      explorerCampaignId: campaignQuery.data.id,
+      sourceUrl: destinationForm.sourceUrl.trim(),
+      displayLabel: destinationForm.displayLabel.trim() || null,
+    });
+  };
+
+  if (!isAdmin) {
+    return (
+      <div className="explorer-admin-panel" data-testid="explorer-admin-panel">
+        <div className="explorer-admin-access-denied">
+          <h2>Access Denied</h2>
+          <p>You do not have admin permissions to manage Explorer campaigns.</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="explorer-admin-panel" data-testid="explorer-admin-panel">
+      {message && (
+        <div className={`explorer-message ${message.type}`} data-testid="explorer-admin-message">
+          {message.text}
+        </div>
+      )}
+
+      {seasons.length > 0 && (
+        <div className="admin-season-selector-wrapper">
+          <SeasonSelector
+            seasons={seasons}
+            selectedSeasonId={resolvedSeasonId}
+            setSelectedSeasonId={onSeasonChange}
+          />
+        </div>
+      )}
+
+      {seasons.length === 0 ? (
+        <div className="explorer-empty-state">
+          <h2>No seasons available</h2>
+          <p>Create a season before setting up an Explorer campaign.</p>
+        </div>
+      ) : !selectedSeason ? (
+        <div className="explorer-empty-state">
+          <h2>Select a season</h2>
+          <p>Choose a season before managing an Explorer campaign.</p>
+        </div>
+      ) : (
+        <>
+          <section className="explorer-season-summary" data-testid="explorer-season-summary">
+            <div>
+              <p className="explorer-section-label">Selected season</p>
+              <h2>{selectedSeason.name}</h2>
+            </div>
+            <p className="explorer-season-window">
+              {formatUnixDate(selectedSeason.start_at)} to {formatUnixDate(selectedSeason.end_at)}
+            </p>
+          </section>
+
+          {campaignQuery.isLoading ? (
+            <div className="explorer-card">
+              <p>Loading Explorer campaign setup...</p>
+            </div>
+          ) : campaignQuery.error ? (
+            <div className="explorer-card explorer-error-card">
+              <p>{campaignQuery.error.message}</p>
+            </div>
+          ) : !campaignQuery.data ? (
+            <section className="explorer-card" data-testid="explorer-create-campaign-card">
+              <div className="explorer-card-header">
+                <div>
+                  <p className="explorer-section-label">Phase 4B setup</p>
+                  <h3>Create Explorer Campaign</h3>
+                </div>
+                <p>Each season can have one Explorer campaign in v1.</p>
+              </div>
+
+              <form className="explorer-form" onSubmit={handleCreateCampaign} data-testid="explorer-create-campaign-form">
+                <div className="explorer-form-group">
+                  <label htmlFor="explorer-display-name">Campaign name</label>
+                  <input
+                    id="explorer-display-name"
+                    data-testid="explorer-display-name-input"
+                    value={campaignForm.displayName}
+                    onChange={(event) =>
+                      setCampaignForm((current) => ({ ...current, displayName: event.target.value }))
+                    }
+                    placeholder={`Defaults to ${selectedSeason.name}`}
+                    maxLength={255}
+                  />
+                </div>
+
+                <div className="explorer-form-group">
+                  <label htmlFor="explorer-rules-blurb">Rules blurb</label>
+                  <textarea
+                    id="explorer-rules-blurb"
+                    data-testid="explorer-rules-blurb-input"
+                    value={campaignForm.rulesBlurb}
+                    onChange={(event) =>
+                      setCampaignForm((current) => ({ ...current, rulesBlurb: event.target.value }))
+                    }
+                    placeholder="Optional guidance shown alongside the Explorer campaign"
+                    rows={4}
+                    maxLength={2000}
+                  />
+                </div>
+
+                <div className="explorer-form-actions">
+                  <button
+                    type="submit"
+                    className="explorer-submit-button"
+                    data-testid="explorer-create-campaign-button"
+                    disabled={createCampaignMutation.isPending}
+                  >
+                    {createCampaignMutation.isPending ? 'Creating...' : 'Create Explorer Campaign'}
+                  </button>
+                </div>
+              </form>
+            </section>
+          ) : (
+            <>
+              <section className="explorer-card" data-testid="explorer-campaign-summary-card">
+                <div className="explorer-card-header">
+                  <div>
+                    <p className="explorer-section-label">Explorer campaign</p>
+                    <h3 data-testid="explorer-campaign-name">{campaignQuery.data.name}</h3>
+                  </div>
+                  <p>{campaignQuery.data.destinations.length} destination{campaignQuery.data.destinations.length === 1 ? '' : 's'}</p>
+                </div>
+
+                {campaignQuery.data.rulesBlurb ? (
+                  <p className="explorer-rules-blurb" data-testid="explorer-campaign-rules-blurb">{campaignQuery.data.rulesBlurb}</p>
+                ) : (
+                  <p className="explorer-muted-copy">No rules blurb has been added yet.</p>
+                )}
+              </section>
+
+              <section className="explorer-card" data-testid="explorer-add-destination-card">
+                <div className="explorer-card-header">
+                  <div>
+                    <p className="explorer-section-label">Destination authoring</p>
+                    <h3>Add Destination</h3>
+                  </div>
+                  <p>Paste a Strava segment URL. Explorer keeps the source URL and cached display metadata.</p>
+                </div>
+
+                <form className="explorer-form" onSubmit={handleAddDestination} data-testid="explorer-add-destination-form">
+                  <div className="explorer-form-group">
+                    <label htmlFor="explorer-source-url">Strava segment URL</label>
+                    <input
+                      id="explorer-source-url"
+                      data-testid="explorer-source-url-input"
+                      value={destinationForm.sourceUrl}
+                      onChange={(event) =>
+                        setDestinationForm((current) => ({ ...current, sourceUrl: event.target.value }))
+                      }
+                      placeholder="https://www.strava.com/segments/2234642"
+                      required
+                    />
+                  </div>
+
+                  <div className="explorer-form-group">
+                    <label htmlFor="explorer-display-label">Display label</label>
+                    <input
+                      id="explorer-display-label"
+                      data-testid="explorer-display-label-input"
+                      value={destinationForm.displayLabel}
+                      onChange={(event) =>
+                        setDestinationForm((current) => ({ ...current, displayLabel: event.target.value }))
+                      }
+                      placeholder="Optional label to override the cached segment name"
+                    />
+                  </div>
+
+                  <div className="explorer-form-actions">
+                    <button
+                      type="submit"
+                      className="explorer-submit-button"
+                      data-testid="explorer-add-destination-button"
+                      disabled={addDestinationMutation.isPending}
+                    >
+                      {addDestinationMutation.isPending ? 'Adding...' : 'Add Destination'}
+                    </button>
+                  </div>
+                </form>
+              </section>
+
+              <section className="explorer-card" data-testid="explorer-destination-list-card">
+                <div className="explorer-card-header">
+                  <div>
+                    <p className="explorer-section-label">Current campaign map</p>
+                    <h3>Destinations</h3>
+                  </div>
+                </div>
+
+                {campaignQuery.data.destinations.length === 0 ? (
+                  <p className="explorer-muted-copy">No destinations added yet.</p>
+                ) : (
+                  <ol className="explorer-destination-list" data-testid="explorer-destination-list">
+                    {campaignQuery.data.destinations.map((destination) => (
+                      <li
+                        key={destination.id}
+                        className="explorer-destination-item"
+                        data-testid={`explorer-destination-row-${destination.id}`}
+                      >
+                        <div>
+                          <p className="explorer-destination-label">{destination.displayLabel}</p>
+                          <p className="explorer-destination-meta">
+                            Segment {destination.stravaSegmentId}
+                            {destination.sourceUrl ? ` • ${destination.sourceUrl}` : ''}
+                          </p>
+                        </div>
+                        <span className="explorer-destination-order">#{destination.displayOrder + 1}</span>
+                      </li>
+                    ))}
+                  </ol>
+                )}
+              </section>
+            </>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+export default ExplorerAdminPanel;

--- a/src/components/ExplorerAdminPanel.tsx
+++ b/src/components/ExplorerAdminPanel.tsx
@@ -36,7 +36,9 @@ function ExplorerAdminPanel({
   });
   const [message, setMessage] = useState<FlashMessage | null>(null);
 
-  const resolvedSeasonId = selectedSeasonId ?? seasons[0]?.id ?? null;
+  const hasSelectedSeason =
+    selectedSeasonId !== null && seasons.some((season) => season.id === selectedSeasonId);
+  const resolvedSeasonId = hasSelectedSeason ? selectedSeasonId : seasons[0]?.id ?? null;
   const selectedSeason = seasons.find((season) => season.id === resolvedSeasonId) || null;
 
   useEffect(() => {
@@ -84,10 +86,9 @@ function ExplorerAdminPanel({
       await utils.explorerAdmin.getCampaignForSeason.invalidate({ seasonId: resolvedSeasonId ?? 0 });
       setDestinationForm({ sourceUrl: '', displayLabel: '' });
 
-      const isMetadataFallback = destination.cached_name === `Segment ${destination.strava_segment_id}`;
       setTimedMessage({
-        type: isMetadataFallback ? 'info' : 'success',
-        text: isMetadataFallback
+        type: destination.usedPlaceholderMetadata ? 'info' : 'success',
+        text: destination.usedPlaceholderMetadata
           ? 'Destination added with placeholder metadata because live segment enrichment was unavailable.'
           : 'Destination added to the Explorer campaign.',
       });

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -197,6 +197,17 @@ export const NavBar: React.FC<NavBarProps> = ({
                           Manage Competition
                         </NavLink>
                         <NavLink 
+                          to="/explorer-admin" 
+                          className={({ isActive }) => `menu-item ${isActive ? 'active' : ''}`}
+                          onClick={() => setIsMenuOpen(false)}
+                        >
+                          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" className="menu-icon">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+                              d="M9 20l-5.447-2.724A1 1 0 013 16.382V5.618a1 1 0 01.553-.894L9 2m0 18l6-3m-6 3V2m6 15l6 3m-6-3V6m6 14V8.618a1 1 0 00-.553-.894L15 5m0 1L9 2" />
+                          </svg>
+                          Manage Explorer
+                        </NavLink>
+                        <NavLink 
                           to="/roles" 
                           className={({ isActive }) => `menu-item ${isActive ? 'active' : ''}`}
                           onClick={() => setIsMenuOpen(false)}

--- a/src/components/__tests__/ExplorerAdminPanel.test.tsx
+++ b/src/components/__tests__/ExplorerAdminPanel.test.tsx
@@ -1,0 +1,288 @@
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Season } from '../../types';
+import ExplorerAdminPanel from '../ExplorerAdminPanel';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const trpcMocks = vi.hoisted(() => ({
+  campaignQuery: {
+    data: null as null | {
+      id: number;
+      name: string;
+      rulesBlurb: string | null;
+      destinations: Array<{
+        id: number;
+        displayLabel: string;
+        displayOrder: number;
+        sourceUrl: string | null;
+        stravaSegmentId: string;
+      }>;
+    },
+    error: null as Error | null,
+    isLoading: false,
+  },
+  invalidate: vi.fn(async () => undefined),
+  createCampaign: vi.fn(async () => ({ id: 1 })),
+  addDestination: vi.fn(async () => ({ id: 1, cached_name: 'Segment 1', strava_segment_id: '1' })),
+}));
+
+vi.mock('../../utils/trpc', () => ({
+  trpc: {
+    useUtils: () => ({
+      explorerAdmin: {
+        getCampaignForSeason: {
+          invalidate: trpcMocks.invalidate,
+        },
+      },
+    }),
+    explorerAdmin: {
+      getCampaignForSeason: {
+        useQuery: () => trpcMocks.campaignQuery,
+      },
+      createCampaign: {
+        useMutation: (options: {
+          onError?: (error: Error) => void;
+          onSuccess?: (result: unknown) => Promise<void> | void;
+        }) => ({
+          isPending: false,
+          mutateAsync: async (input: unknown) => {
+            try {
+              const result = await trpcMocks.createCampaign(input);
+              await options.onSuccess?.(result);
+              return result;
+            } catch (error) {
+              options.onError?.(error as Error);
+              throw error;
+            }
+          },
+        }),
+      },
+      addDestination: {
+        useMutation: (options: {
+          onError?: (error: Error) => void;
+          onSuccess?: (result: { cached_name: string; strava_segment_id: string }) => Promise<void> | void;
+        }) => ({
+          isPending: false,
+          mutateAsync: async (input: unknown) => {
+            try {
+              const result = await trpcMocks.addDestination(input);
+              await options.onSuccess?.(result);
+              return result;
+            } catch (error) {
+              options.onError?.(error as Error);
+              throw error;
+            }
+          },
+        }),
+      },
+    },
+  },
+}));
+
+const seasons: Season[] = [
+  {
+    id: 7,
+    name: 'Spring 2026',
+    start_at: 1711929600,
+    end_at: 1714521600,
+  },
+  {
+    id: 8,
+    name: 'Summer 2026',
+    start_at: 1717200000,
+    end_at: 1719792000,
+  },
+];
+
+interface RenderResult {
+  container: HTMLDivElement;
+  root: Root;
+}
+
+let renderResult: RenderResult | null = null;
+
+async function renderPanel(overrides: Partial<React.ComponentProps<typeof ExplorerAdminPanel>> = {}) {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  await act(async () => {
+    root.render(
+      <ExplorerAdminPanel
+        isAdmin
+        seasons={seasons}
+        selectedSeasonId={seasons[0].id}
+        onSeasonChange={vi.fn()}
+        {...overrides}
+      />
+    );
+  });
+
+  renderResult = { container, root };
+  return renderResult;
+}
+
+function getByTestId(container: HTMLElement, testId: string): HTMLElement {
+  const element = container.querySelector(`[data-testid="${testId}"]`);
+
+  if (!element) {
+    throw new Error(`Expected element with data-testid="${testId}"`);
+  }
+
+  return element as HTMLElement;
+}
+
+function queryByTestId(container: HTMLElement, testId: string): HTMLElement | null {
+  return container.querySelector(`[data-testid="${testId}"]`);
+}
+
+async function setValue(element: HTMLInputElement | HTMLTextAreaElement, value: string) {
+  const prototype = element instanceof HTMLTextAreaElement
+    ? HTMLTextAreaElement.prototype
+    : HTMLInputElement.prototype;
+  const valueSetter = Object.getOwnPropertyDescriptor(prototype, 'value')?.set;
+
+  await act(async () => {
+    valueSetter?.call(element, value);
+    element.dispatchEvent(new Event('input', { bubbles: true }));
+    element.dispatchEvent(new Event('change', { bubbles: true }));
+    await Promise.resolve();
+  });
+}
+
+async function submitForm(form: HTMLElement) {
+  await act(async () => {
+    form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+    await Promise.resolve();
+  });
+}
+
+describe('ExplorerAdminPanel', () => {
+  beforeEach(() => {
+    trpcMocks.campaignQuery.data = null;
+    trpcMocks.campaignQuery.error = null;
+    trpcMocks.campaignQuery.isLoading = false;
+    trpcMocks.invalidate.mockClear();
+    trpcMocks.createCampaign.mockReset();
+    trpcMocks.createCampaign.mockResolvedValue({ id: 1 });
+    trpcMocks.addDestination.mockReset();
+    trpcMocks.addDestination.mockResolvedValue({
+      id: 1,
+      cached_name: 'Segment 2234642',
+      strava_segment_id: '2234642',
+    });
+    vi.useRealTimers();
+  });
+
+  afterEach(async () => {
+    if (renderResult) {
+      await act(async () => {
+        renderResult?.root.unmount();
+      });
+      renderResult.container.remove();
+      renderResult = null;
+    }
+
+    vi.useRealTimers();
+  });
+
+  it('shows an access denied state for non-admin users', async () => {
+    const { container } = await renderPanel({ isAdmin: false });
+
+    expect(getByTestId(container, 'explorer-admin-panel').textContent).toContain('Access Denied');
+    expect(container.textContent).toContain('do not have admin permissions');
+  });
+
+  it('falls back to the first season when no admin season is selected', async () => {
+    const { container } = await renderPanel({ selectedSeasonId: null });
+
+    expect(getByTestId(container, 'explorer-season-summary').textContent).toContain('Spring 2026');
+
+    await submitForm(getByTestId(container, 'explorer-create-campaign-form'));
+
+    expect(trpcMocks.createCampaign).toHaveBeenCalledWith({
+      seasonId: 7,
+      displayName: null,
+      rulesBlurb: null,
+    });
+    expect(trpcMocks.invalidate).toHaveBeenCalledWith({ seasonId: 7 });
+  });
+
+  it('shows the empty state when there are no seasons to configure', async () => {
+    const { container } = await renderPanel({ seasons: [], selectedSeasonId: null });
+
+    expect(container.textContent).toContain('No seasons available');
+    expect(queryByTestId(container, 'explorer-create-campaign-form')).toBeNull();
+  });
+
+  it('adds destinations with trimmed values and preserves the latest flash message timer', async () => {
+    vi.useFakeTimers();
+    trpcMocks.campaignQuery.data = {
+      id: 41,
+      name: 'Spring 2026 Explorer',
+      rulesBlurb: 'Ride every destination once.',
+      destinations: [],
+    };
+    trpcMocks.addDestination
+      .mockResolvedValueOnce({
+        id: 1,
+        cached_name: 'Segment 2234642',
+        strava_segment_id: '2234642',
+      })
+      .mockResolvedValueOnce({
+        id: 2,
+        cached_name: 'Box Hill KOM',
+        strava_segment_id: '2234642',
+      });
+
+    const { container } = await renderPanel();
+
+    await setValue(
+      getByTestId(container, 'explorer-source-url-input') as HTMLInputElement,
+      '  https://www.strava.com/segments/2234642  '
+    );
+    await submitForm(getByTestId(container, 'explorer-add-destination-form'));
+
+    expect(getByTestId(container, 'explorer-admin-message').textContent).toContain('placeholder metadata');
+    expect(trpcMocks.addDestination).toHaveBeenNthCalledWith(1, {
+      explorerCampaignId: 41,
+      sourceUrl: 'https://www.strava.com/segments/2234642',
+      displayLabel: null,
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    await setValue(
+      getByTestId(container, 'explorer-source-url-input') as HTMLInputElement,
+      'https://www.strava.com/segments/2234642'
+    );
+    await setValue(
+      getByTestId(container, 'explorer-display-label-input') as HTMLInputElement,
+      '  Box Hill opener  '
+    );
+    await submitForm(getByTestId(container, 'explorer-add-destination-form'));
+
+    expect(getByTestId(container, 'explorer-admin-message').textContent).toContain('Destination added to the Explorer campaign.');
+    expect(trpcMocks.addDestination).toHaveBeenNthCalledWith(2, {
+      explorerCampaignId: 41,
+      sourceUrl: 'https://www.strava.com/segments/2234642',
+      displayLabel: 'Box Hill opener',
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(4000);
+    });
+
+    expect(getByTestId(container, 'explorer-admin-message').textContent).toContain('Destination added to the Explorer campaign.');
+
+    await act(async () => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    expect(queryByTestId(container, 'explorer-admin-message')).toBeNull();
+  });
+});

--- a/src/components/__tests__/ExplorerAdminPanel.test.tsx
+++ b/src/components/__tests__/ExplorerAdminPanel.test.tsx
@@ -25,7 +25,12 @@ const trpcMocks = vi.hoisted(() => ({
   },
   invalidate: vi.fn(async () => undefined),
   createCampaign: vi.fn(async () => ({ id: 1 })),
-  addDestination: vi.fn(async () => ({ id: 1, cached_name: 'Segment 1', strava_segment_id: '1' })),
+  addDestination: vi.fn(async () => ({
+    id: 1,
+    cached_name: 'Segment 1',
+    strava_segment_id: '1',
+    usedPlaceholderMetadata: true,
+  })),
 }));
 
 vi.mock('../../utils/trpc', () => ({
@@ -62,7 +67,11 @@ vi.mock('../../utils/trpc', () => ({
       addDestination: {
         useMutation: (options: {
           onError?: (error: Error) => void;
-          onSuccess?: (result: { cached_name: string; strava_segment_id: string }) => Promise<void> | void;
+          onSuccess?: (result: {
+            cached_name: string;
+            strava_segment_id: string;
+            usedPlaceholderMetadata: boolean;
+          }) => Promise<void> | void;
         }) => ({
           isPending: false,
           mutateAsync: async (input: unknown) => {
@@ -210,6 +219,12 @@ describe('ExplorerAdminPanel', () => {
     expect(trpcMocks.invalidate).toHaveBeenCalledWith({ seasonId: 7 });
   });
 
+  it('falls back to the first season when the selected season is missing', async () => {
+    const { container } = await renderPanel({ selectedSeasonId: 999 });
+
+    expect(getByTestId(container, 'explorer-season-summary').textContent).toContain('Spring 2026');
+  });
+
   it('shows the empty state when there are no seasons to configure', async () => {
     const { container } = await renderPanel({ seasons: [], selectedSeasonId: null });
 
@@ -230,11 +245,13 @@ describe('ExplorerAdminPanel', () => {
         id: 1,
         cached_name: 'Segment 2234642',
         strava_segment_id: '2234642',
+        usedPlaceholderMetadata: true,
       })
       .mockResolvedValueOnce({
         id: 2,
         cached_name: 'Box Hill KOM',
         strava_segment_id: '2234642',
+        usedPlaceholderMetadata: false,
       });
 
     const { container } = await renderPanel();

--- a/src/components/__tests__/NavBar.explorer-admin.test.tsx
+++ b/src/components/__tests__/NavBar.explorer-admin.test.tsx
@@ -1,0 +1,91 @@
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { UnitProvider } from '../../context/UnitContext';
+import NavBar from '../NavBar';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock('../../api', () => ({
+  disconnect: vi.fn(async () => ({ success: true, message: 'ok' })),
+  getConnectUrl: vi.fn(() => '/auth/strava'),
+}));
+
+interface RenderResult {
+  container: HTMLDivElement;
+  root: Root;
+}
+
+let renderResult: RenderResult | null = null;
+
+async function renderNavBar(overrides: Partial<React.ComponentProps<typeof NavBar>> = {}) {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  await act(async () => {
+    root.render(
+      <MemoryRouter initialEntries={['/leaderboard']}>
+        <UnitProvider>
+          <NavBar
+            title="Weekly Leaderboard"
+            isAdmin
+            isConnected
+            athleteInfo={{ firstname: 'Tim', lastname: 'Downey', profile: undefined }}
+            userAthleteId="366880"
+            {...overrides}
+          />
+        </UnitProvider>
+      </MemoryRouter>
+    );
+  });
+
+  renderResult = { container, root };
+  return renderResult;
+}
+
+async function openMenu(container: HTMLElement) {
+  const button = container.querySelector('button[aria-label="Menu"]');
+
+  if (!(button instanceof HTMLButtonElement)) {
+    throw new Error('Expected profile menu button');
+  }
+
+  await act(async () => {
+    button.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+  });
+}
+
+describe('NavBar Explorer admin link', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(async () => {
+    if (renderResult) {
+      await act(async () => {
+        renderResult?.root.unmount();
+      });
+      renderResult.container.remove();
+      renderResult = null;
+    }
+  });
+
+  it('shows Manage Explorer in the admin menu for admins', async () => {
+    const { container } = await renderNavBar();
+
+    await openMenu(container);
+
+    const explorerLink = container.querySelector('a[href="/explorer-admin"]');
+    expect(explorerLink?.textContent).toContain('Manage Explorer');
+  });
+
+  it('hides Manage Explorer for non-admin users', async () => {
+    const { container } = await renderNavBar({ isAdmin: false });
+
+    await openMenu(container);
+
+    expect(container.querySelector('a[href="/explorer-admin"]')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
Add the minimal admin-gated Explorer setup surface on top of the landed backend contract and hardened E2E harness.

## What changed
- add the Explorer admin route and navbar entry for admins only
- add season campaign read support for the admin UI
- add focused frontend unit coverage and targeted Playwright coverage for admin setup flows
- close the 4B-2 planning state as the minimal admin UI slice and hand the next work back to planning for admin UX refinement
- fix the duplicate Jest manual mock warning by ignoring `server/dist` in backend Jest config
- align local and CI validation by updating docs-site GitHub Actions to Node 24 and using the repo audit workflow in CI
- remediate the actionable backend audit issues by overriding `protobufjs` and `follow-redirects`

## Validation
- `npm run test:frontend -- src/components/__tests__/ExplorerAdminPanel.test.tsx src/components/__tests__/NavBar.explorer-admin.test.tsx`
- `cd server && npx jest --runInBand --runTestsByPath src/__tests__/trpc/explorerAdminRouter.test.ts --coverage=false`
- `ENV_FILE=e2e/.env.e2e npx playwright test e2e/tests/explorer-admin.authenticated.spec.ts --reporter=list`
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `npm run audit`

## Notes
Backend audit still reports the upstream dev-only `drizzle-kit` / `@esbuild-kit` advisory below the repo's `high` threshold. The current branch fixes the actionable `protobufjs` and `follow-redirects` findings and aligns CI with the same local audit policy.