### PR TITLE
Refine Explorer admin UX and add leaderboard design guidance

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -163,6 +163,8 @@ try {
 
 ### Frontend (React + TypeScript)
 
+For end-user leaderboard-inspired UI work, including future public Explorer surfaces, use [docs/LEADERBOARD_DESIGN_SYSTEM.md](./docs/LEADERBOARD_DESIGN_SYSTEM.md) as the canonical design reference before copying patterns from older admin screens.
+
 **tRPC Hooks:**
 ```typescript
 import { trpc } from '@/utils/trpc';
@@ -378,6 +380,7 @@ npm run typecheck
 For detailed information:
 - **Quick start:** [docs/QUICK_START.md](./docs/QUICK_START.md)
 - **Architecture:** [docs/ARCHITECTURE.md](./docs/ARCHITECTURE.md)
+- **Leaderboard design system:** [docs/LEADERBOARD_DESIGN_SYSTEM.md](./docs/LEADERBOARD_DESIGN_SYSTEM.md)
 - **Database:** [docs/DATABASE_DESIGN.md](./docs/DATABASE_DESIGN.md)
 - **API reference:** [docs/API.md](./docs/API.md)
 - **Strava integration:** [docs/STRAVA_INTEGRATION.md](./docs/STRAVA_INTEGRATION.md)

--- a/.github/skills/leaderboard-design-audit/SKILL.md
+++ b/.github/skills/leaderboard-design-audit/SKILL.md
@@ -22,6 +22,8 @@ argument-hint: 'Describe the UI surface to audit or design and whether you want 
 - `src/components/WeeklyHeader.tsx`
 - `src/components/LeaderboardCard.tsx`
 - `src/components/SeasonCard.tsx`
+- `src/components/SegmentCard.tsx`
+- `src/components/CollapsibleSegmentProfile.tsx`
 - `src/components/WeeklyLeaderboard.tsx`
 - `src/components/ScheduleTable.tsx`
 
@@ -30,7 +32,7 @@ argument-hint: 'Describe the UI surface to audit or design and whether you want 
 1. Confirm the work is for the main end-user leaderboard design language, not legacy admin.
 2. Read `docs/LEADERBOARD_DESIGN_SYSTEM.md` first.
 3. Identify which leaderboard source files are the closest analog for the target UI.
-4. Separate reusable primitives from genuinely new requirements.
+4. Decide whether the target surface is primarily a ranking card, a hero header, a compact segment-object card, or a reveal panel.
 5. Call out any gaps where the current leaderboard does not define a stable pattern, especially forms and admin controls.
 6. Recommend the smallest set of new styles necessary after reuse is exhausted.
 
@@ -49,4 +51,5 @@ Return a compact result with:
 - Do not treat legacy admin as the UX source of truth for public Explorer work.
 - Prefer tokenized colors and font scale from `src/index.css` over hardcoded values.
 - Prefer `leaderboard-card`, `card-*`, and `week-header-chip` over bespoke replacements when the semantics match.
+- Prefer `SegmentCard` for compact segment or destination-object title and metadata styling when there is no ranking-row hierarchy.
 - If the leaderboard does not yet define a pattern, name that gap explicitly instead of guessing.

--- a/.github/skills/leaderboard-design-audit/SKILL.md
+++ b/.github/skills/leaderboard-design-audit/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: leaderboard-design-audit
+description: 'Audit or design leaderboard-inspired end-user UI using the canonical Weekly, Season, and Schedule design system.'
+argument-hint: 'Describe the UI surface to audit or design and whether you want a gap analysis, implementation plan, or review.'
+---
+
+# Leaderboard Design Audit
+
+## When To Use
+
+- when building or reviewing Explorer end-user UI
+- when aligning a new public-facing card, chip, header, or schedule-like surface with the existing leaderboard UX
+- when auditing typography, spacing, colors, chip treatment, or expansion behavior against the Weekly, Season, and Schedule tabs
+- when deciding whether a new UI primitive is real or just a duplicate of an existing leaderboard pattern
+
+## Primary References
+
+- `docs/LEADERBOARD_DESIGN_SYSTEM.md`
+- `src/index.css`
+- `src/App.css`
+- `src/components/Card.css`
+- `src/components/WeeklyHeader.tsx`
+- `src/components/LeaderboardCard.tsx`
+- `src/components/SeasonCard.tsx`
+- `src/components/WeeklyLeaderboard.tsx`
+- `src/components/ScheduleTable.tsx`
+
+## Procedure
+
+1. Confirm the work is for the main end-user leaderboard design language, not legacy admin.
+2. Read `docs/LEADERBOARD_DESIGN_SYSTEM.md` first.
+3. Identify which leaderboard source files are the closest analog for the target UI.
+4. Separate reusable primitives from genuinely new requirements.
+5. Call out any gaps where the current leaderboard does not define a stable pattern, especially forms and admin controls.
+6. Recommend the smallest set of new styles necessary after reuse is exhausted.
+
+## Output Expectations
+
+Return a compact result with:
+
+- the closest source-of-truth components
+- what should be reused directly
+- what needs a new primitive
+- specific style or hierarchy mismatches
+- a safe next implementation slice
+
+## Guardrails
+
+- Do not treat legacy admin as the UX source of truth for public Explorer work.
+- Prefer tokenized colors and font scale from `src/index.css` over hardcoded values.
+- Prefer `leaderboard-card`, `card-*`, and `week-header-chip` over bespoke replacements when the semantics match.
+- If the leaderboard does not yet define a pattern, name that gap explicitly instead of guessing.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,6 +123,10 @@ Before merging or opening a substantive PR, run `npm run audit` locally alongsid
    - For pull requests, review comments, issues, labels, searches, and repository metadata, prefer GitHub MCP and workspace-integrated GitHub tools first
    - Fall back to `gh` only when the MCP path is unavailable, missing a needed capability, or returning incomplete results
    - When falling back to `gh`, keep the usage targeted and explain the blocker or gap that required the fallback
+9. **Leaderboard-inspired UI work:**
+   - Treat `docs/LEADERBOARD_DESIGN_SYSTEM.md` as the canonical reference for the end-user Weekly, Season, and Schedule design language
+   - Do not use legacy admin CSS as the default source of truth for public Explorer UI
+   - If the leaderboard does not define a needed pattern, record that gap explicitly instead of freehanding a new local style system
 
 ## Special Tasks
 
@@ -171,6 +175,7 @@ npm run dev
 For detailed information, see:
 - **Quick start:** [docs/QUICK_START.md](./docs/QUICK_START.md)
 - **Architecture:** [docs/ARCHITECTURE.md](./docs/ARCHITECTURE.md)
+- **Leaderboard design system:** [docs/LEADERBOARD_DESIGN_SYSTEM.md](./docs/LEADERBOARD_DESIGN_SYSTEM.md)
 - **Database design:** [docs/DATABASE_DESIGN.md](./docs/DATABASE_DESIGN.md)
 - **Strava integration:** [docs/STRAVA_INTEGRATION.md](./docs/STRAVA_INTEGRATION.md)
 - **API reference:** [docs/API.md](./docs/API.md)

--- a/AGENT_USAGE.md
+++ b/AGENT_USAGE.md
@@ -15,4 +15,6 @@ This file is intentionally brief. It exists to steer agent workflows toward the 
 3. Use `npm run dev` and `npm run dev:cleanup` when a live dev server is actually required.
 4. Do not invent package scripts or alternate process-management commands that the repo does not define.
 5. If a customization file starts repeating command catalogs or environment tables, move that information back to [AGENTS.md](./AGENTS.md) and link to it.
+6. For end-user leaderboard-inspired UI work, read [docs/LEADERBOARD_DESIGN_SYSTEM.md](./docs/LEADERBOARD_DESIGN_SYSTEM.md) before reusing CSS from legacy admin screens.
+7. For public Explorer UI audits or reviews, prefer the repo-local skill at [.github/skills/leaderboard-design-audit/SKILL.md](./.github/skills/leaderboard-design-audit/SKILL.md).
 

--- a/docs/LEADERBOARD_DESIGN_SYSTEM.md
+++ b/docs/LEADERBOARD_DESIGN_SYSTEM.md
@@ -229,6 +229,9 @@ Defining traits:
 - the `Next Up` badge is a specific schedule affordance, not a general chip replacement
 - expanded week content uses the same overlap-and-reveal idea as weekly notes
 - CTAs remain visually subordinate to the main header card
+- the segment name hierarchy is large and prominent, using `var(--font-2xl)` scale rather than compact metadata-card title sizing
+- the segment link keeps the inline external-link arrow attached directly to the title text
+- individual schedule entries should read as single primary surfaces, not stacks of nested boxes inside another card shell
 
 ## Link Rules
 
@@ -241,6 +244,7 @@ There are two valid title-link expressions in the current system:
 
 - `WeeklyHeader` pattern: linked title plus inline external-link icon for a hero-level week surface
 - `SegmentCard` pattern: linked title text without detached icon-first chrome for compact segment-object cards
+- `Schedule` destination-entry pattern: a large title treatment using the same linked-name plus inline-arrow idea, but still rendered as one primary surface with chips beneath it
 
 Rules:
 - for route, week, or destination title links, prefer the linked-name pattern over a separate icon-only action
@@ -257,8 +261,9 @@ Explorer should default to the leaderboard system in this order:
 3. Reuse `week-header-chip` for compact metadata before inventing a new chip style.
 4. Reuse `SegmentCard` title and metadata treatment whenever an Explorer destination is behaving like a compact segment object.
 5. Reuse the linked-title pattern from `WeeklyHeader.tsx` for hero-level Explorer headers or destination surfaces that are acting like weekly-header analogs.
-6. Reuse `CollapsibleSegmentProfile` as the default reference for deeper segment or destination detail reveals inside expanded surfaces.
-7. Only add Explorer-specific classes for layout or semantics the leaderboard primitives do not already express.
+6. Reuse the `Schedule` segment-entry hierarchy for Explorer destination rows when they are the primary objects in a list and need the larger title, inline arrow affordance, and flatter single-surface card treatment.
+7. Reuse `CollapsibleSegmentProfile` as the default reference for deeper segment or destination detail reveals inside expanded surfaces.
+8. Only add Explorer-specific classes for layout or semantics the leaderboard primitives do not already express.
 
 Do not treat legacy admin components as the source of truth for public Explorer UI.
 

--- a/docs/LEADERBOARD_DESIGN_SYSTEM.md
+++ b/docs/LEADERBOARD_DESIGN_SYSTEM.md
@@ -1,0 +1,255 @@
+# Leaderboard Design System
+
+This document defines the current gold-standard UI language for the end-user leaderboard experience only.
+
+Scope:
+- Weekly leaderboard
+- Season leaderboard
+- Schedule tab
+- Shared primitives those tabs already use
+
+Out of scope:
+- Legacy admin screens
+- Explorer admin UX except where it intentionally reuses leaderboard primitives
+- New form-control systems that do not yet exist in the public leaderboard
+
+## Source Of Truth
+
+Use these files in this order when building or reviewing leaderboard-style UI:
+
+| Area | Source file | Role |
+| --- | --- | --- |
+| Global tokens and typography | `src/index.css` | Brand colors, text colors, font scale, heading defaults |
+| App-level layout | `src/App.css` | Main content width, page spacing, table baseline |
+| Shared card shell | `src/components/Card.css` | Card container, collapsed header, expanded details, chip primitives |
+| Weekly header pattern | `src/components/WeeklyHeader.tsx` | Primary hero card for weekly and schedule surfaces |
+| Weekly participant card | `src/components/LeaderboardCard.tsx` | Rank card composition, expanded detail treatment |
+| Season participant card | `src/components/SeasonCard.tsx` | Season-card hierarchy and compact metadata pill treatment |
+| Weekly tab composition | `src/components/WeeklyLeaderboard.tsx` | Card stacking, expansion rhythm, no-results state |
+| Schedule tab composition | `src/components/ScheduleTable.tsx` and `src/components/ScheduleTable.css` | Week-list rhythm, next-up badge, schedule expansion layout |
+
+If a new UI conflicts with these files, the new UI should usually change before the leaderboard primitives do.
+
+## Foundations
+
+### Color Tokens
+
+All new leaderboard-inspired UI should start from the tokens in `src/index.css`:
+
+- `--wmv-purple`: primary heading and brand accent
+- `--wmv-purple-dark`: stronger hover or active purple
+- `--wmv-orange`: interactive accent, CTA, badge, and highlight color
+- `--wmv-orange-hover`: orange hover state
+- `--wmv-orange-light`: warm orange-tinted background
+- `--wmv-text-dark`: primary body text
+- `--wmv-text-light`: secondary metadata text
+- `--wmv-border`: neutral borders and dividers
+- `--wmv-bg-light`: muted chip and expanded-panel background
+- `--wmv-white`: card and surface background
+
+Rules:
+- Prefer these variables over hardcoded hex values.
+- If a new token is needed, add it centrally instead of scattering one-off colors.
+- Public leaderboard-inspired UI should avoid borrowing colors from legacy admin screens unless they are promoted into tokens first.
+
+### Typography
+
+The global type system lives in `src/index.css`.
+
+- Body copy inherits the system sans stack declared on `:root`.
+- Headings use the same sans stack with `font-weight: 700` and `color: var(--wmv-purple)` by default.
+- The responsive scale is tokenized through:
+  - `--font-xs`
+  - `--font-sm`
+  - `--font-base`
+  - `--font-lg`
+  - `--font-xl`
+  - `--font-2xl`
+
+Rules:
+- Prefer the tokenized font scale over hardcoded pixel values.
+- For card titles and key metadata, reuse existing leaderboard classes before inventing new font rules.
+- Secondary metadata should usually sit on `var(--wmv-text-light)` and `var(--font-sm)` or smaller.
+
+### Layout And Spacing
+
+The page container standard comes from `src/App.css`:
+
+- `.app-content` uses a centered max width of `1280px`
+- page padding is `clamp(1rem, 4vw, 2rem)`
+- major app sections breathe with `gap: 2rem`
+
+Leaderboard components then work on a tighter internal rhythm:
+
+- card margin bottom: `12px`
+- common vertical list gap: `16px`
+- header gap: `8px`
+- expanded-detail padding: `16px 16px 24px 16px`
+- large header cards such as `WeeklyHeader` use `24px` internal padding and `16px` radius
+
+Rules:
+- Prefer the existing 4px, 8px, 12px, 16px, 24px cadence.
+- Do not introduce heavier spacing systems in Explorer unless the leaderboard primitives cannot express the layout.
+
+## Core Primitives
+
+### Card Shell
+
+`src/components/Card.css` is the main reusable shell.
+
+Key classes:
+- `.leaderboard-card`
+- `.leaderboard-card.current-user`
+- `.card-header`
+- `.card-jersey`
+- `.card-rank`
+- `.card-avatar`
+- `.card-main-info`
+- `.card-name`
+- `.card-points-row`
+- `.card-right-side`
+- `.card-time`
+- `.card-chevron`
+- `.card-expanded-details`
+
+Behavior rules:
+- cards are white with subtle shadow, 12px radius, and slight hover lift
+- the current-user modifier adds orange emphasis without replacing the core shell
+- expanded details use a light inset panel and stay visually attached to the collapsed header
+- hover and expansion motion should stay subtle and fast
+
+### Chip Pattern
+
+The standard compact metadata badge is `.week-header-chip` with optional `.week-header-chip-icon`.
+
+Characteristics:
+- inline-flex layout
+- muted background using `var(--wmv-bg-light)`
+- rounded 16px pill shape
+- medium-weight text
+- subdued metadata color using `var(--wmv-text-light)`
+
+Use this for:
+- participant count
+- distance
+- elevation
+- grade
+- compact location or status metadata when it fits the same semantic weight
+
+Avoid replacing it with bespoke pill systems unless the new component needs a materially different role.
+
+### Expandable Surface Pattern
+
+The leaderboard uses two related expansion patterns:
+
+1. `Card.css` expansion via `.card-expanded-details`
+2. header-to-detail overlap in `WeeklyLeaderboard.tsx` and `ScheduleTable.tsx`
+
+Common traits:
+- expansion appears attached to the trigger surface
+- detail background is lighter than the collapsed surface
+- animation is modest and short-lived
+- the expanded layer should not visually compete with the main card shell
+
+## Tab-Specific Patterns
+
+### Weekly
+
+Source files:
+- `src/components/WeeklyLeaderboard.tsx`
+- `src/components/WeeklyHeader.tsx`
+- `src/components/LeaderboardCard.tsx`
+- `src/components/WeeklyLeaderboard.css`
+
+Defining traits:
+- the week header is the hero surface for the page
+- the week name itself is the Strava link, styled in orange with an inline external-link icon
+- metadata directly under the title is quiet and compact
+- detailed rider rows use the shared card shell, not bespoke component framing
+- expanded rider details keep metrics and links compact, not dashboard-like
+
+### Season
+
+Source files:
+- `src/components/SeasonLeaderboard.tsx`
+- `src/components/SeasonCard.tsx`
+
+Defining traits:
+- season cards reuse the same shell and hierarchy as weekly cards
+- participant identity still leads the card
+- compact pills can sit inside the card body when they read as secondary metadata
+- the right side emphasizes the primary value, but without abandoning the shared card rhythm
+
+### Schedule
+
+Source files:
+- `src/components/ScheduleTable.tsx`
+- `src/components/ScheduleTable.css`
+- `src/components/WeeklyHeader.tsx`
+
+Defining traits:
+- schedule reuses `WeeklyHeader` rather than inventing a parallel card shell
+- the `Next Up` badge is a specific schedule affordance, not a general chip replacement
+- expanded week content uses the same overlap-and-reveal idea as weekly notes
+- CTAs remain visually subordinate to the main header card
+
+## Link Rules
+
+The public leaderboard establishes two important link conventions:
+
+1. Important Strava destination titles are usually the link themselves.
+2. External-link icons are inline companions to the text, not detached action buttons.
+
+Rules:
+- for route, week, or destination title links, prefer the linked-name pattern over a separate icon-only action
+- use `var(--wmv-orange)` for high-signal interactive links tied to the sport object itself
+- avoid button-styling normal navigation or outbound links when a text link is clearer
+
+## Reuse Rules For Explorer
+
+Explorer should default to the leaderboard system in this order:
+
+1. Reuse the existing token and typography system from `src/index.css`.
+2. Reuse `leaderboard-card` and `card-*` classes from `src/components/Card.css` whenever the Explorer surface is still fundamentally a card.
+3. Reuse `week-header-chip` for compact metadata before inventing a new chip style.
+4. Reuse the linked-title pattern from `WeeklyHeader.tsx` for public-facing Explorer destination titles.
+5. Only add Explorer-specific classes for layout or semantics the leaderboard primitives do not already express.
+
+Do not treat legacy admin components as the source of truth for public Explorer UI.
+
+## Patterns That Are Not Yet Fully Defined
+
+The leaderboard does not yet provide a complete design system for:
+
+- forms and field groups
+- admin action buttons
+- validation and toast states
+- destructive actions
+- dense configuration panels
+
+When new Explorer or admin work needs these patterns:
+- define them deliberately
+- prefer tokenized colors and existing spacing rhythm
+- document the new primitive once it stabilizes
+- do not backfill from old admin CSS by default
+
+## Design Audit Checklist
+
+Before approving a new leaderboard-inspired UI, check:
+
+1. Does it use `src/index.css` tokens instead of hardcoded colors and ad hoc font sizes?
+2. Does it reuse `leaderboard-card`, `card-*`, or `week-header-chip` where the semantics match?
+3. Does the title, metadata, and value hierarchy feel consistent with Weekly, Season, or Schedule?
+4. Is the link treatment consistent with the public leaderboard rather than legacy admin?
+5. Are any new classes truly new primitives, or are they accidental duplicates of existing ones?
+6. If a new primitive is real, has it been documented here or in a companion UI standard?
+
+## Non-Authoritative References
+
+These components may still be useful, but they do not outrank the leaderboard sources above for public Explorer UX:
+
+- legacy admin panels
+- older management screens such as season and segment admin views
+- one-off exploratory component CSS
+
+If these surfaces conflict with the leaderboard system, follow the leaderboard system unless product requirements explicitly say otherwise.

--- a/docs/LEADERBOARD_DESIGN_SYSTEM.md
+++ b/docs/LEADERBOARD_DESIGN_SYSTEM.md
@@ -6,6 +6,7 @@ Scope:
 - Weekly leaderboard
 - Season leaderboard
 - Schedule tab
+- Segment-linked surfaces reused inside those tabs
 - Shared primitives those tabs already use
 
 Out of scope:
@@ -25,6 +26,8 @@ Use these files in this order when building or reviewing leaderboard-style UI:
 | Weekly header pattern | `src/components/WeeklyHeader.tsx` | Primary hero card for weekly and schedule surfaces |
 | Weekly participant card | `src/components/LeaderboardCard.tsx` | Rank card composition, expanded detail treatment |
 | Season participant card | `src/components/SeasonCard.tsx` | Season-card hierarchy and compact metadata pill treatment |
+| Segment card primitive | `src/components/SegmentCard.tsx` and `src/components/SegmentCard.css` | Compact segment or destination title and metadata treatment |
+| Segment profile wrapper | `src/components/CollapsibleSegmentProfile.tsx` | Collapsible segment-detail heading and reveal pattern |
 | Weekly tab composition | `src/components/WeeklyLeaderboard.tsx` | Card stacking, expansion rhythm, no-results state |
 | Schedule tab composition | `src/components/ScheduleTable.tsx` and `src/components/ScheduleTable.css` | Week-list rhythm, next-up badge, schedule expansion layout |
 
@@ -151,6 +154,39 @@ Common traits:
 - animation is modest and short-lived
 - the expanded layer should not visually compete with the main card shell
 
+### Segment And Destination Metadata Card Pattern
+
+`src/components/SegmentCard.tsx` and `src/components/SegmentCard.css` define a compact metadata card that is not the same thing as a leaderboard row.
+
+Use this pattern when the UI is presenting a segment-like object or destination-like object as a compact reference card rather than as a ranked participant row.
+
+Defining traits:
+- title line uses `var(--font-base)` with a dark text heading tone
+- the segment or destination name itself is the Strava link
+- the link uses the orange `.segment-link` treatment with `font-weight: 600`
+- optional identity metadata such as the segment ID appears as a warm pill, not as dominant body text
+- secondary metadata sits below the title in a single compact row with muted tone and bullet separators
+- location, distance, and average grade live at the same hierarchy level unless product requirements elevate one of them
+
+Rules:
+- use this pattern as the primary source of truth when Explorer destinations are acting more like segment objects than like leaderboard standings
+- do not force these objects into `leaderboard-card` row anatomy when there is no rank, avatar, or right-side value hierarchy
+- if a destination card blends leaderboard shell plus segment metadata, the segment title and metadata treatment should still come from `SegmentCard`
+
+### Segment Profile Reveal Pattern
+
+`src/components/CollapsibleSegmentProfile.tsx` defines the segment-profile reveal used inside Weekly and Schedule expanded states.
+
+Defining traits:
+- the section label is uppercase, compact, and secondary in tone
+- the profile toggle is lightweight and text-led, not a large button chrome treatment
+- the reveal animation is small and attached to the parent expanded surface
+- the profile content is subordinate to the parent week card, not a competing hero surface
+
+Rules:
+- when Explorer needs to reveal deeper destination geometry or embedded segment detail, this is the closest reference pattern
+- prefer a lightweight heading-plus-chevron reveal before introducing a new destination-detail container system
+
 ## Tab-Specific Patterns
 
 ### Weekly
@@ -167,6 +203,7 @@ Defining traits:
 - metadata directly under the title is quiet and compact
 - detailed rider rows use the shared card shell, not bespoke component framing
 - expanded rider details keep metrics and links compact, not dashboard-like
+- segment profile reveal inside expanded notes uses the lightweight `CollapsibleSegmentProfile` pattern rather than a second hero card
 
 ### Season
 
@@ -200,10 +237,16 @@ The public leaderboard establishes two important link conventions:
 1. Important Strava destination titles are usually the link themselves.
 2. External-link icons are inline companions to the text, not detached action buttons.
 
+There are two valid title-link expressions in the current system:
+
+- `WeeklyHeader` pattern: linked title plus inline external-link icon for a hero-level week surface
+- `SegmentCard` pattern: linked title text without detached icon-first chrome for compact segment-object cards
+
 Rules:
 - for route, week, or destination title links, prefer the linked-name pattern over a separate icon-only action
 - use `var(--wmv-orange)` for high-signal interactive links tied to the sport object itself
 - avoid button-styling normal navigation or outbound links when a text link is clearer
+- choose between the `WeeklyHeader` link treatment and the `SegmentCard` link treatment based on hierarchy, not personal preference
 
 ## Reuse Rules For Explorer
 
@@ -212,8 +255,10 @@ Explorer should default to the leaderboard system in this order:
 1. Reuse the existing token and typography system from `src/index.css`.
 2. Reuse `leaderboard-card` and `card-*` classes from `src/components/Card.css` whenever the Explorer surface is still fundamentally a card.
 3. Reuse `week-header-chip` for compact metadata before inventing a new chip style.
-4. Reuse the linked-title pattern from `WeeklyHeader.tsx` for public-facing Explorer destination titles.
-5. Only add Explorer-specific classes for layout or semantics the leaderboard primitives do not already express.
+4. Reuse `SegmentCard` title and metadata treatment whenever an Explorer destination is behaving like a compact segment object.
+5. Reuse the linked-title pattern from `WeeklyHeader.tsx` for hero-level Explorer headers or destination surfaces that are acting like weekly-header analogs.
+6. Reuse `CollapsibleSegmentProfile` as the default reference for deeper segment or destination detail reveals inside expanded surfaces.
+7. Only add Explorer-specific classes for layout or semantics the leaderboard primitives do not already express.
 
 Do not treat legacy admin components as the source of truth for public Explorer UI.
 
@@ -239,10 +284,11 @@ Before approving a new leaderboard-inspired UI, check:
 
 1. Does it use `src/index.css` tokens instead of hardcoded colors and ad hoc font sizes?
 2. Does it reuse `leaderboard-card`, `card-*`, or `week-header-chip` where the semantics match?
-3. Does the title, metadata, and value hierarchy feel consistent with Weekly, Season, or Schedule?
-4. Is the link treatment consistent with the public leaderboard rather than legacy admin?
-5. Are any new classes truly new primitives, or are they accidental duplicates of existing ones?
-6. If a new primitive is real, has it been documented here or in a companion UI standard?
+3. Does it use `SegmentCard` conventions when the surface is fundamentally a segment or destination object rather than a ranking row?
+4. Does the title, metadata, and value hierarchy feel consistent with Weekly, Season, Schedule, or Segment patterns?
+5. Is the link treatment consistent with the public leaderboard rather than legacy admin?
+6. Are any new classes truly new primitives, or are they accidental duplicates of existing ones?
+7. If a new primitive is real, has it been documented here or in a companion UI standard?
 
 ## Non-Authoritative References
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,6 +35,7 @@ Welcome to the WMV Cycling Series documentation. Start with **Getting Started**,
 ### Branding & Standards
 
 - **[Strava Branding](../STRAVA_BRANDING.md)** - OAuth button guidelines and attribution
+- **[Leaderboard Design System](./LEADERBOARD_DESIGN_SYSTEM.md)** - Canonical UI language for the Weekly, Season, and Schedule tabs
 
 ---
 
@@ -62,6 +63,7 @@ Welcome to the WMV Cycling Series documentation. Start with **Getting Started**,
 
 ### Frontend Developer
 - Reference: [Architecture Overview](./ARCHITECTURE.md)
+- UI source of truth: [Leaderboard Design System](./LEADERBOARD_DESIGN_SYSTEM.md)
 - API calls: [API Reference](./API.md)
 - Auth flow: [Strava Integration](./STRAVA_INTEGRATION.md)
 
@@ -76,6 +78,7 @@ Welcome to the WMV Cycling Series documentation. Start with **Getting Started**,
 ├── QUICK_START.md              # Get running in 5 minutes
 ├── ARCHITECTURE.md             # System design overview
 ├── API.md                      # Endpoint reference
+├── LEADERBOARD_DESIGN_SYSTEM.md # Weekly/Season/Schedule UI source of truth
 ├── DATABASE_DESIGN.md          # Schema and queries
 ├── STRAVA_INTEGRATION.md       # OAuth and activity flow
 ├── WEBHOOKS.md                 # Real-time webhook processing
@@ -99,6 +102,7 @@ Welcome to the WMV Cycling Series documentation. Start with **Getting Started**,
 | **QUICK_START.md** | Get running immediately | You want to run the app NOW |
 | **ARCHITECTURE.md** | Understand the system | You want to understand how it works |
 | **API.md** | Reference all endpoints | You're building features |
+| **LEADERBOARD_DESIGN_SYSTEM.md** | Public leaderboard UI rules | You're building or reviewing leaderboard-style UI |
 | **DATABASE_DESIGN.md** | Understand the schema | You're working with data |
 | **STRAVA_INTEGRATION.md** | Learn OAuth + activity flow | You're integrating Strava or debugging auth |
 | **WEBHOOKS.md** | Real-time webhook processing | You're implementing/understanding webhooks |

--- a/docs/prds/wmv-explorer-destinations-phases.md
+++ b/docs/prds/wmv-explorer-destinations-phases.md
@@ -152,7 +152,7 @@ Scope:
 	- parse and validate a pasted Strava segment URL quickly using the existing validation seam
 	- show an immediate preview card with segment details before persistence
 	- provide icon-first accept and reject controls for the previewed destination, with accessible text or `aria-label` support
-	- allow the optional Explorer display label to be set during the preview step rather than through a heavier follow-up form
+	- defer optional Explorer display-label overrides until a later slice instead of reintroducing a heavier follow-up form into 4B-3
 - Render already-added campaign destinations as richer cards instead of a plain list so admins can see what is already in the campaign at a glance.
 - Extend Explorer admin read-side data only as needed to support richer accepted-destination cards, including the currently available distance, average grade, city, state, country, and source URL values.
 - Make the original Strava segment source clearly clickable from the accepted destination card without falling back to button-like link treatment.

--- a/docs/prds/wmv-explorer-destinations-phases.md
+++ b/docs/prds/wmv-explorer-destinations-phases.md
@@ -97,7 +97,7 @@ Out of scope:
 
 Goal: make Explorer and existing Playwright coverage run against a portable, explicit, repeatable E2E harness before adding more admin UI surface.
 
-Status: complete in the current local implementation work. The remaining operational step is to stage or PR the harness-only file set separately from the 4B-2 admin UI follow-on files.
+Status: merged as the portable baseline for later Explorer UI work.
 
 Scope:
 
@@ -123,7 +123,7 @@ Implementation notes:
 
 Goal: expose the approved admin backend capabilities through an admin-only WMV surface once the E2E harness is portable enough to support repeatable regression coverage.
 
-Status: complete in the current local implementation work as a minimal admin-gated setup surface. The next step should return to planning for a follow-on admin UX refinement slice rather than continue broadening this implementation branch opportunistically.
+Status: merged as the minimal admin-gated setup surface. The next step should build a bounded admin UX refinement slice from updated `main` on a fresh branch rather than continue broadening 4B-2 opportunistically.
 
 Scope:
 
@@ -137,6 +137,45 @@ Scope:
 Follow-on planning note:
 
 - Treat richer admin guidance, stronger client-side segment validation, and broader card or component-system refinement as the next planning surface, not as open-ended scope creep inside 4B-2.
+
+### Slice 4B-3: Admin UX Refinement (Card-First Destination Authoring)
+
+Goal: refine Explorer admin setup into a more interactive, card-first authoring experience that mirrors the existing WMV leaderboard surfaces and supports repeated paste-and-add destination setup without widening into the full later admin-management backlog.
+
+Status: ready for implementation from updated `main` on a dedicated feature branch now that 4B-2 is merged.
+
+Scope:
+
+- Reuse existing WMV card patterns where practical for Explorer admin hierarchy instead of continuing with bespoke form-block presentation.
+- Keep the season and campaign framing at the top of the screen, but restyle it into the same card language used by the leaderboard, weekly, season, and schedule surfaces.
+- Replace the plain add-destination form with an interactive authoring card that supports repeated paste-and-add work:
+	- parse and validate a pasted Strava segment URL quickly using the existing validation seam
+	- show an immediate preview card with segment details before persistence
+	- provide icon-first accept and reject controls for the previewed destination, with accessible text or `aria-label` support
+	- allow the optional Explorer display label to be set during the preview step rather than through a heavier follow-up form
+- Render already-added campaign destinations as richer cards instead of a plain list so admins can see what is already in the campaign at a glance.
+- Extend Explorer admin read-side data only as needed to support richer accepted-destination cards, including the currently available distance, average grade, city, state, country, and source URL values.
+- Make the original Strava segment source clearly clickable from the accepted destination card without falling back to button-like link treatment.
+
+Out of scope:
+
+- Strava segment search or discovery workflows
+- Persisted edit, remove, or reorder flows for already-added destinations
+- Refresh or backfill mutations
+- Athlete-facing Explorer hub work
+- Public Explorer navigation or release exposure
+
+Validation:
+
+- Frontend unit tests for the authoring-card state flow, including paste, validation, preview, accept, reject, and repeated add behavior
+- Focused backend service or router tests only if the Explorer admin read shape is expanded for richer destination cards
+- Targeted Playwright coverage for the admin paste-validate-preview-add flow and the accepted-destination card rendering
+- Slice-normal `npm run lint`, `npm run typecheck`, and targeted build verification
+
+Implementation note:
+
+- If the slice later grows to include persisted inline editing for accepted destination cards, that should be called out explicitly as a scope change because it pulls in new admin mutations rather than remaining a UI refinement only.
+- True map plotting is not part of 4B-3. The current shared segment model carries location text fields, but a future map slice may still require coordinate or geometry storage if the product needs real map pins rather than text-only place context.
 
 ## Phase 5: Explorer Hub MVP
 

--- a/docs/prds/wmv-explorer-execution-briefing.md
+++ b/docs/prds/wmv-explorer-execution-briefing.md
@@ -179,10 +179,8 @@ Prompts should remain narrow and convenient.
 
 ### Slice-splitting note for 4B
 
-- Phase 4B is now intended to land as two implementation branches, not one mixed branch.
-- 4B-1 has now hardened the portable E2E harness locally and should be preserved as its own clean commit or PR set.
-- 4B-2 should add the admin-only Explorer UI only after the harness-only changes are merged or cleanly staged on top of them.
-- Do not leave harness surgery and admin UI work interleaved on the same long-running branch once the split is approved in the planning docs.
+- The earlier 4B split is now complete: 4B-1 hardened the portable E2E harness and 4B-2 landed the minimal admin-only Explorer UI.
+- Follow-on work should now start from updated `main` on a fresh branch for the approved 4B-3 admin UX refinement slice rather than reopening the already-merged split work.
 
 ### Slice completion discipline
 

--- a/docs/prds/wmv-explorer-readiness-checklist.md
+++ b/docs/prds/wmv-explorer-readiness-checklist.md
@@ -17,21 +17,23 @@ The ideas backlog is intentionally excluded from v1 implementation scope. It exi
 
 ## Current Go Decision
 
-**Status:** Phase 1 Complete; Season-Campaign Correction Landed; Backend Campaign Slice Merged; Phase 4A Admin Backend Complete; Phase 4B-1 E2E Harness Hardening Merged; Phase 4B-2 Minimal Admin UI Implemented Locally; Ready For Admin UX Refinement Planning
+**Status:** Phase 1 Complete; Season-Campaign Correction Landed; Backend Campaign Slice Merged; Phase 4A Admin Backend Complete; Phase 4B-1 E2E Harness Hardening Merged; Phase 4B-2 Minimal Admin UI Merged; Ready For Phase 4B-3 Admin UX Refinement
 
-Explorer has completed the narrow Phase 1 webhook-orchestration slice that preserves current competition behavior while introducing delegated in-process handlers. The planning set on this branch now corrects the MVP to a season-campaign-first model attached to an existing WMV season, with optional mini-campaigns and explicit publish-status workflows deferred. The backend campaign slice is merged, the 4A admin backend slice is landed, the 4B-1 portable harness work is merged, and the 4B-2 admin-gated UI now exists as a minimal setup surface with local unit, backend, E2E, lint, typecheck, build, and audit validation. The next recommended work is to return to planning for a bounded admin UX refinement slice rather than continue broadening 4B-2 ad hoc.
+Explorer has completed the narrow Phase 1 webhook-orchestration slice that preserves current competition behavior while introducing delegated in-process handlers. The planning set on this branch now corrects the MVP to a season-campaign-first model attached to an existing WMV season, with optional mini-campaigns and explicit publish-status workflows deferred. The backend campaign slice is merged, the 4A admin backend slice is landed, the 4B-1 portable harness work is merged, and the 4B-2 admin-gated UI is now merged as a minimal setup surface. The next recommended work is a bounded 4B-3 admin UX refinement slice that improves repeated paste-and-add authoring and card presentation without widening into the later admin-management backlog.
+
+The current 4B-3 boundary is now explicit: no persisted inline card editing in this slice, icon-first preview actions with accessible labels, accepted destination cards that surface the existing distance, average grade, location, and source-link metadata, and no attempt to solve true map plotting until a later slice defines any needed coordinate or geometry storage.
 
 ## Current Status Summary
 
 | Area | Status | Notes |
 | --- | --- | --- |
 | Product framing | Ready | The PRD is clear on goals, users, must-haves, non-goals, and success criteria. |
-| Execution phasing | Ready For Next Planning Slice | The phases doc now treats 4B-2 as the minimal admin-gated UI completion point and sends the next work back through planning for admin UX refinement. |
-| Architecture closure | Ready For Next Planning Slice | The technical spec and landed slices are sufficient for a planning pass on the next admin UX improvement slice without reopening the campaign model or harness work. |
+| Execution phasing | Ready For Phase 4B-3 | The phases doc now treats 4B-2 as merged and names 4B-3 as the bounded admin UX refinement slice. |
+| Architecture closure | Ready For Phase 4B-3 | The technical spec and landed slices are sufficient for the next admin UX improvement slice without reopening the campaign model or harness work, though true map rendering remains a later non-blocking data-shape question. |
 | Open questions handling | Ready | The worklog now records the corrected model plus the remaining non-blocking questions. |
-| Blocking research closure | Ready For Next Planning Slice | The product-intent correction is closed for this branch. |
-| Test planning | Ready For Next Planning Slice | The minimal admin UI is now validated, so the next test-planning work should attach to the separate admin UX refinement slice. |
-| Documentation impact plan | Ready For Next Planning Slice | The next documentation impact is the planning handoff for admin UX refinement rather than more broadening of the current implementation slice. |
+| Blocking research closure | Ready For Phase 4B-3 | The product-intent correction is closed for this branch. |
+| Test planning | Ready For Phase 4B-3 | The next test-planning work is attached to the bounded admin UX refinement slice rather than to a broad continuation of 4B-2. |
+| Documentation impact plan | Ready For Phase 4B-3 | The next documentation impact is the 4B-3 planning handoff plus any Explorer admin read-contract notes needed for richer destination cards. |
 
 ## Must Resolve Before Broad Implementation
 
@@ -66,7 +68,7 @@ Explorer has completed the narrow Phase 1 webhook-orchestration slice that prese
 | Why it matters | Explorer destination setup depends on how segment data is validated, stored, and displayed over time. |
 | Evidence | The current UI already has real segment URL parsing and validation patterns in [src/components/SegmentInput.tsx](../../src/components/SegmentInput.tsx) and [src/components/ManageSegments.tsx](../../src/components/ManageSegments.tsx), but the Explorer spec still leaves room for multiple storage strategies. |
 | Acceptance criteria | The tech spec explicitly states whether Explorer reuses the existing segment table, stores Explorer-local cached metadata, or uses both with clear responsibilities for each. |
-| Next action | Carry the locked storage responsibilities and DB-first segment reuse policy into the corrected implementation slice. |
+| Next action | Carry the locked storage responsibilities and DB-first segment reuse policy into 4B-3, and treat any future coordinate or geometry storage for maps as a later non-blocking expansion rather than as part of this UI slice. |
 
 ### 4. Centralized Open Questions
 
@@ -86,8 +88,8 @@ Explorer has completed the narrow Phase 1 webhook-orchestration slice that prese
 | Status | Ready |
 | Gate | Must Resolve |
 | Why it matters | The team needs a shared rule for what can proceed now versus what must wait for the season-model correction. |
-| Evidence | The implemented webhook seam remains valid, the backend campaign slice is merged, the 4A admin backend contract is landed, and the next slice is now re-approved as Phase 4B admin-gated UI work against the corrected season campaign model. |
-| Acceptance criteria | The readiness artifacts clearly state that Explorer is ready for one bounded admin-UI slice next and identify what remains out of scope. |
+| Evidence | The implemented webhook seam remains valid, the backend campaign slice is merged, the 4A admin backend contract is landed, the 4B-2 minimal admin UI is merged, and the next slice is now re-approved as Phase 4B-3 admin UX refinement against the corrected season campaign model. |
+| Acceptance criteria | The readiness artifacts clearly state that Explorer is ready for one bounded admin-UX slice next and identify what remains out of scope. |
 | Next action | Keep the current go decision updated as additional corrected Explorer slices are approved or deferred, and close slice-local planning state in the implementation PR when the slice changes readiness or phase status. |
 
 ## Should Resolve Before 4A And 4B Expand
@@ -112,18 +114,18 @@ Explorer has completed the narrow Phase 1 webhook-orchestration slice that prese
 | Why it matters | Explorer admin UI flows and the existing Playwright suite need repeatable end-to-end coverage, and the current code path reaches outbound Strava services from the backend during destination authoring and some read flows. |
 | Evidence | The backend now has an explicit E2E mode in [server/src/config.ts](../../server/src/config.ts), the E2E database resets from the committed sanitized fixture [server/data/wmv_e2e_fixture.db](../../server/data/wmv_e2e_fixture.db), and deterministic read-side Strava behavior now flows through explicit providers in [server/src/services/segmentMetadataProvider.ts](../../server/src/services/segmentMetadataProvider.ts) and [server/src/services/stravaReadProvider.ts](../../server/src/services/stravaReadProvider.ts) rather than through scattered service-level `isE2EMode()` branches. Full validation is green, including `npm test`, `npm run test:e2e`, `npm run typecheck`, `npm run lint`, and `npm run build`. |
 | Acceptance criteria | Explorer and existing E2E scenarios run against an explicit backend E2E mode, deterministic campaign and leaderboard data are provisioned without copying a contributor's local development database, and outbound Strava-dependent behavior is selected through explicit providers rather than scattered feature-level short-circuits. |
-| Next action | Preserve the harness-only file set as its own commit or PR, then build the 4B-2 admin UI slice on top of that stabilized baseline. |
+| Next action | Preserve the centralized E2E-mode and explicit-provider discipline as 4B-3 refines the admin UX on top of the merged harness baseline. |
 
 ### 3. Documentation Impact Plan
 
 | Field | Value |
 | --- | --- |
-| Status | Ready For Phase 4B-2 |
+| Status | Ready For Phase 4B-3 |
 | Gate | Should Resolve |
 | Why it matters | Explorer touches admin, athlete, API, database, and release-note surfaces. That work should be visible before coding. |
-| Evidence | The 4A slice updated `docs/API.md`, `docs/DATABASE_DESIGN.md`, and the slice-local planning docs while still deferring user-facing release-note files. The next harness slice will also need E2E doc updates because current reality changed again. |
+| Evidence | The 4A slice updated `docs/API.md`, `docs/DATABASE_DESIGN.md`, and the slice-local planning docs while still deferring user-facing release-note files. The 4B-3 slice may also need `docs/API.md` updates if richer Explorer admin destination cards require extra read-side fields. |
 | Acceptance criteria | The worklog or implementation slice names the docs expected to change when the slice lands, including any slice-local planning docs needed to close the state transition. |
-| Next action | Keep the documentation-impact checklist current and treat the clean harness PR or commit set plus the 4B-2 UI docs as separate follow-on update sets. |
+| Next action | Keep the documentation-impact checklist current and treat 4B-3 planning-state maintenance plus any slice-local API notes as the next expected update set. |
 
 ### 4. Smallest End-To-End Slice
 
@@ -165,8 +167,9 @@ If a slice is expected to change the approved next step, readiness wording, or p
 | Season-Campaign Correction Landed | Yes |
 | Backend Campaign Slice Merged | Yes |
 | Phase 4A Admin Backend Complete | Yes |
-| Phase 4B-1 E2E Harness Hardening Validated Locally | Yes |
-| Ready For Phase 4B-2 Admin UI | Yes |
+| Phase 4B-1 E2E Harness Hardening Merged | Yes |
+| Phase 4B-2 Minimal Admin UI Merged | Yes |
+| Ready For Phase 4B-3 Admin UX Refinement | Yes |
 | Ready For Broad Feature Implementation | No |
 
-If this file says anything stronger than **Phase 1 Complete; Season-Campaign Correction Landed; Backend Campaign Slice Merged; Phase 4A Admin Backend Complete; Phase 4B-1 E2E Harness Hardening Validated Locally; Ready For Phase 4B-2 Admin UI**, the linked worklog should show exactly what changed to justify that shift.
+If this file says anything stronger than **Phase 1 Complete; Season-Campaign Correction Landed; Backend Campaign Slice Merged; Phase 4A Admin Backend Complete; Phase 4B-1 E2E Harness Hardening Merged; Phase 4B-2 Minimal Admin UI Merged; Ready For Phase 4B-3 Admin UX Refinement**, the linked worklog should show exactly what changed to justify that shift.

--- a/docs/prds/wmv-explorer-worklog.md
+++ b/docs/prds/wmv-explorer-worklog.md
@@ -4,15 +4,15 @@ This worklog is the active operating log for Explorer. The readiness checklist i
 
 ## Current Focus
 
-- Prepare the next bounded admin UX refinement slice for Explorer admin setup now that 4B-2 is merged.
-- Keep the next slice focused on card-first destination authoring and richer accepted-destination presentation rather than broad Explorer management expansion.
+- Preserve the checkpointed functional 4B-3 admin UX work while documenting the leaderboard design system before more Explorer UX polish continues.
+- Keep the next slice focused on Weekly, Season, and Schedule UI audit and documentation so future Explorer surfaces start from the right public-facing primitives.
 - Keep any pre-release Explorer UI admin-gated until there is an explicit end-user release decision.
 - Keep the next handoff and implementation brief aligned with the landed backend authoring contract plus the existing `segment.validate` preview seam.
 
 ## Current Go State
 
 - **Readiness:** Phase 1 Complete; Season-Campaign Correction Landed; Backend Campaign Slice Merged; Phase 4A Admin Backend Complete; Phase 4B-1 E2E Harness Hardening Merged; Phase 4B-2 Minimal Admin UI Merged; Ready For Phase 4B-3 Admin UX Refinement
-- **Immediate scope:** implement the bounded 4B-3 admin UX refinement slice from updated `main` on a dedicated feature branch
+- **Immediate scope:** document the canonical leaderboard design system and wire that guidance into future Explorer implementation before resuming UX-polish work on top of the checkpointed 4B-3 branch state
 - **Not yet in scope:** public athlete-facing Explorer release, public navigation to Explorer, mini-campaigns, or explicit publish-status workflows
 
 ## Decisions Made
@@ -143,25 +143,23 @@ The current preservation target is backed by:
 
 ### Recommended Next PR
 
-- Start from updated `main` on a dedicated implementation branch.
-- Keep the next implementation PR scoped to Slice 4B-3 only:
-	- reuse existing WMV leaderboard-style card language where practical
-	- convert destination authoring from a plain form into a paste-validate-preview-add card flow
-	- use icon-first accept or reject controls with accessible labeling for previewed destinations
-	- render accepted destinations as richer cards with Explorer-specific labeling plus known segment metadata
-	- make the Strava source link clearly clickable from the accepted card without styling it as a generic button
-	- keep admin authoring fast for repeated paste-and-add sessions
-	- avoid new persisted edit, remove, reorder, refresh, or search workflows unless the slice is explicitly re-approved
+- Start from the checkpointed 4B-3 branch state on a dedicated documentation or design-system branch.
+- Keep the next implementation PR scoped to the leaderboard design-system audit and documentation slice:
+	- document the canonical Weekly, Season, and Schedule design language in one durable reference
+	- identify which shared primitives Explorer should reuse by default
+	- record gaps where the public leaderboard does not yet define a stable form or admin-control pattern
+	- wire the documented guidance into repo instructions or agent-facing surfaces so future Explorer work reads it first
+	- avoid further piecemeal Explorer restyling until that guide exists
 - Validation path for the next PR:
-	- frontend unit coverage for the authoring-card state machine
-	- focused backend coverage only if the Explorer admin read shape grows
-	- targeted Playwright for the authoring and accepted-card flow
-	- normal lint, typecheck, and build verification
+	- document review against the authoritative source files
+	- verify agent-facing references point to the new guide
+	- no product-code validation beyond any touched markdown or instruction surfaces unless the slice expands again
 - Planning and documentation surfaces likely to change when 4B-3 lands:
+	- `docs/LEADERBOARD_DESIGN_SYSTEM.md`
 	- `docs/prds/wmv-explorer-destinations-phases.md`
 	- `docs/prds/wmv-explorer-worklog.md`
 	- `docs/prds/wmv-explorer-readiness-checklist.md`
-	- `docs/API.md` only if the Explorer admin read contract is expanded
+	- repo instruction surfaces such as `AGENTS.md`, `AGENT_USAGE.md`, or `.github/copilot-instructions.md`
 
 ### 4B-3 Implementation Handoff
 

--- a/docs/prds/wmv-explorer-worklog.md
+++ b/docs/prds/wmv-explorer-worklog.md
@@ -172,7 +172,7 @@ The current preservation target is backed by:
 	- the UI parses and validates promptly through the existing `segment.validate` seam
 	- a preview card appears with segment metadata before persistence
 	- the admin explicitly accepts or rejects the preview
-	- the optional Explorer display label is applied during that preview step
+	- optional Explorer display-label entry is deferred from the shipped 4B-3 preview-add flow
 - Backend expectation:
 	- keep the existing `explorerAdmin.addDestination` write contract
 	- expand Explorer admin read-side destination fields only if needed for richer accepted-card rendering
@@ -214,7 +214,7 @@ Required outcome:
 	- the UI validates through the existing `segment.validate` seam
 	- a preview card appears with segment metadata before persistence
 	- the admin uses icon-first accept or reject controls with accessible labels
-	- the optional Explorer display label is applied during that preview step
+	- optional Explorer display-label entry is deferred from the shipped 4B-3 preview-add flow
 - Accepted destinations render as richer cards rather than a plain list.
 - Each accepted destination card shows, when available:
 	- Explorer display label or resolved destination name

--- a/docs/prds/wmv-explorer-worklog.md
+++ b/docs/prds/wmv-explorer-worklog.md
@@ -4,15 +4,15 @@ This worklog is the active operating log for Explorer. The readiness checklist i
 
 ## Current Focus
 
-- Close out Phase 4B-2 as the minimal admin-gated Explorer setup surface.
-- Prepare a planning handoff for the next admin UX refinement slice instead of broadening 4B-2 in-place.
+- Prepare the next bounded admin UX refinement slice for Explorer admin setup now that 4B-2 is merged.
+- Keep the next slice focused on card-first destination authoring and richer accepted-destination presentation rather than broad Explorer management expansion.
 - Keep any pre-release Explorer UI admin-gated until there is an explicit end-user release decision.
-- Keep the next handoff and implementation brief aligned with the landed backend authoring contract.
+- Keep the next handoff and implementation brief aligned with the landed backend authoring contract plus the existing `segment.validate` preview seam.
 
 ## Current Go State
 
-- **Readiness:** Phase 1 Complete; Season-Campaign Correction Landed; Backend Campaign Slice Merged; Phase 4A Admin Backend Complete; Phase 4B-1 E2E Harness Hardening Merged; Phase 4B-2 Minimal Admin UI Implemented Locally; Ready For Admin UX Refinement Planning
-- **Immediate scope:** land the minimal 4B-2 admin-gated setup surface, then return to planning for the next bounded admin UX slice
+- **Readiness:** Phase 1 Complete; Season-Campaign Correction Landed; Backend Campaign Slice Merged; Phase 4A Admin Backend Complete; Phase 4B-1 E2E Harness Hardening Merged; Phase 4B-2 Minimal Admin UI Merged; Ready For Phase 4B-3 Admin UX Refinement
+- **Immediate scope:** implement the bounded 4B-3 admin UX refinement slice from updated `main` on a dedicated feature branch
 - **Not yet in scope:** public athlete-facing Explorer release, public navigation to Explorer, mini-campaigns, or explicit publish-status workflows
 
 ## Decisions Made
@@ -35,6 +35,9 @@ This worklog is the active operating log for Explorer. The readiness checklist i
 - 4A destination authoring accepts validated Strava segment URLs, not raw segment IDs.
 - If URL parsing succeeds but live Strava metadata enrichment fails, destination creation still succeeds with stored segment ID and source URL.
 - Refresh and backfill admin mutations are deferred out of 4A.
+- 4B-3 should defer persisted inline editing for accepted destination cards and keep the slice focused on preview-add authoring plus richer read-only cards.
+- Icon-first admin actions are the preferred interaction style going forward, provided they keep accessible labels.
+- The first accepted-destination card metadata set for 4B-3 should surface distance, average grade, location text, and a clearly clickable source link back to Strava.
 
 ## Open Questions
 
@@ -53,6 +56,8 @@ This worklog is the active operating log for Explorer. The readiness checklist i
 | Should 4A accept raw segment IDs as an admin authoring input? | Closed | No | No. Use validated Strava segment URLs only in the 4A backend contract. |
 | What happens if URL parsing succeeds but live metadata enrichment fails? | Closed | No | Allow creation and preserve segment ID plus source URL for later repair. |
 | Do refresh and backfill admin mutations belong in 4A? | Closed | No | No. Defer them to a later admin slice. |
+| Should already-added Explorer destination cards support persisted inline editing in the first UX-refinement slice? | Closed For 4B-3 | No | No. Keep 4B-3 to preview-add flow plus richer read-only cards. |
+| Does 4B-3 need true map-ready coordinate storage for accepted destination cards? | Open | No | No for 4B-3. Current location text plus source link are enough for this slice, but actual map rendering may require later schema or API expansion for coordinates or geometry. |
 
 ## Blockers
 
@@ -139,102 +144,131 @@ The current preservation target is backed by:
 ### Recommended Next PR
 
 - Start from updated `main` on a dedicated implementation branch.
-- Keep the current implementation PR scoped to the minimal 4B-2 admin-gated UI surface:
-	- create-campaign and add-destination admin flows on top of the stabilized harness
-	- targeted browser coverage for the admin surface
-	- no public athlete-facing Explorer exposure
-	- slice-local planning updates that mark 4B-2 complete and hand back to planning for the next slice
-- The next planning pass should define a separate admin UX refinement slice for:
-	- clearer setup guidance and validation feedback
-	- stronger client-side segment URL assistance
-	- more intentional component reuse and card hierarchy aligned with the existing WMV surfaces
-	- any workflow changes beyond the minimal 4A contract exposure
+- Keep the next implementation PR scoped to Slice 4B-3 only:
+	- reuse existing WMV leaderboard-style card language where practical
+	- convert destination authoring from a plain form into a paste-validate-preview-add card flow
+	- use icon-first accept or reject controls with accessible labeling for previewed destinations
+	- render accepted destinations as richer cards with Explorer-specific labeling plus known segment metadata
+	- make the Strava source link clearly clickable from the accepted card without styling it as a generic button
+	- keep admin authoring fast for repeated paste-and-add sessions
+	- avoid new persisted edit, remove, reorder, refresh, or search workflows unless the slice is explicitly re-approved
+- Validation path for the next PR:
+	- frontend unit coverage for the authoring-card state machine
+	- focused backend coverage only if the Explorer admin read shape grows
+	- targeted Playwright for the authoring and accepted-card flow
+	- normal lint, typecheck, and build verification
+- Planning and documentation surfaces likely to change when 4B-3 lands:
+	- `docs/prds/wmv-explorer-destinations-phases.md`
+	- `docs/prds/wmv-explorer-worklog.md`
+	- `docs/prds/wmv-explorer-readiness-checklist.md`
+	- `docs/API.md` only if the Explorer admin read contract is expanded
 
-### 4B-1 Harness Recommendation
+### 4B-3 Implementation Handoff
 
-- Prefer a general backend E2E mode rather than a single Explorer-only env flag.
-- Keep that mode narrow: it should enable test-only auth helpers, fail-fast environment validation, and dependency selection for outbound integrations.
-- Do not use the general mode to hide ad hoc behavior changes deep in feature logic.
-- For external calls, use explicit provider selection where needed. For example, Strava-dependent server behavior should choose live, fixture-backed, or mock-server-backed behavior intentionally rather than inferring it indirectly.
-- The portable-harness goal is that a fresh clone can run `npm run test:e2e` without depending on a contributor's pre-existing development database.
-- If a checked-in E2E database is used, it must be sanitized and must not contain live Strava OAuth secrets.
-- Real Strava OAuth should remain optional for exploratory manual runs only, not for regression E2E.
-
-### 4B-1 Implementation Handoff
-
-- Slice: Phase 4B-1 only.
+- Slice: Phase 4B-3 only.
 - Branch start point: updated `main`, then a dedicated feature branch before coding.
-- Governing scope: portable E2E harness hardening that supports the landed 4A backend contract and existing browser coverage, with no public Explorer exposure.
-- Harness rule: keep E2E and test-mode checks centralized in config, app bootstrap, and scripts rather than scattering them through feature logic.
-- Backend wiring recommendation:
-	- one explicit backend E2E mode for test-only wiring
-	- explicit provider selection for outbound integrations
-	- fail-fast startup or test bootstrap when the expected E2E env is missing
-- First outbound seam to implement: deterministic segment metadata lookup for `explorerAdmin.addDestination`.
-- Additional requirement: remove reliance on copied development token rows or other local-only state for normal E2E regression runs.
+- Governing scope: card-first destination authoring and richer accepted-destination cards on top of the already-merged 4B-1 harness and 4B-2 minimal UI baseline.
+- UI rule: prefer reuse of the existing WMV leaderboard card language and component patterns where that reuse clarifies hierarchy, rather than layering more bespoke Explorer-only form styling.
+- Authoring flow recommendation:
+	- admin pastes a Strava segment URL
+	- the UI parses and validates promptly through the existing `segment.validate` seam
+	- a preview card appears with segment metadata before persistence
+	- the admin explicitly accepts or rejects the preview
+	- the optional Explorer display label is applied during that preview step
+- Backend expectation:
+	- keep the existing `explorerAdmin.addDestination` write contract
+	- expand Explorer admin read-side destination fields only if needed for richer accepted-card rendering
+	- do not add persisted edit, remove, reorder, refresh, or search mutations in this slice
 - Existing Playwright impact:
-	- keep current browser-side interception for UI-only Strava rendering tests
-	- keep current e2e-login auth helper for logged-in browser coverage
-	- add the new backend provider behavior only where server-side Strava calls are part of the tested flow
+	- preserve the admin-only route and navigation behavior
+	- add or adjust browser coverage only for the interactive preview-add flow and accepted-card presentation
+	- continue using the hardened E2E harness rather than local-only assumptions
 
-### 4B-1 Branch-Ready Task List
+### 4B-3 Branch-Ready Task List
 
-1. Add a single backend E2E mode entrypoint in config or bootstrap and make Playwright fail fast if the intended env file is missing.
-2. Replace the copied-dev-database approach with a deterministic E2E data source that is safe for contributors and CI.
-3. Add explicit provider selection for Strava-dependent backend behavior, starting with fixture-backed segment metadata for Explorer admin destination authoring and removing scattered business-logic short-circuits where possible.
-4. Fix brittle Playwright assumptions such as hard-coded local URLs or seed-specific IDs so the suite matches the portable harness.
-5. Update shared docs that describe E2E behavior and the Explorer planning state so they match the implemented harness.
+1. Rework the Explorer admin screen so season summary, campaign summary, authoring, and accepted destinations follow a coherent card hierarchy aligned with the current WMV leaderboard surfaces.
+2. Replace the plain add-destination form with a fast paste-validate-preview-add interaction using the existing segment-validation seam.
+3. Extend accepted-destination cards to show richer segment details already known to the system, such as distance, grade, and location, plus Explorer-specific label context.
+4. Keep campaign creation visually consistent with the updated card hierarchy without widening into broader management workflows.
+5. Update slice-local tests and planning docs so the merged outcome clearly records 4B-3 completion and the next approved Explorer step.
 
-### Current Working Tree Split Plan
+### 4B-3 Implementation Brief
 
-Use this split if the current mixed branch needs to be separated into a harness PR and a later UI PR.
+- Phase: 4B-3 Admin UX Refinement
+- Readiness state: approved to implement now; no blocking planning questions remain for this slice
+- Branch start point: commit the current planning-doc updates on `main`, then create a fresh feature branch from updated `main` before any product-code changes
 
-Harness-first files for 4B-1:
+Primary governing references:
 
-- `.gitignore`
 - `docs/prds/wmv-explorer-destinations-phases.md`
-- `docs/prds/wmv-explorer-execution-briefing.md`
 - `docs/prds/wmv-explorer-readiness-checklist.md`
-- `docs/prds/wmv-explorer-worklog.md`
-- `e2e/README.md`
-- `e2e/auth.setup.ts`
-- `e2e/fixtures/test-helpers.ts`
-- `e2e/tests/authenticated.spec.ts`
-- `e2e/tests/leaderboard-card.spec.ts`
-- `package.json`
-- `playwright.config.ts`
-- `server/data/wmv_e2e_fixture.db`
-- `server/scripts/build-e2e-fixture.cjs`
-- `server/src/config.ts`
-- `server/src/db.ts`
-- `server/src/index.ts`
-- `server/src/__tests__/stravaReadProvider.test.ts`
-- `server/src/services/ClubService.ts`
-- `server/src/services/LoginService.ts`
-- `server/src/services/SegmentService.ts`
-- `server/src/services/StravaProfileService.ts`
-- `server/src/services/WebhookAdminService.ts`
-- `server/src/services/segmentMetadataFixtures.ts`
-- `server/src/services/segmentMetadataProvider.ts`
-- `server/src/services/stravaReadProvider.ts`
+- `docs/prds/wmv-explorer-destinations-tech-spec.md` sections `5.3 Segment source model`, `6.2 Explorer query service`, `6.3 Explorer admin service`, and `8.2 Admin surface`
 
-UI-follow-on files for 4B-2:
+Goal:
 
-- `src/App.tsx`
-- `src/components/NavBar.tsx`
-- `src/components/ExplorerAdminPanel.tsx`
-- `src/components/ExplorerAdminPanel.css`
-- `e2e/tests/explorer-admin.authenticated.spec.ts`
-- `server/src/routers/explorerAdmin.ts`
-- `server/src/services/ExplorerQueryService.ts`
-- `server/src/__tests__/trpc/explorerAdminRouter.test.ts`
+- Turn the minimal Explorer admin setup screen into a more interactive, modern, card-first authoring experience that matches the existing WMV card language and makes repeated paste-and-add destination setup feel fast and obvious.
 
-If a file remains shared across both slices, prefer keeping it in 4B-1 only when the change is strictly required for the portable harness. Otherwise, restage it into 4B-2.
+Required outcome:
 
-### 4B-2 Preview
+- The Explorer admin screen keeps season and campaign framing at the top, but uses a clearer card hierarchy consistent with the leaderboard, weekly, season, and schedule surfaces.
+- Destination authoring becomes a preview-first flow:
+	- the admin pastes a Strava segment URL
+	- the UI validates through the existing `segment.validate` seam
+	- a preview card appears with segment metadata before persistence
+	- the admin uses icon-first accept or reject controls with accessible labels
+	- the optional Explorer display label is applied during that preview step
+- Accepted destinations render as richer cards rather than a plain list.
+- Each accepted destination card shows, when available:
+	- Explorer display label or resolved destination name
+	- distance
+	- average grade
+	- location text using city, state, and country
+	- a clearly clickable link back to the original Strava segment source
 
-- After the 4B-1 harness-only commit or PR is separated cleanly, resume the admin-only Explorer setup UI for create-campaign and add-destination flows.
-- Keep the 4B-2 UI PR focused on the admin route, duplicate or invalid authoring states, and the minimum browser coverage needed on top of the hardened harness.
+Expected code surfaces:
+
+- Frontend likely:
+	- `src/components/ExplorerAdminPanel.tsx`
+	- `src/components/ExplorerAdminPanel.css`
+	- shared card or metadata display helpers only if reuse is actually cleaner than local duplication
+- Backend only if needed for richer accepted-card data:
+	- `server/src/services/ExplorerQueryService.ts`
+	- `server/src/routers/explorerAdmin.ts`
+	- `server/src/__tests__/trpc/explorerAdminRouter.test.ts`
+- Tests likely:
+	- `src/components/__tests__/ExplorerAdminPanel.test.tsx`
+	- `e2e/tests/explorer-admin.authenticated.spec.ts`
+
+Implementation constraints:
+
+- Do not add persisted edit, remove, reorder, refresh, or search flows in this slice.
+- Do not add public Explorer exposure.
+- Do not convert links into generic button-styled actions when a normal link is clearer.
+- Keep icon-first actions accessible with visible context and `aria-label` support where needed.
+- Treat map plotting as deferred. Location text should be surfaced now, but real coordinate or geometry storage is not part of 4B-3.
+
+Validation path:
+
+- Frontend unit tests covering preview state, validation success and failure, accept, reject, and repeated add behavior
+- Focused backend tests only if the Explorer admin read shape changes
+- Targeted Playwright coverage for the admin paste-validate-preview-add flow and richer accepted-card rendering
+- `npm run lint`
+- `npm run typecheck`
+- targeted build verification for the touched UI
+
+Documentation expectations when 4B-3 lands:
+
+- update `docs/prds/wmv-explorer-destinations-phases.md` to mark 4B-3 complete if the slice lands as approved
+- update `docs/prds/wmv-explorer-worklog.md` and `docs/prds/wmv-explorer-readiness-checklist.md` to record the new next step
+- update `docs/API.md` only if the Explorer admin read contract expands
+
+Non-blockers to leave alone:
+
+- true map rendering
+- coordinate or geometry persistence
+- persisted inline card editing
+- Strava destination search
+- refresh or backfill admin actions
 
 ## 4A Planning Inputs Closed
 
@@ -249,6 +283,7 @@ These decisions are now closed for the 4A implementation handoff.
 
 - Implement Explorer admin backend setup
 - Add admin-gated Explorer setup UI
+- Refine Explorer admin destination authoring UX
 - Prepare the athlete-facing Explorer hub for a later release gate
 
 ## Documentation Impact Checklist

--- a/e2e/tests/explorer-admin.authenticated.spec.ts
+++ b/e2e/tests/explorer-admin.authenticated.spec.ts
@@ -49,11 +49,14 @@ test.describe('Explorer Admin Setup', () => {
 
     await page.getByTestId('explorer-source-url-input').fill('https://www.strava.com/segments/2234642');
     await page.getByTestId('explorer-display-label-input').fill('Box Hill opener');
-    await page.getByTestId('explorer-add-destination-button').click();
+    await page.getByTestId('explorer-preview-destination-button').click();
+
+    await expect(page.getByTestId('explorer-destination-preview-card')).toContainText('Box Hill opener');
+    await page.getByTestId('explorer-accept-preview-button').click();
 
     await expect(page.getByTestId('explorer-admin-message')).toContainText('Destination added');
     await expect(page.getByTestId('explorer-destination-list')).toContainText('Box Hill opener');
-    await expect(page.getByTestId('explorer-destination-list')).toContainText('Segment 2234642');
+    await expect(page.getByTestId('explorer-destination-list')).toContainText('Open original Strava segment');
   });
 
   test('admin sees invalid URL and duplicate destination states', async ({ page }) => {
@@ -64,15 +67,17 @@ test.describe('Explorer Admin Setup', () => {
     await ensureCampaignExists(page);
 
     await page.getByTestId('explorer-source-url-input').fill('https://www.strava.com/routes/2234642');
-    await page.getByTestId('explorer-add-destination-button').click();
-    await expect(page.getByTestId('explorer-admin-message')).toContainText('valid Strava segment URL');
+    await page.getByTestId('explorer-preview-destination-button').click();
+    await expect(page.getByTestId('explorer-preview-error')).toContainText('valid Strava segment URL');
 
     await page.getByTestId('explorer-source-url-input').fill('https://www.strava.com/segments/12345');
-    await page.getByTestId('explorer-add-destination-button').click();
+    await page.getByTestId('explorer-preview-destination-button').click();
+    await page.getByTestId('explorer-accept-preview-button').click();
     await expect(page.getByTestId('explorer-admin-message')).toContainText('Destination added');
 
     await page.getByTestId('explorer-source-url-input').fill('https://www.strava.com/segments/12345');
-    await page.getByTestId('explorer-add-destination-button').click();
+    await page.getByTestId('explorer-preview-destination-button').click();
+    await page.getByTestId('explorer-accept-preview-button').click();
     await expect(page.getByTestId('explorer-admin-message')).toContainText('already exists');
   });
 });

--- a/e2e/tests/explorer-admin.authenticated.spec.ts
+++ b/e2e/tests/explorer-admin.authenticated.spec.ts
@@ -48,15 +48,15 @@ test.describe('Explorer Admin Setup', () => {
     await expect(page.getByTestId('explorer-campaign-name')).toContainText('Fall 2025 Explorer');
 
     await page.getByTestId('explorer-source-url-input').fill('https://www.strava.com/segments/2234642');
-    await page.getByTestId('explorer-display-label-input').fill('Box Hill opener');
-    await page.getByTestId('explorer-preview-destination-button').click();
+    await page.getByTestId('explorer-source-url-input').blur();
 
-    await expect(page.getByTestId('explorer-destination-preview-card')).toContainText('Box Hill opener');
+    await expect(page.getByTestId('explorer-destination-preview-card')).toContainText('Box Hill KOM');
     await page.getByTestId('explorer-accept-preview-button').click();
 
     await expect(page.getByTestId('explorer-admin-message')).toContainText('Destination added');
-    await expect(page.getByTestId('explorer-destination-list')).toContainText('Box Hill opener');
-    await expect(page.getByTestId('explorer-destination-list')).toContainText('Open original Strava segment');
+    await expect(page.getByTestId('explorer-destination-list')).toContainText('Box Hill KOM');
+    await expect(page.getByTestId('explorer-destination-list')).toContainText('Dorking, Surrey, United Kingdom');
+    await expect(page.getByRole('link', { name: 'Box Hill KOM' }).first()).toBeVisible();
   });
 
   test('admin sees invalid URL and duplicate destination states', async ({ page }) => {
@@ -67,16 +67,16 @@ test.describe('Explorer Admin Setup', () => {
     await ensureCampaignExists(page);
 
     await page.getByTestId('explorer-source-url-input').fill('https://www.strava.com/routes/2234642');
-    await page.getByTestId('explorer-preview-destination-button').click();
+    await page.getByTestId('explorer-source-url-input').blur();
     await expect(page.getByTestId('explorer-preview-error')).toContainText('valid Strava segment URL');
 
     await page.getByTestId('explorer-source-url-input').fill('https://www.strava.com/segments/12345');
-    await page.getByTestId('explorer-preview-destination-button').click();
+    await page.getByTestId('explorer-source-url-input').blur();
     await page.getByTestId('explorer-accept-preview-button').click();
     await expect(page.getByTestId('explorer-admin-message')).toContainText('Destination added');
 
     await page.getByTestId('explorer-source-url-input').fill('https://www.strava.com/segments/12345');
-    await page.getByTestId('explorer-preview-destination-button').click();
+    await page.getByTestId('explorer-source-url-input').blur();
     await page.getByTestId('explorer-accept-preview-button').click();
     await expect(page.getByTestId('explorer-admin-message')).toContainText('already exists');
   });

--- a/server/src/__tests__/trpc/explorerAdminRouter.test.ts
+++ b/server/src/__tests__/trpc/explorerAdminRouter.test.ts
@@ -200,6 +200,7 @@ describe('explorerAdminRouter', () => {
     expect(result?.destinations).toHaveLength(1);
     expect(result?.destinations[0]?.displayLabel).toBe('Hilltown opener');
     expect(result?.destinations[0]?.segmentName).toBe('Mocked Segment');
+    expect(result?.destinations[0]?.createdAt).toBeTruthy();
     expect(result?.destinations[0]?.distance).toBe(3210);
     expect(result?.destinations[0]?.averageGrade).toBe(4.2);
     expect(result?.destinations[0]?.city).toBe('Northampton');

--- a/server/src/__tests__/trpc/explorerAdminRouter.test.ts
+++ b/server/src/__tests__/trpc/explorerAdminRouter.test.ts
@@ -6,7 +6,7 @@ import { createContext } from '../../trpc/context';
 import { explorerCampaign, explorerDestination, participant } from '../../db/schema';
 import { ExplorerAdminService } from '../../services/ExplorerAdminService';
 import { SegmentService } from '../../services/SegmentService';
-import { clearAllData, createExplorerCampaign, createParticipant, createSeason, setupTestDb, teardownTestDb } from '../testDataHelpers';
+import { clearAllData, createExplorerCampaign, createParticipant, createSeason, createSegment, setupTestDb, teardownTestDb } from '../testDataHelpers';
 
 describe('explorerAdminRouter', () => {
   let db: Database;
@@ -142,6 +142,11 @@ describe('explorerAdminRouter', () => {
     jest.spyOn(SegmentService.prototype, 'fetchAndStoreSegmentMetadata').mockResolvedValue({
       strava_segment_id: '12744502',
       name: 'Mocked Segment',
+      distance: 3210,
+      average_grade: 4.2,
+      city: 'Northampton',
+      state: 'MA',
+      country: 'USA',
     } as any);
 
     const result = await caller.explorerAdmin.addDestination({
@@ -169,6 +174,13 @@ describe('explorerAdminRouter', () => {
       rulesBlurb: 'Ride every destination once.',
     });
     const caller = getCaller(true);
+    createSegment(drizzleDb, '12744502', 'Mocked Segment', {
+      distance: 3210,
+      averageGrade: 4.2,
+      city: 'Northampton',
+      state: 'MA',
+      country: 'USA',
+    });
     jest.spyOn(SegmentService.prototype, 'fetchAndStoreSegmentMetadata').mockResolvedValue({
       strava_segment_id: '12744502',
       name: 'Mocked Segment',
@@ -187,6 +199,12 @@ describe('explorerAdminRouter', () => {
     expect(result?.rulesBlurb).toBe('Ride every destination once.');
     expect(result?.destinations).toHaveLength(1);
     expect(result?.destinations[0]?.displayLabel).toBe('Hilltown opener');
+    expect(result?.destinations[0]?.segmentName).toBe('Mocked Segment');
+    expect(result?.destinations[0]?.distance).toBe(3210);
+    expect(result?.destinations[0]?.averageGrade).toBe(4.2);
+    expect(result?.destinations[0]?.city).toBe('Northampton');
+    expect(result?.destinations[0]?.state).toBe('MA');
+    expect(result?.destinations[0]?.country).toBe('USA');
   });
 
   it('allows destination creation when metadata enrichment falls back to placeholder data', async () => {

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -258,6 +258,10 @@ export function isDevelopmentMode(): boolean {
   return getMode() === 'development';
 }
 
+export function getBrowserEntryUrl(): string {
+  return config.isSplitStack ? config.frontendUrl : config.backendUrl;
+}
+
 /**
  * Log configuration on startup (for debugging URL issues)
  */
@@ -265,12 +269,17 @@ export function logConfigOnStartup(): void {
   console.log('========== CONFIGURATION ==========');
   console.log(`[CONFIG] Mode: ${getMode()}`);
   console.log(`[CONFIG] Runtime mode: ${config.runtimeMode}`);
+  console.log(`[CONFIG] Open in browser: ${getBrowserEntryUrl()}`);
   console.log(`[CONFIG] Split stack: ${config.isSplitStack}`);
-  console.log(`[CONFIG] Frontend URL: ${config.frontendUrl}`);
-  console.log(`[CONFIG] Backend URL: ${config.backendUrl}`);
+  console.log(`[CONFIG] Frontend URL (browser origin / CORS): ${config.frontendUrl}`);
+  console.log(`[CONFIG] Backend URL (server origin / OAuth + webhooks): ${config.backendUrl}`);
   console.log(`[CONFIG] Strava API mode: ${config.stravaApiMode}`);
   console.log(`[CONFIG] OAuth callback: ${config.stravaRedirectUri}`);
   console.log(`[CONFIG] Webhook callback: ${config.webhookCallbackUrl}`);
+
+  if (isDevelopmentMode()) {
+    console.log('[CONFIG] Local dev note: the browser entry URL follows the active frontend origin; the Express server origin is logged separately below.');
+  }
 
   // Warn about missing env vars if in production
   if (isProduction() && !process.env.APP_BASE_URL && !process.env.FRONTEND_URL) {

--- a/server/src/services/ExplorerQueryService.ts
+++ b/server/src/services/ExplorerQueryService.ts
@@ -83,7 +83,7 @@ function resolveSegmentName(destination: {
   cached_name: string | null;
   segment_name: string | null;
 }): string {
-  return destination.cached_name || destination.segment_name || `Segment ${destination.strava_segment_id}`;
+  return destination.segment_name || destination.cached_name || `Segment ${destination.strava_segment_id}`;
 }
 
 export class ExplorerQueryService {

--- a/server/src/services/ExplorerQueryService.ts
+++ b/server/src/services/ExplorerQueryService.ts
@@ -12,7 +12,14 @@ interface ExplorerDestinationView {
   id: number;
   stravaSegmentId: string;
   displayLabel: string;
+  customLabel: string | null;
+  segmentName: string;
   sourceUrl: string | null;
+  distance: number | null;
+  averageGrade: number | null;
+  city: string | null;
+  state: string | null;
+  country: string | null;
   surfaceType: string | null;
   category: string | null;
   displayOrder: number;
@@ -70,6 +77,14 @@ function resolveCampaignName(displayName: string | null, seasonName: string): st
   return displayName || seasonName;
 }
 
+function resolveSegmentName(destination: {
+  strava_segment_id: string;
+  cached_name: string | null;
+  segment_name: string | null;
+}): string {
+  return destination.cached_name || destination.segment_name || `Segment ${destination.strava_segment_id}`;
+}
+
 export class ExplorerQueryService {
   constructor(private readonly db: BetterSQLite3Database) {}
 
@@ -104,6 +119,11 @@ export class ExplorerQueryService {
         category: explorerDestination.category,
         display_order: explorerDestination.display_order,
         segment_name: segment.name,
+        distance: segment.distance,
+        average_grade: segment.average_grade,
+        city: segment.city,
+        state: segment.state,
+        country: segment.country,
       })
       .from(explorerDestination)
       .leftJoin(segment, eq(explorerDestination.strava_segment_id, segment.strava_segment_id))
@@ -123,7 +143,14 @@ export class ExplorerQueryService {
         id: destination.id,
         stravaSegmentId: destination.strava_segment_id,
         displayLabel: resolveDestinationLabel(destination),
+        customLabel: destination.display_label,
+        segmentName: resolveSegmentName(destination),
         sourceUrl: destination.source_url,
+        distance: destination.distance,
+        averageGrade: destination.average_grade,
+        city: destination.city,
+        state: destination.state,
+        country: destination.country,
         surfaceType: destination.surface_type,
         category: destination.category,
         displayOrder: destination.display_order,
@@ -167,6 +194,11 @@ export class ExplorerQueryService {
           category: explorerDestination.category,
           display_order: explorerDestination.display_order,
           segment_name: segment.name,
+          distance: segment.distance,
+          average_grade: segment.average_grade,
+          city: segment.city,
+          state: segment.state,
+          country: segment.country,
         })
         .from(explorerDestination)
         .leftJoin(segment, eq(explorerDestination.strava_segment_id, segment.strava_segment_id))
@@ -190,7 +222,14 @@ export class ExplorerQueryService {
           id: destination.id,
           stravaSegmentId: destination.strava_segment_id,
           displayLabel: resolveDestinationLabel(destination),
+          customLabel: destination.display_label,
+          segmentName: resolveSegmentName(destination),
           sourceUrl: destination.source_url,
+          distance: destination.distance,
+          averageGrade: destination.average_grade,
+          city: destination.city,
+          state: destination.state,
+          country: destination.country,
           surfaceType: destination.surface_type,
           category: destination.category,
           displayOrder: destination.display_order,
@@ -235,6 +274,11 @@ export class ExplorerQueryService {
         category: explorerDestination.category,
         display_order: explorerDestination.display_order,
         segment_name: segment.name,
+        distance: segment.distance,
+        average_grade: segment.average_grade,
+        city: segment.city,
+        state: segment.state,
+        country: segment.country,
       })
       .from(explorerDestination)
       .leftJoin(segment, eq(explorerDestination.strava_segment_id, segment.strava_segment_id))
@@ -266,7 +310,14 @@ export class ExplorerQueryService {
         id: destination.id,
         stravaSegmentId: destination.strava_segment_id,
         displayLabel: resolveDestinationLabel(destination),
+        customLabel: destination.display_label,
+        segmentName: resolveSegmentName(destination),
         sourceUrl: destination.source_url,
+        distance: destination.distance,
+        averageGrade: destination.average_grade,
+        city: destination.city,
+        state: destination.state,
+        country: destination.country,
         surfaceType: destination.surface_type,
         category: destination.category,
         displayOrder: destination.display_order,

--- a/server/src/services/ExplorerQueryService.ts
+++ b/server/src/services/ExplorerQueryService.ts
@@ -15,6 +15,7 @@ interface ExplorerDestinationView {
   customLabel: string | null;
   segmentName: string;
   sourceUrl: string | null;
+  createdAt: string | null;
   distance: number | null;
   averageGrade: number | null;
   city: string | null;
@@ -115,6 +116,7 @@ export class ExplorerQueryService {
         display_label: explorerDestination.display_label,
         cached_name: explorerDestination.cached_name,
         source_url: explorerDestination.source_url,
+        created_at: explorerDestination.created_at,
         surface_type: explorerDestination.surface_type,
         category: explorerDestination.category,
         display_order: explorerDestination.display_order,
@@ -146,6 +148,7 @@ export class ExplorerQueryService {
         customLabel: destination.display_label,
         segmentName: resolveSegmentName(destination),
         sourceUrl: destination.source_url,
+        createdAt: destination.created_at,
         distance: destination.distance,
         averageGrade: destination.average_grade,
         city: destination.city,
@@ -190,6 +193,7 @@ export class ExplorerQueryService {
           display_label: explorerDestination.display_label,
           cached_name: explorerDestination.cached_name,
           source_url: explorerDestination.source_url,
+          created_at: explorerDestination.created_at,
           surface_type: explorerDestination.surface_type,
           category: explorerDestination.category,
           display_order: explorerDestination.display_order,
@@ -225,6 +229,7 @@ export class ExplorerQueryService {
           customLabel: destination.display_label,
           segmentName: resolveSegmentName(destination),
           sourceUrl: destination.source_url,
+          createdAt: destination.created_at,
           distance: destination.distance,
           averageGrade: destination.average_grade,
           city: destination.city,
@@ -270,6 +275,7 @@ export class ExplorerQueryService {
         display_label: explorerDestination.display_label,
         cached_name: explorerDestination.cached_name,
         source_url: explorerDestination.source_url,
+        created_at: explorerDestination.created_at,
         surface_type: explorerDestination.surface_type,
         category: explorerDestination.category,
         display_order: explorerDestination.display_order,
@@ -313,6 +319,7 @@ export class ExplorerQueryService {
         customLabel: destination.display_label,
         segmentName: resolveSegmentName(destination),
         sourceUrl: destination.source_url,
+        createdAt: destination.created_at,
         distance: destination.distance,
         averageGrade: destination.average_grade,
         city: destination.city,

--- a/src/components/ExplorerAdminPanel.css
+++ b/src/components/ExplorerAdminPanel.css
@@ -9,13 +9,18 @@
 
 .explorer-admin-access-denied,
 .explorer-empty-state,
-.explorer-card,
 .explorer-season-summary {
   background: #fff;
   border: 1px solid #e5e7eb;
   border-radius: 12px;
   padding: 1.5rem;
   box-shadow: 0 10px 28px rgba(15, 23, 42, 0.06);
+}
+
+.explorer-card,
+.explorer-preview-card,
+.explorer-destination-card {
+  padding: 1.5rem;
 }
 
 .explorer-admin-access-denied {
@@ -123,6 +128,9 @@
 }
 
 .explorer-submit-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
   border: none;
   background: #f56004;
   color: #fff;
@@ -141,6 +149,139 @@
   opacity: 0.7;
 }
 
+.explorer-button-icon {
+  width: 1rem;
+  height: 1rem;
+}
+
+.explorer-spin {
+  animation: explorer-spin 1s linear infinite;
+}
+
+.explorer-input-help,
+.explorer-preview-subtitle,
+.explorer-preview-error {
+  margin: 0;
+  font-size: 0.9rem;
+}
+
+.explorer-input-help,
+.explorer-preview-subtitle {
+  color: #6b7280;
+}
+
+.explorer-preview-error {
+  color: #b91c1c;
+  font-weight: 600;
+}
+
+.explorer-preview-card,
+.explorer-destination-card {
+  margin-top: 1rem;
+  border: 1px solid #e5e7eb;
+}
+
+.explorer-preview-header {
+  align-items: center;
+}
+
+.explorer-preview-actions {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.explorer-icon-button {
+  width: 2.75rem;
+  height: 2.75rem;
+  border-radius: 999px;
+  border: 1px solid #d1d5db;
+  background: #fff;
+  color: #111827;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.explorer-icon-button svg {
+  width: 1.25rem;
+  height: 1.25rem;
+}
+
+.explorer-icon-button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(15, 23, 42, 0.08);
+}
+
+.explorer-icon-button-accept {
+  border-color: #86efac;
+  color: #166534;
+}
+
+.explorer-icon-button-accept:disabled,
+.explorer-icon-button-reject:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.explorer-icon-button-reject {
+  border-color: #fca5a5;
+  color: #b91c1c;
+}
+
+.explorer-destination-stats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 0.85rem;
+}
+
+.explorer-stat-pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background: #f3f4f6;
+  color: #374151;
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+.explorer-destination-location {
+  margin: 0.85rem 0 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  color: #4b5563;
+  font-size: 0.95rem;
+}
+
+.explorer-destination-location svg {
+  width: 1rem;
+  height: 1rem;
+  flex-shrink: 0;
+}
+
+.explorer-destination-link {
+  margin-top: 0.85rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  color: #c2410c;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.explorer-destination-link:hover {
+  text-decoration: underline;
+}
+
+.explorer-destination-link svg {
+  width: 1rem;
+  height: 1rem;
+}
+
 .explorer-destination-list {
   margin: 1rem 0 0;
   padding: 0;
@@ -152,7 +293,6 @@
 
 .explorer-destination-item {
   padding: 0.95rem 1rem;
-  border: 1px solid #e5e7eb;
   border-radius: 10px;
   background: #fafaf9;
 }
@@ -176,6 +316,16 @@
   border-color: #fca5a5;
 }
 
+@keyframes explorer-spin {
+  from {
+    transform: rotate(0deg);
+  }
+
+  to {
+    transform: rotate(360deg);
+  }
+}
+
 @media (max-width: 768px) {
   .explorer-season-summary,
   .explorer-card-header,
@@ -185,5 +335,10 @@
 
   .explorer-submit-button {
     width: 100%;
+  }
+
+  .explorer-preview-actions {
+    width: 100%;
+    justify-content: flex-start;
   }
 }

--- a/src/components/ExplorerAdminPanel.css
+++ b/src/components/ExplorerAdminPanel.css
@@ -10,11 +10,11 @@
 .explorer-admin-access-denied,
 .explorer-empty-state,
 .explorer-season-summary {
-  background: #fff;
-  border: 1px solid #e5e7eb;
+  background: var(--wmv-white);
+  border: 1px solid var(--wmv-border);
   border-radius: 12px;
   padding: 1.5rem;
-  box-shadow: 0 10px 28px rgba(15, 23, 42, 0.06);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
 }
 
 .explorer-card,
@@ -32,7 +32,7 @@
 .explorer-card h3,
 .explorer-season-summary h2 {
   margin: 0 0 0.5rem;
-  color: #1f2937;
+  color: var(--wmv-purple);
 }
 
 .explorer-message {
@@ -61,7 +61,7 @@
 
 .explorer-season-summary,
 .explorer-card-header,
-.explorer-destination-item {
+.explorer-preview-header {
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
@@ -70,11 +70,11 @@
 
 .explorer-section-label {
   margin: 0 0 0.35rem;
-  font-size: 0.78rem;
+  font-size: var(--font-xs);
   font-weight: 700;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: #f56004;
+  color: var(--wmv-orange);
 }
 
 .explorer-season-window,
@@ -83,7 +83,7 @@
 .explorer-rules-blurb,
 .explorer-destination-meta {
   margin: 0;
-  color: #6b7280;
+  color: var(--wmv-text-light);
 }
 
 .explorer-form {
@@ -101,24 +101,24 @@
 
 .explorer-form-group label {
   font-weight: 700;
-  color: #1f2937;
+  color: var(--wmv-text-dark);
 }
 
 .explorer-form-group input,
 .explorer-form-group textarea {
   width: 100%;
   padding: 0.8rem 0.95rem;
-  border: 1px solid #d1d5db;
+  border: 1px solid var(--wmv-border);
   border-radius: 10px;
-  font-size: 0.95rem;
-  color: #111827;
-  background: #fff;
+  font-size: var(--font-base);
+  color: var(--wmv-text-dark);
+  background: var(--wmv-white);
 }
 
 .explorer-form-group input:focus,
 .explorer-form-group textarea:focus {
   outline: none;
-  border-color: #f56004;
+  border-color: var(--wmv-orange);
   box-shadow: 0 0 0 3px rgba(245, 96, 4, 0.12);
 }
 
@@ -142,7 +142,7 @@
 .explorer-input-help,
 .explorer-preview-subtitle,
 .explorer-preview-status {
-  color: #6b7280;
+  color: var(--wmv-text-light);
 }
 
 .explorer-preview-status {
@@ -156,18 +156,11 @@
   font-weight: 600;
 }
 
-.explorer-preview-card,
-.explorer-destination-card {
-  margin-top: 1rem;
-  border: 1px solid #e5e7eb;
-}
-
 .explorer-preview-card {
-  cursor: default;
-}
-
-.explorer-preview-header {
-  align-items: center;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  margin-top: 1rem;
 }
 
 .explorer-preview-actions {
@@ -175,13 +168,28 @@
   gap: 0.75rem;
 }
 
-.explorer-destination-heading {
-  margin: 0 0 0.5rem;
-  font-size: var(--font-base);
-  color: #333;
-  display: flex;
-  align-items: center;
-  flex-wrap: wrap;
+.explorer-destination-card {
+  margin-top: 1rem;
+}
+
+.explorer-destination-meta-card,
+.explorer-destination-summary-card {
+  border-color: var(--wmv-border);
+  border-radius: 12px;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.explorer-destination-summary-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+}
+
+.explorer-destination-card[data-expanded='true'] .explorer-destination-summary-card {
+  border-color: rgba(245, 96, 4, 0.28);
+}
+
+.explorer-destination-title {
+  margin-bottom: 0.35rem;
 }
 
 .explorer-destination-name-link {
@@ -193,9 +201,9 @@
   width: 2.75rem;
   height: 2.75rem;
   border-radius: 999px;
-  border: 1px solid #d1d5db;
-  background: #fff;
-  color: #111827;
+  border: 1px solid var(--wmv-border);
+  background: var(--wmv-white);
+  color: var(--wmv-text-dark);
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -210,7 +218,7 @@
 
 .explorer-icon-button:hover {
   transform: translateY(-1px);
-  box-shadow: 0 4px 12px rgba(15, 23, 42, 0.08);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
 }
 
 .explorer-icon-button-accept {
@@ -236,21 +244,22 @@
   margin-top: 0.85rem;
 }
 
+.explorer-destination-stats {
+  margin-top: 0;
+}
+
 .explorer-destination-summary {
   width: 100%;
   padding: 0;
+  border: none;
+  background: transparent;
   text-align: left;
   cursor: pointer;
   outline: none;
 }
 
-.explorer-destination-item {
-  padding: 0.95rem 1rem;
-  background: transparent;
-}
-
 .explorer-destination-label {
-  color: #333;
+  color: var(--wmv-text-dark);
   font-weight: 600;
 }
 
@@ -273,7 +282,7 @@
   flex-shrink: 0;
   width: 1.25rem;
   height: 1.25rem;
-  color: #6b7280;
+  color: var(--wmv-text-light);
   transition: transform 0.2s ease;
 }
 
@@ -292,12 +301,19 @@
   align-items: center;
 }
 
-.explorer-destination-card[data-expanded='true'] {
-  border-color: rgba(245, 96, 4, 0.28);
+.explorer-destination-detail-block {
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
 }
 
-.explorer-error-card {
-  border-color: #fca5a5;
+.explorer-detail-label {
+  margin: 0;
+  font-size: var(--font-xs);
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--wmv-text-light);
 }
 
 @keyframes explorer-spin {
@@ -313,16 +329,13 @@
 @media (max-width: 768px) {
   .explorer-season-summary,
   .explorer-card-header,
-  .explorer-destination-item {
+  .explorer-preview-header,
+  .explorer-destination-summary-card {
     flex-direction: column;
   }
 
   .explorer-preview-actions {
     width: 100%;
     justify-content: flex-start;
-  }
-
-  .explorer-destination-heading {
-    flex-wrap: wrap;
   }
 }

--- a/src/components/ExplorerAdminPanel.css
+++ b/src/components/ExplorerAdminPanel.css
@@ -163,6 +163,12 @@
   margin-top: 1rem;
 }
 
+.explorer-destination-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
 .explorer-preview-actions {
   display: flex;
   gap: 0.75rem;
@@ -172,10 +178,15 @@
   margin-top: 1rem;
 }
 
-.explorer-destination-meta-card,
+.explorer-destination-surface {
+  background-color: var(--wmv-white);
+  border-radius: 16px;
+  padding: 24px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+  border: 1px solid transparent;
+}
+
 .explorer-destination-summary-card {
-  border-color: var(--wmv-border);
-  border-radius: 12px;
   transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
 }
 
@@ -185,16 +196,38 @@
 }
 
 .explorer-destination-card[data-expanded='true'] .explorer-destination-summary-card {
-  border-color: rgba(245, 96, 4, 0.28);
+  border-color: var(--wmv-orange);
 }
 
-.explorer-destination-title {
-  margin-bottom: 0.35rem;
+.explorer-destination-hero-title {
+  margin: 0;
+  font-size: var(--font-2xl);
+  line-height: 1.2;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
 }
 
-.explorer-destination-name-link {
+.explorer-destination-list-title {
+  padding-right: 16px;
+}
+
+.explorer-destination-surface-link {
   display: inline-flex;
   align-items: center;
+  gap: 6px;
+  color: var(--wmv-orange);
+  text-decoration: none;
+}
+
+.explorer-destination-surface-link:hover {
+  text-decoration: underline;
+}
+
+.explorer-destination-surface-link svg {
+  width: 20px;
+  height: 20px;
 }
 
 .explorer-icon-button {
@@ -237,15 +270,11 @@
   color: #b91c1c;
 }
 
-.explorer-destination-chips {
+.explorer-destination-chip-row {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.5rem;
-  margin-top: 0.85rem;
-}
-
-.explorer-destination-stats {
-  margin-top: 0;
+  gap: 8px;
+  margin-top: 8px;
 }
 
 .explorer-destination-summary {
@@ -258,9 +287,17 @@
   outline: none;
 }
 
+.explorer-destination-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
 .explorer-destination-label {
   color: var(--wmv-text-dark);
   font-weight: 600;
+  font-size: var(--font-2xl);
+  line-height: 1.2;
 }
 
 .explorer-destination-meta {
@@ -280,8 +317,8 @@
 
 .explorer-destination-chevron {
   flex-shrink: 0;
-  width: 1.25rem;
-  height: 1.25rem;
+  width: 24px;
+  height: 24px;
   color: var(--wmv-text-light);
   transition: transform 0.2s ease;
 }
@@ -291,7 +328,13 @@
 }
 
 .explorer-destination-details {
-  margin-top: 0;
+  margin: -8px 16px 16px;
+  border: 1px solid var(--wmv-border);
+  border-top: none;
+  border-bottom-left-radius: 16px;
+  border-bottom-right-radius: 16px;
+  background-color: #f9fafb;
+  padding-top: 32px;
 }
 
 .explorer-destination-detail-row {
@@ -334,8 +377,17 @@
     flex-direction: column;
   }
 
+  .explorer-destination-surface {
+    padding: 20px;
+  }
+
   .explorer-preview-actions {
     width: 100%;
     justify-content: flex-start;
+  }
+
+  .explorer-destination-hero-title,
+  .explorer-destination-label {
+    font-size: var(--font-xl);
   }
 }

--- a/src/components/ExplorerAdminPanel.css
+++ b/src/components/ExplorerAdminPanel.css
@@ -122,33 +122,6 @@
   box-shadow: 0 0 0 3px rgba(245, 96, 4, 0.12);
 }
 
-.explorer-form-actions {
-  display: flex;
-  justify-content: flex-start;
-}
-
-.explorer-submit-button {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.5rem;
-  border: none;
-  background: #f56004;
-  color: #fff;
-  padding: 0.85rem 1.25rem;
-  border-radius: 999px;
-  font-weight: 700;
-  cursor: pointer;
-}
-
-.explorer-submit-button:hover {
-  background: #d9480f;
-}
-
-.explorer-submit-button:disabled {
-  cursor: not-allowed;
-  opacity: 0.7;
-}
-
 .explorer-button-icon {
   width: 1rem;
   height: 1rem;
@@ -160,14 +133,22 @@
 
 .explorer-input-help,
 .explorer-preview-subtitle,
-.explorer-preview-error {
+.explorer-preview-error,
+.explorer-preview-status {
   margin: 0;
   font-size: 0.9rem;
 }
 
 .explorer-input-help,
-.explorer-preview-subtitle {
+.explorer-preview-subtitle,
+.explorer-preview-status {
   color: #6b7280;
+}
+
+.explorer-preview-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
 }
 
 .explorer-preview-error {
@@ -181,6 +162,10 @@
   border: 1px solid #e5e7eb;
 }
 
+.explorer-preview-card {
+  cursor: default;
+}
+
 .explorer-preview-header {
   align-items: center;
 }
@@ -188,6 +173,20 @@
 .explorer-preview-actions {
   display: flex;
   gap: 0.75rem;
+}
+
+.explorer-destination-heading {
+  margin: 0 0 0.5rem;
+  font-size: var(--font-base);
+  color: #333;
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.explorer-destination-name-link {
+  display: inline-flex;
+  align-items: center;
 }
 
 .explorer-icon-button {
@@ -230,86 +229,71 @@
   color: #b91c1c;
 }
 
-.explorer-destination-stats {
+.explorer-destination-chips {
   display: flex;
   flex-wrap: wrap;
   gap: 0.5rem;
   margin-top: 0.85rem;
 }
 
-.explorer-stat-pill {
-  display: inline-flex;
-  align-items: center;
-  padding: 0.35rem 0.75rem;
-  border-radius: 999px;
-  background: #f3f4f6;
-  color: #374151;
-  font-size: 0.9rem;
-  font-weight: 600;
-}
-
-.explorer-destination-location {
-  margin: 0.85rem 0 0;
-  display: inline-flex;
-  align-items: center;
-  gap: 0.45rem;
-  color: #4b5563;
-  font-size: 0.95rem;
-}
-
-.explorer-destination-location svg {
-  width: 1rem;
-  height: 1rem;
-  flex-shrink: 0;
-}
-
-.explorer-destination-link {
-  margin-top: 0.85rem;
-  display: inline-flex;
-  align-items: center;
-  gap: 0.4rem;
-  color: #c2410c;
-  font-weight: 700;
-  text-decoration: none;
-}
-
-.explorer-destination-link:hover {
-  text-decoration: underline;
-}
-
-.explorer-destination-link svg {
-  width: 1rem;
-  height: 1rem;
-}
-
-.explorer-destination-list {
-  margin: 1rem 0 0;
+.explorer-destination-summary {
+  width: 100%;
   padding: 0;
-  list-style: none;
-  display: flex;
-  flex-direction: column;
-  gap: 0.85rem;
+  text-align: left;
+  cursor: pointer;
+  outline: none;
 }
 
 .explorer-destination-item {
   padding: 0.95rem 1rem;
-  border-radius: 10px;
-  background: #fafaf9;
+  background: transparent;
 }
 
 .explorer-destination-label {
-  margin: 0 0 0.25rem;
-  font-weight: 700;
-  color: #111827;
+  color: #333;
+  font-weight: 600;
 }
 
-.explorer-destination-order {
+.explorer-destination-meta {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  margin: 0;
+  color: var(--wmv-text-light);
+  font-size: var(--font-sm);
+}
+
+.explorer-destination-meta svg {
+  width: 0.95rem;
+  height: 0.95rem;
   flex-shrink: 0;
-  border-radius: 999px;
-  background: rgba(245, 96, 4, 0.12);
-  color: #c2410c;
-  padding: 0.35rem 0.7rem;
-  font-weight: 700;
+}
+
+.explorer-destination-chevron {
+  flex-shrink: 0;
+  width: 1.25rem;
+  height: 1.25rem;
+  color: #6b7280;
+  transition: transform 0.2s ease;
+}
+
+.explorer-destination-chevron.is-expanded {
+  transform: rotate(180deg);
+}
+
+.explorer-destination-details {
+  margin-top: 0;
+}
+
+.explorer-destination-detail-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.explorer-destination-card[data-expanded='true'] {
+  border-color: rgba(245, 96, 4, 0.28);
 }
 
 .explorer-error-card {
@@ -333,12 +317,12 @@
     flex-direction: column;
   }
 
-  .explorer-submit-button {
-    width: 100%;
-  }
-
   .explorer-preview-actions {
     width: 100%;
     justify-content: flex-start;
+  }
+
+  .explorer-destination-heading {
+    flex-wrap: wrap;
   }
 }

--- a/src/components/ExplorerAdminPanel.tsx
+++ b/src/components/ExplorerAdminPanel.tsx
@@ -4,7 +4,6 @@ import {
   ChevronDownIcon,
   CheckIcon,
   ClockIcon,
-  MapPinIcon,
   XMarkIcon,
 } from '@heroicons/react/24/outline';
 import type { Season } from '../types';
@@ -74,6 +73,39 @@ function formatDestinationCreatedAt(createdAt?: string | null): string | null {
 
   const formatted = formatUtcIsoDateTime(createdAt);
   return formatted === '—' ? null : formatted.replace(/,\s+\d{1,2}:\d{2}:\d{2}\s+[AP]M$/, '');
+}
+
+function getDestinationStatItems({
+  distance,
+  averageGrade,
+  city,
+  state,
+  country,
+}: {
+  distance?: number | null;
+  averageGrade?: number | null;
+  city?: string | null;
+  state?: string | null;
+  country?: string | null;
+}): string[] {
+  const statItems: string[] = [];
+  const distanceLabel = formatSegmentDistance(distance);
+  const averageGradeLabel = formatAverageGrade(averageGrade);
+  const locationLabel = formatLocation(city, state, country);
+
+  if (distanceLabel) {
+    statItems.push(distanceLabel);
+  }
+
+  if (averageGradeLabel) {
+    statItems.push(averageGradeLabel);
+  }
+
+  if (locationLabel) {
+    statItems.push(locationLabel);
+  }
+
+  return statItems;
 }
 
 function ExplorerAdminPanel({
@@ -451,21 +483,9 @@ function ExplorerAdminPanel({
                   ) : null}
 
                   {destinationPreview ? (
-                    <article className="leaderboard-card explorer-preview-card" data-testid="explorer-destination-preview-card">
-                      <div className="explorer-card-header explorer-preview-header">
-                        <div>
-                          <p className="explorer-section-label">Preview</p>
-                          <h3 className="explorer-destination-heading" data-testid="explorer-preview-name">
-                            <a
-                              className="segment-link explorer-destination-name-link"
-                              href={destinationPreview.sourceUrl}
-                              target="_blank"
-                              rel="noreferrer"
-                            >
-                              {destinationPreview.name}
-                            </a>
-                          </h3>
-                        </div>
+                    <article className="explorer-preview-card" data-testid="explorer-destination-preview-card">
+                      <div className="explorer-preview-header">
+                        <p className="explorer-section-label">Preview</p>
                         <div className="explorer-preview-actions">
                           <button
                             type="button"
@@ -494,18 +514,24 @@ function ExplorerAdminPanel({
                         </div>
                       </div>
 
-                      <div className="explorer-destination-chips">
-                        {formatSegmentDistance(destinationPreview.distance) ? (
-                          <span className="week-header-chip">{formatSegmentDistance(destinationPreview.distance)}</span>
-                        ) : null}
-                        {formatAverageGrade(destinationPreview.averageGrade) ? (
-                          <span className="week-header-chip">{formatAverageGrade(destinationPreview.averageGrade)}</span>
-                        ) : null}
-                        {formatLocation(destinationPreview.city, destinationPreview.state, destinationPreview.country) ? (
-                          <span className="week-header-chip explorer-location-chip">
-                            <MapPinIcon className="week-header-chip-icon" aria-hidden="true" />
-                            <span>{formatLocation(destinationPreview.city, destinationPreview.state, destinationPreview.country)}</span>
-                          </span>
+                      <div className="segment-card explorer-destination-meta-card">
+                        <h3 className="segment-card-title explorer-destination-title" data-testid="explorer-preview-name">
+                          <a
+                            className="segment-link explorer-destination-name-link"
+                            href={destinationPreview.sourceUrl}
+                            target="_blank"
+                            rel="noreferrer"
+                          >
+                            {destinationPreview.name}
+                          </a>
+                        </h3>
+
+                        {getDestinationStatItems(destinationPreview).length > 0 ? (
+                          <div className="segment-card-stats explorer-destination-stats">
+                            {getDestinationStatItems(destinationPreview).map((item) => (
+                              <span key={item}>{item}</span>
+                            ))}
+                          </div>
                         ) : null}
                       </div>
                     </article>
@@ -528,12 +554,18 @@ function ExplorerAdminPanel({
                     {sortedDestinations.map((destination) => {
                       const isExpanded = expandedDestinationId === destination.id;
                       const createdAtLabel = formatDestinationCreatedAt(destination.createdAt);
-                      const locationLabel = formatLocation(destination.city, destination.state, destination.country);
+                      const destinationStatItems = getDestinationStatItems({
+                        distance: destination.distance,
+                        averageGrade: destination.averageGrade,
+                        city: destination.city,
+                        state: destination.state,
+                        country: destination.country,
+                      });
 
                       return (
                         <li
                           key={destination.id}
-                          className="leaderboard-card explorer-destination-card"
+                          className="explorer-destination-card"
                           data-expanded={isExpanded}
                           data-testid={`explorer-destination-row-${destination.id}`}
                         >
@@ -553,9 +585,9 @@ function ExplorerAdminPanel({
                             aria-expanded={isExpanded}
                             data-testid={`explorer-destination-toggle-${destination.id}`}
                           >
-                            <div className="explorer-destination-item">
+                            <div className="segment-card explorer-destination-summary-card">
                               <div>
-                                <h4 className="explorer-destination-heading">
+                                <h4 className="segment-card-title explorer-destination-title">
                                   {destination.sourceUrl ? (
                                     <a
                                       className="segment-link explorer-destination-name-link"
@@ -573,20 +605,13 @@ function ExplorerAdminPanel({
                                   )}
                                 </h4>
 
-                                <div className="explorer-destination-chips">
-                                  {formatSegmentDistance(destination.distance) ? (
-                                    <span className="week-header-chip">{formatSegmentDistance(destination.distance)}</span>
-                                  ) : null}
-                                  {formatAverageGrade(destination.averageGrade) ? (
-                                    <span className="week-header-chip">{formatAverageGrade(destination.averageGrade)}</span>
-                                  ) : null}
-                                  {locationLabel ? (
-                                    <span className="week-header-chip explorer-location-chip">
-                                      <MapPinIcon className="week-header-chip-icon" aria-hidden="true" />
-                                      <span>{locationLabel}</span>
-                                    </span>
-                                  ) : null}
-                                </div>
+                                {destinationStatItems.length > 0 ? (
+                                  <div className="segment-card-stats explorer-destination-stats">
+                                    {destinationStatItems.map((item) => (
+                                      <span key={item}>{item}</span>
+                                    ))}
+                                  </div>
+                                ) : null}
                               </div>
 
                               <ChevronDownIcon className={`explorer-destination-chevron${isExpanded ? ' is-expanded' : ''}`} aria-hidden="true" />
@@ -595,19 +620,23 @@ function ExplorerAdminPanel({
 
                           {isExpanded ? (
                             <div className="card-expanded-details explorer-destination-details">
-                              {destination.customLabel && destination.customLabel !== destination.segmentName ? (
-                                <p className="explorer-preview-subtitle">Original segment name: {destination.segmentName}</p>
-                              ) : null}
+                              <div className="explorer-destination-detail-block">
+                                <p className="explorer-detail-label">Details</p>
 
-                              <div className="explorer-destination-detail-row">
-                                {createdAtLabel ? (
-                                  <p className="explorer-destination-meta">
-                                    <ClockIcon aria-hidden="true" />
-                                    <span>Added {createdAtLabel}</span>
-                                  </p>
-                                ) : (
-                                  <p className="explorer-muted-copy">Added date unavailable.</p>
-                                )}
+                                {destination.customLabel && destination.customLabel !== destination.segmentName ? (
+                                  <p className="explorer-preview-subtitle">Original segment name: {destination.segmentName}</p>
+                                ) : null}
+
+                                <div className="explorer-destination-detail-row">
+                                  {createdAtLabel ? (
+                                    <p className="explorer-destination-meta">
+                                      <ClockIcon aria-hidden="true" />
+                                      <span>Added {createdAtLabel}</span>
+                                    </p>
+                                  ) : (
+                                    <p className="explorer-muted-copy">Added date unavailable.</p>
+                                  )}
+                                </div>
                               </div>
                             </div>
                           ) : null}

--- a/src/components/ExplorerAdminPanel.tsx
+++ b/src/components/ExplorerAdminPanel.tsx
@@ -1,17 +1,19 @@
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   ArrowPathIcon,
-  ArrowTopRightOnSquareIcon,
+  ChevronDownIcon,
   CheckIcon,
+  ClockIcon,
   MapPinIcon,
   XMarkIcon,
 } from '@heroicons/react/24/outline';
 import type { Season } from '../types';
 import { trpc } from '../utils/trpc';
-import { formatUnixDate } from '../utils/dateUtils';
+import { formatUnixDate, formatUtcIsoDateTime } from '../utils/dateUtils';
 import SeasonSelector from './SeasonSelector';
 import './AdminPanel.css';
 import './Card.css';
+import './SegmentCard.css';
 import './ExplorerAdminPanel.css';
 
 interface ExplorerAdminPanelProps {
@@ -28,7 +30,6 @@ interface FlashMessage {
 
 interface PreviewDestination {
   sourceUrl: string;
-  stravaSegmentId: string;
   name: string;
   distance?: number | null;
   averageGrade?: number | null;
@@ -66,6 +67,15 @@ function formatLocation(city?: string | null, state?: string | null, country?: s
   return locationParts.length > 0 ? locationParts.join(', ') : null;
 }
 
+function formatDestinationCreatedAt(createdAt?: string | null): string | null {
+  if (!createdAt) {
+    return null;
+  }
+
+  const formatted = formatUtcIsoDateTime(createdAt);
+  return formatted === '—' ? null : formatted.replace(/,\s+\d{1,2}:\d{2}:\d{2}\s+[AP]M$/, '');
+}
+
 function ExplorerAdminPanel({
   isAdmin,
   seasons,
@@ -78,13 +88,11 @@ function ExplorerAdminPanel({
     displayName: '',
     rulesBlurb: '',
   });
-  const [destinationForm, setDestinationForm] = useState({
-    sourceUrl: '',
-    displayLabel: '',
-  });
+  const [destinationForm, setDestinationForm] = useState({ sourceUrl: '' });
   const [destinationPreview, setDestinationPreview] = useState<PreviewDestination | null>(null);
   const [previewError, setPreviewError] = useState<string | null>(null);
   const [isValidatingPreview, setIsValidatingPreview] = useState(false);
+  const [expandedDestinationId, setExpandedDestinationId] = useState<number | null>(null);
   const [message, setMessage] = useState<FlashMessage | null>(null);
 
   const hasSelectedSeason =
@@ -135,9 +143,10 @@ function ExplorerAdminPanel({
   const addDestinationMutation = trpc.explorerAdmin.addDestination.useMutation({
     onSuccess: async (destination) => {
       await utils.explorerAdmin.getCampaignForSeason.invalidate({ seasonId: resolvedSeasonId ?? 0 });
-      setDestinationForm({ sourceUrl: '', displayLabel: '' });
+      setDestinationForm({ sourceUrl: '' });
       setDestinationPreview(null);
       setPreviewError(null);
+      setExpandedDestinationId(destination.id);
 
       setTimedMessage({
         type: destination.usedPlaceholderMetadata ? 'info' : 'success',
@@ -166,7 +175,7 @@ function ExplorerAdminPanel({
     });
   };
 
-  const requestDestinationPreview = async () => {
+  const requestDestinationPreview = useCallback(async () => {
     const trimmedSourceUrl = destinationForm.sourceUrl.trim();
 
     if (!trimmedSourceUrl) {
@@ -195,7 +204,6 @@ function ExplorerAdminPanel({
 
       setDestinationPreview({
         sourceUrl: trimmedSourceUrl,
-        stravaSegmentId: segment.strava_segment_id,
         name: segment.name,
         distance: segment.distance,
         averageGrade: segment.average_grade,
@@ -210,7 +218,7 @@ function ExplorerAdminPanel({
     } finally {
       setIsValidatingPreview(false);
     }
-  };
+  }, [destinationForm.sourceUrl, utils.client.segment.validate]);
 
   const handleAcceptPreview = async () => {
     if (!destinationPreview) {
@@ -225,11 +233,44 @@ function ExplorerAdminPanel({
     await addDestinationMutation.mutateAsync({
       explorerCampaignId: campaignQuery.data.id,
       sourceUrl: destinationPreview.sourceUrl,
-      displayLabel: destinationForm.displayLabel.trim() || null,
     });
   };
 
-  const previewDisplayLabel = destinationForm.displayLabel.trim();
+  useEffect(() => {
+    if (!campaignQuery.data) {
+      return;
+    }
+
+    const trimmedSourceUrl = destinationForm.sourceUrl.trim();
+
+    if (!trimmedSourceUrl) {
+      setDestinationPreview(null);
+      setPreviewError(null);
+      return;
+    }
+
+    const previewTimeout = window.setTimeout(() => {
+      void requestDestinationPreview();
+    }, 150);
+
+    return () => {
+      window.clearTimeout(previewTimeout);
+    };
+  }, [campaignQuery.data, destinationForm.sourceUrl, requestDestinationPreview]);
+
+  const sortedDestinations = campaignQuery.data
+    ? [...campaignQuery.data.destinations].sort((left, right) => {
+        if (left.createdAt && right.createdAt && left.createdAt !== right.createdAt) {
+          return right.createdAt.localeCompare(left.createdAt);
+        }
+
+        if (left.displayOrder !== right.displayOrder) {
+          return right.displayOrder - left.displayOrder;
+        }
+
+        return right.id - left.id;
+      })
+    : [];
 
   if (!isAdmin) {
     return (
@@ -244,13 +285,13 @@ function ExplorerAdminPanel({
 
   return (
     <div className="explorer-admin-panel" data-testid="explorer-admin-panel">
-      {message && (
+      {message ? (
         <div className={`explorer-message ${message.type}`} data-testid="explorer-admin-message">
           {message.text}
         </div>
-      )}
+      ) : null}
 
-      {seasons.length > 0 && (
+      {seasons.length > 0 ? (
         <div className="admin-season-selector-wrapper">
           <SeasonSelector
             seasons={seasons}
@@ -258,7 +299,7 @@ function ExplorerAdminPanel({
             setSelectedSeasonId={onSeasonChange}
           />
         </div>
-      )}
+      ) : null}
 
       {seasons.length === 0 ? (
         <div className="explorer-empty-state">
@@ -283,33 +324,31 @@ function ExplorerAdminPanel({
           </section>
 
           {campaignQuery.isLoading ? (
-            <div className="leaderboard-card explorer-card">
-              <p>Loading Explorer campaign setup...</p>
-            </div>
-          ) : campaignQuery.error ? (
-            <div className="leaderboard-card explorer-card explorer-error-card">
-              <p>{campaignQuery.error.message}</p>
-            </div>
-          ) : !campaignQuery.data ? (
+            <section className="leaderboard-card explorer-card">
+              <p className="explorer-muted-copy">Loading Explorer campaign…</p>
+            </section>
+          ) : campaignQuery.data == null ? (
             <section className="leaderboard-card explorer-card" data-testid="explorer-create-campaign-card">
               <div className="explorer-card-header">
                 <div>
                   <p className="explorer-section-label">Phase 4B setup</p>
                   <h3>Create Explorer Campaign</h3>
                 </div>
-                <p>Each season can have one Explorer campaign in v1.</p>
+                <p>Start with a campaign shell for this season, then add destinations below.</p>
               </div>
 
-              <form className="explorer-form" onSubmit={handleCreateCampaign} data-testid="explorer-create-campaign-form">
+              <form className="explorer-form" data-testid="explorer-create-campaign-form" onSubmit={(event) => {
+                void handleCreateCampaign(event);
+              }}>
                 <div className="explorer-form-group">
-                  <label htmlFor="explorer-display-name">Campaign name</label>
+                  <label htmlFor="explorer-display-name">Display name</label>
                   <input
                     id="explorer-display-name"
                     data-testid="explorer-display-name-input"
                     value={campaignForm.displayName}
-                    onChange={(event) =>
-                      setCampaignForm((current) => ({ ...current, displayName: event.target.value }))
-                    }
+                    onChange={(event) => {
+                      setCampaignForm((current) => ({ ...current, displayName: event.target.value }));
+                    }}
                     placeholder={`Defaults to ${selectedSeason.name}`}
                     maxLength={255}
                   />
@@ -321,9 +360,9 @@ function ExplorerAdminPanel({
                     id="explorer-rules-blurb"
                     data-testid="explorer-rules-blurb-input"
                     value={campaignForm.rulesBlurb}
-                    onChange={(event) =>
-                      setCampaignForm((current) => ({ ...current, rulesBlurb: event.target.value }))
-                    }
+                    onChange={(event) => {
+                      setCampaignForm((current) => ({ ...current, rulesBlurb: event.target.value }));
+                    }}
                     placeholder="Optional guidance shown alongside the Explorer campaign"
                     rows={4}
                     maxLength={2000}
@@ -350,11 +389,15 @@ function ExplorerAdminPanel({
                     <p className="explorer-section-label">Explorer campaign</p>
                     <h3 data-testid="explorer-campaign-name">{campaignQuery.data.name}</h3>
                   </div>
-                  <p>{campaignQuery.data.destinations.length} destination{campaignQuery.data.destinations.length === 1 ? '' : 's'}</p>
+                  <p>
+                    {campaignQuery.data.destinations.length} destination{campaignQuery.data.destinations.length === 1 ? '' : 's'}
+                  </p>
                 </div>
 
                 {campaignQuery.data.rulesBlurb ? (
-                  <p className="explorer-rules-blurb" data-testid="explorer-campaign-rules-blurb">{campaignQuery.data.rulesBlurb}</p>
+                  <p className="explorer-rules-blurb" data-testid="explorer-campaign-rules-blurb">
+                    {campaignQuery.data.rulesBlurb}
+                  </p>
                 ) : (
                   <p className="explorer-muted-copy">No rules blurb has been added yet.</p>
                 )}
@@ -366,7 +409,7 @@ function ExplorerAdminPanel({
                     <p className="explorer-section-label">Destination authoring</p>
                     <h3>Add Destination</h3>
                   </div>
-                  <p>Paste a Strava segment URL to preview it, then accept or reject before adding it to the campaign.</p>
+                  <p>Paste a Strava segment URL and Explorer will validate it into a quick add preview automatically.</p>
                 </div>
 
                 <div className="explorer-form" data-testid="explorer-add-destination-form">
@@ -377,12 +420,9 @@ function ExplorerAdminPanel({
                       data-testid="explorer-source-url-input"
                       value={destinationForm.sourceUrl}
                       onChange={(event) => {
-                        setDestinationForm((current) => ({ ...current, sourceUrl: event.target.value }));
+                        setDestinationForm({ sourceUrl: event.target.value });
                         setDestinationPreview(null);
                         setPreviewError(null);
-                      }}
-                      onBlur={() => {
-                        void requestDestinationPreview();
                       }}
                       onPaste={() => {
                         window.setTimeout(() => {
@@ -393,56 +433,38 @@ function ExplorerAdminPanel({
                       required
                     />
                     <p className="explorer-input-help">
-                      Explorer keeps the original source URL and cached display metadata for stable rendering.
+                      Explorer keeps the original Strava URL and previews the segment automatically as you paste.
                     </p>
                   </div>
 
-                  <div className="explorer-form-group">
-                    <label htmlFor="explorer-display-label">Display label</label>
-                    <input
-                      id="explorer-display-label"
-                      data-testid="explorer-display-label-input"
-                      value={destinationForm.displayLabel}
-                      onChange={(event) =>
-                        setDestinationForm((current) => ({ ...current, displayLabel: event.target.value }))
-                      }
-                      placeholder="Optional label to override the cached segment name"
-                    />
-                  </div>
+                  {isValidatingPreview ? (
+                    <p className="explorer-preview-status" data-testid="explorer-preview-status">
+                      <ArrowPathIcon className="explorer-button-icon explorer-spin" aria-hidden="true" />
+                      <span>Validating segment...</span>
+                    </p>
+                  ) : null}
 
-                  <div className="explorer-form-actions">
-                    <button
-                      type="button"
-                      className="explorer-submit-button"
-                      data-testid="explorer-preview-destination-button"
-                      disabled={isValidatingPreview || addDestinationMutation.isPending}
-                      onClick={() => {
-                        void requestDestinationPreview();
-                      }}
-                    >
-                      {isValidatingPreview ? (
-                        <>
-                          <ArrowPathIcon className="explorer-button-icon explorer-spin" aria-hidden="true" />
-                          <span>Validating...</span>
-                        </>
-                      ) : (
-                        <span>Preview Destination</span>
-                      )}
-                    </button>
-                  </div>
-
-                  {previewError && (
+                  {previewError ? (
                     <p className="explorer-preview-error" data-testid="explorer-preview-error">
                       {previewError}
                     </p>
-                  )}
+                  ) : null}
 
-                  {destinationPreview && (
+                  {destinationPreview ? (
                     <article className="leaderboard-card explorer-preview-card" data-testid="explorer-destination-preview-card">
                       <div className="explorer-card-header explorer-preview-header">
                         <div>
                           <p className="explorer-section-label">Preview</p>
-                          <h3 data-testid="explorer-preview-name">{previewDisplayLabel || destinationPreview.name}</h3>
+                          <h3 className="explorer-destination-heading" data-testid="explorer-preview-name">
+                            <a
+                              className="segment-link explorer-destination-name-link"
+                              href={destinationPreview.sourceUrl}
+                              target="_blank"
+                              rel="noreferrer"
+                            >
+                              {destinationPreview.name}
+                            </a>
+                          </h3>
                         </div>
                         <div className="explorer-preview-actions">
                           <button
@@ -472,39 +494,22 @@ function ExplorerAdminPanel({
                         </div>
                       </div>
 
-                      {previewDisplayLabel && (
-                        <p className="explorer-preview-subtitle" data-testid="explorer-preview-segment-name">
-                          Segment name: {destinationPreview.name}
-                        </p>
-                      )}
-
-                      <div className="explorer-destination-stats">
-                        {formatSegmentDistance(destinationPreview.distance) && (
-                          <span className="explorer-stat-pill">{formatSegmentDistance(destinationPreview.distance)}</span>
-                        )}
-                        {formatAverageGrade(destinationPreview.averageGrade) && (
-                          <span className="explorer-stat-pill">{formatAverageGrade(destinationPreview.averageGrade)}</span>
-                        )}
+                      <div className="explorer-destination-chips">
+                        {formatSegmentDistance(destinationPreview.distance) ? (
+                          <span className="week-header-chip">{formatSegmentDistance(destinationPreview.distance)}</span>
+                        ) : null}
+                        {formatAverageGrade(destinationPreview.averageGrade) ? (
+                          <span className="week-header-chip">{formatAverageGrade(destinationPreview.averageGrade)}</span>
+                        ) : null}
+                        {formatLocation(destinationPreview.city, destinationPreview.state, destinationPreview.country) ? (
+                          <span className="week-header-chip explorer-location-chip">
+                            <MapPinIcon className="week-header-chip-icon" aria-hidden="true" />
+                            <span>{formatLocation(destinationPreview.city, destinationPreview.state, destinationPreview.country)}</span>
+                          </span>
+                        ) : null}
                       </div>
-
-                      {formatLocation(destinationPreview.city, destinationPreview.state, destinationPreview.country) && (
-                        <p className="explorer-destination-location">
-                          <MapPinIcon aria-hidden="true" />
-                          <span>{formatLocation(destinationPreview.city, destinationPreview.state, destinationPreview.country)}</span>
-                        </p>
-                      )}
-
-                      <a
-                        className="explorer-destination-link"
-                        href={destinationPreview.sourceUrl}
-                        target="_blank"
-                        rel="noreferrer"
-                      >
-                        <span>Open original Strava segment</span>
-                        <ArrowTopRightOnSquareIcon aria-hidden="true" />
-                      </a>
                     </article>
-                  )}
+                  ) : null}
                 </div>
               </section>
 
@@ -520,52 +525,95 @@ function ExplorerAdminPanel({
                   <p className="explorer-muted-copy">No destinations added yet.</p>
                 ) : (
                   <ol className="explorer-destination-list" data-testid="explorer-destination-list">
-                    {campaignQuery.data.destinations.map((destination) => (
-                      <li
-                        key={destination.id}
-                        className="leaderboard-card explorer-destination-card"
-                        data-testid={`explorer-destination-row-${destination.id}`}
-                      >
-                        <div className="explorer-destination-item">
-                          <div>
-                            <p className="explorer-destination-label">{destination.displayLabel}</p>
-                            {destination.customLabel && destination.customLabel !== destination.segmentName ? (
-                              <p className="explorer-preview-subtitle">Segment name: {destination.segmentName}</p>
-                            ) : null}
-                            <p className="explorer-destination-meta">Segment {destination.stravaSegmentId}</p>
+                    {sortedDestinations.map((destination) => {
+                      const isExpanded = expandedDestinationId === destination.id;
+                      const createdAtLabel = formatDestinationCreatedAt(destination.createdAt);
+                      const locationLabel = formatLocation(destination.city, destination.state, destination.country);
 
-                            <div className="explorer-destination-stats">
-                              {formatSegmentDistance(destination.distance) && (
-                                <span className="explorer-stat-pill">{formatSegmentDistance(destination.distance)}</span>
-                              )}
-                              {formatAverageGrade(destination.averageGrade) && (
-                                <span className="explorer-stat-pill">{formatAverageGrade(destination.averageGrade)}</span>
-                              )}
+                      return (
+                        <li
+                          key={destination.id}
+                          className="leaderboard-card explorer-destination-card"
+                          data-expanded={isExpanded}
+                          data-testid={`explorer-destination-row-${destination.id}`}
+                        >
+                          <div
+                            role="button"
+                            tabIndex={0}
+                            className="explorer-destination-summary"
+                            onClick={() => {
+                              setExpandedDestinationId((current) => current === destination.id ? null : destination.id);
+                            }}
+                            onKeyDown={(event) => {
+                              if (event.key === 'Enter' || event.key === ' ') {
+                                event.preventDefault();
+                                setExpandedDestinationId((current) => current === destination.id ? null : destination.id);
+                              }
+                            }}
+                            aria-expanded={isExpanded}
+                            data-testid={`explorer-destination-toggle-${destination.id}`}
+                          >
+                            <div className="explorer-destination-item">
+                              <div>
+                                <h4 className="explorer-destination-heading">
+                                  {destination.sourceUrl ? (
+                                    <a
+                                      className="segment-link explorer-destination-name-link"
+                                      href={destination.sourceUrl}
+                                      target="_blank"
+                                      rel="noreferrer"
+                                      onClick={(event) => {
+                                        event.stopPropagation();
+                                      }}
+                                    >
+                                      {destination.displayLabel}
+                                    </a>
+                                  ) : (
+                                    <span className="explorer-destination-label">{destination.displayLabel}</span>
+                                  )}
+                                </h4>
+
+                                <div className="explorer-destination-chips">
+                                  {formatSegmentDistance(destination.distance) ? (
+                                    <span className="week-header-chip">{formatSegmentDistance(destination.distance)}</span>
+                                  ) : null}
+                                  {formatAverageGrade(destination.averageGrade) ? (
+                                    <span className="week-header-chip">{formatAverageGrade(destination.averageGrade)}</span>
+                                  ) : null}
+                                  {locationLabel ? (
+                                    <span className="week-header-chip explorer-location-chip">
+                                      <MapPinIcon className="week-header-chip-icon" aria-hidden="true" />
+                                      <span>{locationLabel}</span>
+                                    </span>
+                                  ) : null}
+                                </div>
+                              </div>
+
+                              <ChevronDownIcon className={`explorer-destination-chevron${isExpanded ? ' is-expanded' : ''}`} aria-hidden="true" />
                             </div>
-
-                            {formatLocation(destination.city, destination.state, destination.country) && (
-                              <p className="explorer-destination-location">
-                                <MapPinIcon aria-hidden="true" />
-                                <span>{formatLocation(destination.city, destination.state, destination.country)}</span>
-                              </p>
-                            )}
-
-                            {destination.sourceUrl ? (
-                              <a
-                                className="explorer-destination-link"
-                                href={destination.sourceUrl}
-                                target="_blank"
-                                rel="noreferrer"
-                              >
-                                <span>Open original Strava segment</span>
-                                <ArrowTopRightOnSquareIcon aria-hidden="true" />
-                              </a>
-                            ) : null}
                           </div>
-                          <span className="explorer-destination-order">#{destination.displayOrder + 1}</span>
-                        </div>
-                      </li>
-                    ))}
+
+                          {isExpanded ? (
+                            <div className="card-expanded-details explorer-destination-details">
+                              {destination.customLabel && destination.customLabel !== destination.segmentName ? (
+                                <p className="explorer-preview-subtitle">Original segment name: {destination.segmentName}</p>
+                              ) : null}
+
+                              <div className="explorer-destination-detail-row">
+                                {createdAtLabel ? (
+                                  <p className="explorer-destination-meta">
+                                    <ClockIcon aria-hidden="true" />
+                                    <span>Added {createdAtLabel}</span>
+                                  </p>
+                                ) : (
+                                  <p className="explorer-muted-copy">Added date unavailable.</p>
+                                )}
+                              </div>
+                            </div>
+                          ) : null}
+                        </li>
+                      );
+                    })}
                   </ol>
                 )}
               </section>

--- a/src/components/ExplorerAdminPanel.tsx
+++ b/src/components/ExplorerAdminPanel.tsx
@@ -116,6 +116,7 @@ function ExplorerAdminPanel({
 }: ExplorerAdminPanelProps) {
   const utils = trpc.useUtils();
   const messageTimeoutRef = useRef<number | null>(null);
+  const previewRequestIdRef = useRef(0);
   const [campaignForm, setCampaignForm] = useState({
     displayName: '',
     rulesBlurb: '',
@@ -209,6 +210,9 @@ function ExplorerAdminPanel({
 
   const requestDestinationPreview = useCallback(async () => {
     const trimmedSourceUrl = destinationForm.sourceUrl.trim();
+    const requestId = previewRequestIdRef.current + 1;
+
+    previewRequestIdRef.current = requestId;
 
     if (!trimmedSourceUrl) {
       setDestinationPreview(null);
@@ -230,6 +234,10 @@ function ExplorerAdminPanel({
     try {
       const segment = await utils.client.segment.validate.query(parsedSegmentId);
 
+      if (previewRequestIdRef.current !== requestId || destinationForm.sourceUrl.trim() !== trimmedSourceUrl) {
+        return;
+      }
+
       if (!segment) {
         throw new Error('Segment metadata could not be loaded');
       }
@@ -244,11 +252,17 @@ function ExplorerAdminPanel({
         country: segment.country,
       });
     } catch (error) {
+      if (previewRequestIdRef.current !== requestId || destinationForm.sourceUrl.trim() !== trimmedSourceUrl) {
+        return;
+      }
+
       const errorMessage = error instanceof Error ? error.message : 'Segment metadata could not be loaded';
       setDestinationPreview(null);
       setPreviewError(errorMessage);
     } finally {
-      setIsValidatingPreview(false);
+      if (previewRequestIdRef.current === requestId) {
+        setIsValidatingPreview(false);
+      }
     }
   }, [destinationForm.sourceUrl, utils.client.segment.validate]);
 
@@ -276,6 +290,7 @@ function ExplorerAdminPanel({
     const trimmedSourceUrl = destinationForm.sourceUrl.trim();
 
     if (!trimmedSourceUrl) {
+      previewRequestIdRef.current += 1;
       setDestinationPreview(null);
       setPreviewError(null);
       return;
@@ -456,11 +471,6 @@ function ExplorerAdminPanel({
                         setDestinationPreview(null);
                         setPreviewError(null);
                       }}
-                      onPaste={() => {
-                        window.setTimeout(() => {
-                          void requestDestinationPreview();
-                        }, 0);
-                      }}
                       placeholder="https://www.strava.com/segments/2234642"
                       required
                     />
@@ -483,59 +493,65 @@ function ExplorerAdminPanel({
                   ) : null}
 
                   {destinationPreview ? (
-                    <article className="explorer-preview-card" data-testid="explorer-destination-preview-card">
-                      <div className="explorer-preview-header">
-                        <p className="explorer-section-label">Preview</p>
-                        <div className="explorer-preview-actions">
-                          <button
-                            type="button"
-                            className="explorer-icon-button explorer-icon-button-accept"
-                            data-testid="explorer-accept-preview-button"
-                            aria-label="Accept destination preview"
-                            onClick={() => {
-                              void handleAcceptPreview();
-                            }}
-                            disabled={addDestinationMutation.isPending}
-                          >
-                            <CheckIcon aria-hidden="true" />
-                          </button>
-                          <button
-                            type="button"
-                            className="explorer-icon-button explorer-icon-button-reject"
-                            data-testid="explorer-reject-preview-button"
-                            aria-label="Reject destination preview"
-                            onClick={() => {
-                              setDestinationPreview(null);
-                              setPreviewError(null);
-                            }}
-                          >
-                            <XMarkIcon aria-hidden="true" />
-                          </button>
-                        </div>
-                      </div>
+                    (() => {
+                      const previewStatItems = getDestinationStatItems(destinationPreview);
 
-                      <div className="explorer-destination-surface explorer-destination-surface-preview">
-                        <h3 className="explorer-destination-hero-title" data-testid="explorer-preview-name">
-                          <a
-                            className="explorer-destination-surface-link"
-                            href={destinationPreview.sourceUrl}
-                            target="_blank"
-                            rel="noreferrer"
-                          >
-                            {destinationPreview.name}
-                            <ArrowTopRightOnSquareIcon aria-hidden="true" />
-                          </a>
-                        </h3>
-
-                        {getDestinationStatItems(destinationPreview).length > 0 ? (
-                          <div className="explorer-destination-chip-row">
-                            {getDestinationStatItems(destinationPreview).map((item) => (
-                              <span key={item} className="week-header-chip">{item}</span>
-                            ))}
+                      return (
+                        <article className="explorer-preview-card" data-testid="explorer-destination-preview-card">
+                          <div className="explorer-preview-header">
+                            <p className="explorer-section-label">Preview</p>
+                            <div className="explorer-preview-actions">
+                              <button
+                                type="button"
+                                className="explorer-icon-button explorer-icon-button-accept"
+                                data-testid="explorer-accept-preview-button"
+                                aria-label="Accept destination preview"
+                                onClick={() => {
+                                  void handleAcceptPreview();
+                                }}
+                                disabled={addDestinationMutation.isPending}
+                              >
+                                <CheckIcon aria-hidden="true" />
+                              </button>
+                              <button
+                                type="button"
+                                className="explorer-icon-button explorer-icon-button-reject"
+                                data-testid="explorer-reject-preview-button"
+                                aria-label="Reject destination preview"
+                                onClick={() => {
+                                  setDestinationPreview(null);
+                                  setPreviewError(null);
+                                }}
+                              >
+                                <XMarkIcon aria-hidden="true" />
+                              </button>
+                            </div>
                           </div>
-                        ) : null}
-                      </div>
-                    </article>
+
+                          <div className="explorer-destination-surface explorer-destination-surface-preview">
+                            <h3 className="explorer-destination-hero-title" data-testid="explorer-preview-name">
+                              <a
+                                className="explorer-destination-surface-link"
+                                href={destinationPreview.sourceUrl}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                              >
+                                {destinationPreview.name}
+                                <ArrowTopRightOnSquareIcon aria-hidden="true" />
+                              </a>
+                            </h3>
+
+                            {previewStatItems.length > 0 ? (
+                              <div className="explorer-destination-chip-row">
+                                {previewStatItems.map((item) => (
+                                  <span key={item} className="week-header-chip">{item}</span>
+                                ))}
+                              </div>
+                            ) : null}
+                          </div>
+                        </article>
+                      );
+                    })()
                   ) : null}
                 </div>
               </section>
@@ -594,7 +610,7 @@ function ExplorerAdminPanel({
                                       className="explorer-destination-surface-link"
                                       href={destination.sourceUrl}
                                       target="_blank"
-                                      rel="noreferrer"
+                                      rel="noopener noreferrer"
                                       onClick={(event) => {
                                         event.stopPropagation();
                                       }}

--- a/src/components/ExplorerAdminPanel.tsx
+++ b/src/components/ExplorerAdminPanel.tsx
@@ -1,9 +1,17 @@
 import { useEffect, useRef, useState } from 'react';
+import {
+  ArrowPathIcon,
+  ArrowTopRightOnSquareIcon,
+  CheckIcon,
+  MapPinIcon,
+  XMarkIcon,
+} from '@heroicons/react/24/outline';
 import type { Season } from '../types';
 import { trpc } from '../utils/trpc';
 import { formatUnixDate } from '../utils/dateUtils';
 import SeasonSelector from './SeasonSelector';
 import './AdminPanel.css';
+import './Card.css';
 import './ExplorerAdminPanel.css';
 
 interface ExplorerAdminPanelProps {
@@ -16,6 +24,46 @@ interface ExplorerAdminPanelProps {
 interface FlashMessage {
   type: 'success' | 'error' | 'info';
   text: string;
+}
+
+interface PreviewDestination {
+  sourceUrl: string;
+  stravaSegmentId: string;
+  name: string;
+  distance?: number | null;
+  averageGrade?: number | null;
+  city?: string | null;
+  state?: string | null;
+  country?: string | null;
+}
+
+function parseSegmentId(sourceUrl: string): string | null {
+  const trimmedSourceUrl = sourceUrl.trim();
+  const segmentMatch = trimmedSourceUrl.match(/^https?:\/\/(?:www\.)?strava\.com\/segments\/(\d+)(?:[/?#].*)?$/i);
+
+  return segmentMatch?.[1] ?? null;
+}
+
+function formatSegmentDistance(distance?: number | null): string | null {
+  if (distance == null) {
+    return null;
+  }
+
+  return `${(distance / 1000).toFixed(2)} km`;
+}
+
+function formatAverageGrade(averageGrade?: number | null): string | null {
+  if (averageGrade == null) {
+    return null;
+  }
+
+  return `${averageGrade.toFixed(1)}% avg grade`;
+}
+
+function formatLocation(city?: string | null, state?: string | null, country?: string | null): string | null {
+  const locationParts = [city, state, country].filter(Boolean);
+
+  return locationParts.length > 0 ? locationParts.join(', ') : null;
 }
 
 function ExplorerAdminPanel({
@@ -34,6 +82,9 @@ function ExplorerAdminPanel({
     sourceUrl: '',
     displayLabel: '',
   });
+  const [destinationPreview, setDestinationPreview] = useState<PreviewDestination | null>(null);
+  const [previewError, setPreviewError] = useState<string | null>(null);
+  const [isValidatingPreview, setIsValidatingPreview] = useState(false);
   const [message, setMessage] = useState<FlashMessage | null>(null);
 
   const hasSelectedSeason =
@@ -85,6 +136,8 @@ function ExplorerAdminPanel({
     onSuccess: async (destination) => {
       await utils.explorerAdmin.getCampaignForSeason.invalidate({ seasonId: resolvedSeasonId ?? 0 });
       setDestinationForm({ sourceUrl: '', displayLabel: '' });
+      setDestinationPreview(null);
+      setPreviewError(null);
 
       setTimedMessage({
         type: destination.usedPlaceholderMetadata ? 'info' : 'success',
@@ -113,8 +166,56 @@ function ExplorerAdminPanel({
     });
   };
 
-  const handleAddDestination = async (event: React.FormEvent) => {
-    event.preventDefault();
+  const requestDestinationPreview = async () => {
+    const trimmedSourceUrl = destinationForm.sourceUrl.trim();
+
+    if (!trimmedSourceUrl) {
+      setDestinationPreview(null);
+      setPreviewError(null);
+      return;
+    }
+
+    const parsedSegmentId = parseSegmentId(trimmedSourceUrl);
+
+    if (!parsedSegmentId) {
+      setDestinationPreview(null);
+      setPreviewError('Please provide a valid Strava segment URL');
+      return;
+    }
+
+    setIsValidatingPreview(true);
+    setPreviewError(null);
+
+    try {
+      const segment = await utils.client.segment.validate.query(parsedSegmentId);
+
+      if (!segment) {
+        throw new Error('Segment metadata could not be loaded');
+      }
+
+      setDestinationPreview({
+        sourceUrl: trimmedSourceUrl,
+        stravaSegmentId: segment.strava_segment_id,
+        name: segment.name,
+        distance: segment.distance,
+        averageGrade: segment.average_grade,
+        city: segment.city,
+        state: segment.state,
+        country: segment.country,
+      });
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : 'Segment metadata could not be loaded';
+      setDestinationPreview(null);
+      setPreviewError(errorMessage);
+    } finally {
+      setIsValidatingPreview(false);
+    }
+  };
+
+  const handleAcceptPreview = async () => {
+    if (!destinationPreview) {
+      return;
+    }
 
     if (!campaignQuery.data) {
       setTimedMessage({ type: 'error', text: 'Create a campaign before adding Explorer destinations.' });
@@ -123,10 +224,12 @@ function ExplorerAdminPanel({
 
     await addDestinationMutation.mutateAsync({
       explorerCampaignId: campaignQuery.data.id,
-      sourceUrl: destinationForm.sourceUrl.trim(),
+      sourceUrl: destinationPreview.sourceUrl,
       displayLabel: destinationForm.displayLabel.trim() || null,
     });
   };
+
+  const previewDisplayLabel = destinationForm.displayLabel.trim();
 
   if (!isAdmin) {
     return (
@@ -169,7 +272,7 @@ function ExplorerAdminPanel({
         </div>
       ) : (
         <>
-          <section className="explorer-season-summary" data-testid="explorer-season-summary">
+          <section className="leaderboard-card explorer-season-summary" data-testid="explorer-season-summary">
             <div>
               <p className="explorer-section-label">Selected season</p>
               <h2>{selectedSeason.name}</h2>
@@ -180,15 +283,15 @@ function ExplorerAdminPanel({
           </section>
 
           {campaignQuery.isLoading ? (
-            <div className="explorer-card">
+            <div className="leaderboard-card explorer-card">
               <p>Loading Explorer campaign setup...</p>
             </div>
           ) : campaignQuery.error ? (
-            <div className="explorer-card explorer-error-card">
+            <div className="leaderboard-card explorer-card explorer-error-card">
               <p>{campaignQuery.error.message}</p>
             </div>
           ) : !campaignQuery.data ? (
-            <section className="explorer-card" data-testid="explorer-create-campaign-card">
+            <section className="leaderboard-card explorer-card" data-testid="explorer-create-campaign-card">
               <div className="explorer-card-header">
                 <div>
                   <p className="explorer-section-label">Phase 4B setup</p>
@@ -241,7 +344,7 @@ function ExplorerAdminPanel({
             </section>
           ) : (
             <>
-              <section className="explorer-card" data-testid="explorer-campaign-summary-card">
+              <section className="leaderboard-card explorer-card" data-testid="explorer-campaign-summary-card">
                 <div className="explorer-card-header">
                   <div>
                     <p className="explorer-section-label">Explorer campaign</p>
@@ -257,28 +360,41 @@ function ExplorerAdminPanel({
                 )}
               </section>
 
-              <section className="explorer-card" data-testid="explorer-add-destination-card">
+              <section className="leaderboard-card explorer-card" data-testid="explorer-add-destination-card">
                 <div className="explorer-card-header">
                   <div>
                     <p className="explorer-section-label">Destination authoring</p>
                     <h3>Add Destination</h3>
                   </div>
-                  <p>Paste a Strava segment URL. Explorer keeps the source URL and cached display metadata.</p>
+                  <p>Paste a Strava segment URL to preview it, then accept or reject before adding it to the campaign.</p>
                 </div>
 
-                <form className="explorer-form" onSubmit={handleAddDestination} data-testid="explorer-add-destination-form">
+                <div className="explorer-form" data-testid="explorer-add-destination-form">
                   <div className="explorer-form-group">
                     <label htmlFor="explorer-source-url">Strava segment URL</label>
                     <input
                       id="explorer-source-url"
                       data-testid="explorer-source-url-input"
                       value={destinationForm.sourceUrl}
-                      onChange={(event) =>
-                        setDestinationForm((current) => ({ ...current, sourceUrl: event.target.value }))
-                      }
+                      onChange={(event) => {
+                        setDestinationForm((current) => ({ ...current, sourceUrl: event.target.value }));
+                        setDestinationPreview(null);
+                        setPreviewError(null);
+                      }}
+                      onBlur={() => {
+                        void requestDestinationPreview();
+                      }}
+                      onPaste={() => {
+                        window.setTimeout(() => {
+                          void requestDestinationPreview();
+                        }, 0);
+                      }}
                       placeholder="https://www.strava.com/segments/2234642"
                       required
                     />
+                    <p className="explorer-input-help">
+                      Explorer keeps the original source URL and cached display metadata for stable rendering.
+                    </p>
                   </div>
 
                   <div className="explorer-form-group">
@@ -296,18 +412,103 @@ function ExplorerAdminPanel({
 
                   <div className="explorer-form-actions">
                     <button
-                      type="submit"
+                      type="button"
                       className="explorer-submit-button"
-                      data-testid="explorer-add-destination-button"
-                      disabled={addDestinationMutation.isPending}
+                      data-testid="explorer-preview-destination-button"
+                      disabled={isValidatingPreview || addDestinationMutation.isPending}
+                      onClick={() => {
+                        void requestDestinationPreview();
+                      }}
                     >
-                      {addDestinationMutation.isPending ? 'Adding...' : 'Add Destination'}
+                      {isValidatingPreview ? (
+                        <>
+                          <ArrowPathIcon className="explorer-button-icon explorer-spin" aria-hidden="true" />
+                          <span>Validating...</span>
+                        </>
+                      ) : (
+                        <span>Preview Destination</span>
+                      )}
                     </button>
                   </div>
-                </form>
+
+                  {previewError && (
+                    <p className="explorer-preview-error" data-testid="explorer-preview-error">
+                      {previewError}
+                    </p>
+                  )}
+
+                  {destinationPreview && (
+                    <article className="leaderboard-card explorer-preview-card" data-testid="explorer-destination-preview-card">
+                      <div className="explorer-card-header explorer-preview-header">
+                        <div>
+                          <p className="explorer-section-label">Preview</p>
+                          <h3 data-testid="explorer-preview-name">{previewDisplayLabel || destinationPreview.name}</h3>
+                        </div>
+                        <div className="explorer-preview-actions">
+                          <button
+                            type="button"
+                            className="explorer-icon-button explorer-icon-button-accept"
+                            data-testid="explorer-accept-preview-button"
+                            aria-label="Accept destination preview"
+                            onClick={() => {
+                              void handleAcceptPreview();
+                            }}
+                            disabled={addDestinationMutation.isPending}
+                          >
+                            <CheckIcon aria-hidden="true" />
+                          </button>
+                          <button
+                            type="button"
+                            className="explorer-icon-button explorer-icon-button-reject"
+                            data-testid="explorer-reject-preview-button"
+                            aria-label="Reject destination preview"
+                            onClick={() => {
+                              setDestinationPreview(null);
+                              setPreviewError(null);
+                            }}
+                          >
+                            <XMarkIcon aria-hidden="true" />
+                          </button>
+                        </div>
+                      </div>
+
+                      {previewDisplayLabel && (
+                        <p className="explorer-preview-subtitle" data-testid="explorer-preview-segment-name">
+                          Segment name: {destinationPreview.name}
+                        </p>
+                      )}
+
+                      <div className="explorer-destination-stats">
+                        {formatSegmentDistance(destinationPreview.distance) && (
+                          <span className="explorer-stat-pill">{formatSegmentDistance(destinationPreview.distance)}</span>
+                        )}
+                        {formatAverageGrade(destinationPreview.averageGrade) && (
+                          <span className="explorer-stat-pill">{formatAverageGrade(destinationPreview.averageGrade)}</span>
+                        )}
+                      </div>
+
+                      {formatLocation(destinationPreview.city, destinationPreview.state, destinationPreview.country) && (
+                        <p className="explorer-destination-location">
+                          <MapPinIcon aria-hidden="true" />
+                          <span>{formatLocation(destinationPreview.city, destinationPreview.state, destinationPreview.country)}</span>
+                        </p>
+                      )}
+
+                      <a
+                        className="explorer-destination-link"
+                        href={destinationPreview.sourceUrl}
+                        target="_blank"
+                        rel="noreferrer"
+                      >
+                        <span>Open original Strava segment</span>
+                        <ArrowTopRightOnSquareIcon aria-hidden="true" />
+                      </a>
+                    </article>
+                  )}
+                </div>
               </section>
 
-              <section className="explorer-card" data-testid="explorer-destination-list-card">
+              <section className="leaderboard-card explorer-card" data-testid="explorer-destination-list-card">
                 <div className="explorer-card-header">
                   <div>
                     <p className="explorer-section-label">Current campaign map</p>
@@ -322,17 +523,47 @@ function ExplorerAdminPanel({
                     {campaignQuery.data.destinations.map((destination) => (
                       <li
                         key={destination.id}
-                        className="explorer-destination-item"
+                        className="leaderboard-card explorer-destination-card"
                         data-testid={`explorer-destination-row-${destination.id}`}
                       >
-                        <div>
-                          <p className="explorer-destination-label">{destination.displayLabel}</p>
-                          <p className="explorer-destination-meta">
-                            Segment {destination.stravaSegmentId}
-                            {destination.sourceUrl ? ` • ${destination.sourceUrl}` : ''}
-                          </p>
+                        <div className="explorer-destination-item">
+                          <div>
+                            <p className="explorer-destination-label">{destination.displayLabel}</p>
+                            {destination.customLabel && destination.customLabel !== destination.segmentName ? (
+                              <p className="explorer-preview-subtitle">Segment name: {destination.segmentName}</p>
+                            ) : null}
+                            <p className="explorer-destination-meta">Segment {destination.stravaSegmentId}</p>
+
+                            <div className="explorer-destination-stats">
+                              {formatSegmentDistance(destination.distance) && (
+                                <span className="explorer-stat-pill">{formatSegmentDistance(destination.distance)}</span>
+                              )}
+                              {formatAverageGrade(destination.averageGrade) && (
+                                <span className="explorer-stat-pill">{formatAverageGrade(destination.averageGrade)}</span>
+                              )}
+                            </div>
+
+                            {formatLocation(destination.city, destination.state, destination.country) && (
+                              <p className="explorer-destination-location">
+                                <MapPinIcon aria-hidden="true" />
+                                <span>{formatLocation(destination.city, destination.state, destination.country)}</span>
+                              </p>
+                            )}
+
+                            {destination.sourceUrl ? (
+                              <a
+                                className="explorer-destination-link"
+                                href={destination.sourceUrl}
+                                target="_blank"
+                                rel="noreferrer"
+                              >
+                                <span>Open original Strava segment</span>
+                                <ArrowTopRightOnSquareIcon aria-hidden="true" />
+                              </a>
+                            ) : null}
+                          </div>
+                          <span className="explorer-destination-order">#{destination.displayOrder + 1}</span>
                         </div>
-                        <span className="explorer-destination-order">#{destination.displayOrder + 1}</span>
                       </li>
                     ))}
                   </ol>

--- a/src/components/ExplorerAdminPanel.tsx
+++ b/src/components/ExplorerAdminPanel.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   ArrowPathIcon,
+  ArrowTopRightOnSquareIcon,
   ChevronDownIcon,
   CheckIcon,
   ClockIcon,
@@ -12,7 +13,6 @@ import { formatUnixDate, formatUtcIsoDateTime } from '../utils/dateUtils';
 import SeasonSelector from './SeasonSelector';
 import './AdminPanel.css';
 import './Card.css';
-import './SegmentCard.css';
 import './ExplorerAdminPanel.css';
 
 interface ExplorerAdminPanelProps {
@@ -514,22 +514,23 @@ function ExplorerAdminPanel({
                         </div>
                       </div>
 
-                      <div className="segment-card explorer-destination-meta-card">
-                        <h3 className="segment-card-title explorer-destination-title" data-testid="explorer-preview-name">
+                      <div className="explorer-destination-surface explorer-destination-surface-preview">
+                        <h3 className="explorer-destination-hero-title" data-testid="explorer-preview-name">
                           <a
-                            className="segment-link explorer-destination-name-link"
+                            className="explorer-destination-surface-link"
                             href={destinationPreview.sourceUrl}
                             target="_blank"
                             rel="noreferrer"
                           >
                             {destinationPreview.name}
+                            <ArrowTopRightOnSquareIcon aria-hidden="true" />
                           </a>
                         </h3>
 
                         {getDestinationStatItems(destinationPreview).length > 0 ? (
-                          <div className="segment-card-stats explorer-destination-stats">
+                          <div className="explorer-destination-chip-row">
                             {getDestinationStatItems(destinationPreview).map((item) => (
-                              <span key={item}>{item}</span>
+                              <span key={item} className="week-header-chip">{item}</span>
                             ))}
                           </div>
                         ) : null}
@@ -539,7 +540,7 @@ function ExplorerAdminPanel({
                 </div>
               </section>
 
-              <section className="leaderboard-card explorer-card" data-testid="explorer-destination-list-card">
+              <section className="explorer-destination-section" data-testid="explorer-destination-list-card">
                 <div className="explorer-card-header">
                   <div>
                     <p className="explorer-section-label">Current campaign map</p>
@@ -585,12 +586,12 @@ function ExplorerAdminPanel({
                             aria-expanded={isExpanded}
                             data-testid={`explorer-destination-toggle-${destination.id}`}
                           >
-                            <div className="segment-card explorer-destination-summary-card">
+                            <div className="explorer-destination-surface explorer-destination-summary-card">
                               <div>
-                                <h4 className="segment-card-title explorer-destination-title">
+                                <h4 className="explorer-destination-hero-title explorer-destination-list-title">
                                   {destination.sourceUrl ? (
                                     <a
-                                      className="segment-link explorer-destination-name-link"
+                                      className="explorer-destination-surface-link"
                                       href={destination.sourceUrl}
                                       target="_blank"
                                       rel="noreferrer"
@@ -599,6 +600,7 @@ function ExplorerAdminPanel({
                                       }}
                                     >
                                       {destination.displayLabel}
+                                      <ArrowTopRightOnSquareIcon aria-hidden="true" />
                                     </a>
                                   ) : (
                                     <span className="explorer-destination-label">{destination.displayLabel}</span>
@@ -606,9 +608,9 @@ function ExplorerAdminPanel({
                                 </h4>
 
                                 {destinationStatItems.length > 0 ? (
-                                  <div className="segment-card-stats explorer-destination-stats">
+                                  <div className="explorer-destination-chip-row">
                                     {destinationStatItems.map((item) => (
-                                      <span key={item}>{item}</span>
+                                      <span key={item} className="week-header-chip">{item}</span>
                                     ))}
                                   </div>
                                 ) : null}

--- a/src/components/__tests__/ExplorerAdminPanel.test.tsx
+++ b/src/components/__tests__/ExplorerAdminPanel.test.tsx
@@ -134,7 +134,21 @@ interface RenderResult {
   root: Root;
 }
 
+interface DeferredValue<T> {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+}
+
 let renderResult: RenderResult | null = null;
+
+function createDeferredValue<T>(): DeferredValue<T> {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+
+  return { promise, resolve };
+}
 
 async function renderPanel(overrides: Partial<React.ComponentProps<typeof ExplorerAdminPanel>> = {}) {
   const container = document.createElement('div');
@@ -363,6 +377,116 @@ describe('ExplorerAdminPanel', () => {
     });
 
     expect(queryByTestId(container, 'explorer-admin-message')).toBeNull();
+  });
+
+  it('requests a single preview validation for each source-url change', async () => {
+    vi.useFakeTimers();
+    trpcMocks.campaignQuery.data = {
+      id: 41,
+      name: 'Spring 2026 Explorer',
+      rulesBlurb: 'Ride every destination once.',
+      destinations: [],
+    };
+
+    const { container } = await renderPanel();
+
+    await setValue(
+      getByTestId(container, 'explorer-source-url-input') as HTMLInputElement,
+      'https://www.strava.com/segments/2234642'
+    );
+
+    await act(async () => {
+      vi.advanceTimersByTime(150);
+      await Promise.resolve();
+    });
+
+    expect(trpcMocks.validateSegment).toHaveBeenCalledTimes(1);
+    expect(trpcMocks.validateSegment).toHaveBeenCalledWith('2234642');
+  });
+
+  it('ignores stale preview responses when the source URL changes mid-request', async () => {
+    vi.useFakeTimers();
+    trpcMocks.campaignQuery.data = {
+      id: 41,
+      name: 'Spring 2026 Explorer',
+      rulesBlurb: 'Ride every destination once.',
+      destinations: [],
+    };
+
+    const firstPreview = createDeferredValue({
+      strava_segment_id: '2234642',
+      name: 'Older Preview',
+      distance: 1000,
+      average_grade: 2.1,
+      city: 'Oldtown',
+      state: 'MA',
+      country: 'USA',
+    });
+    const secondPreview = createDeferredValue({
+      strava_segment_id: '9999999',
+      name: 'Newest Preview',
+      distance: 4500,
+      average_grade: 6.2,
+      city: 'Newtown',
+      state: 'VT',
+      country: 'USA',
+    });
+
+    trpcMocks.validateSegment.mockReset();
+    trpcMocks.validateSegment
+      .mockReturnValueOnce(firstPreview.promise)
+      .mockReturnValueOnce(secondPreview.promise);
+
+    const { container } = await renderPanel();
+
+    await setValue(
+      getByTestId(container, 'explorer-source-url-input') as HTMLInputElement,
+      'https://www.strava.com/segments/2234642'
+    );
+    await act(async () => {
+      vi.advanceTimersByTime(150);
+      await Promise.resolve();
+    });
+
+    await setValue(
+      getByTestId(container, 'explorer-source-url-input') as HTMLInputElement,
+      'https://www.strava.com/segments/9999999'
+    );
+    await act(async () => {
+      vi.advanceTimersByTime(150);
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      firstPreview.resolve({
+        strava_segment_id: '2234642',
+        name: 'Older Preview',
+        distance: 1000,
+        average_grade: 2.1,
+        city: 'Oldtown',
+        state: 'MA',
+        country: 'USA',
+      });
+      await Promise.resolve();
+    });
+
+    expect(queryByTestId(container, 'explorer-destination-preview-card')).toBeNull();
+
+    await act(async () => {
+      secondPreview.resolve({
+        strava_segment_id: '9999999',
+        name: 'Newest Preview',
+        distance: 4500,
+        average_grade: 6.2,
+        city: 'Newtown',
+        state: 'VT',
+        country: 'USA',
+      });
+      await Promise.resolve();
+    });
+
+    expect(getByTestId(container, 'explorer-destination-preview-card').textContent).toContain('Newest Preview');
+    expect(getByTestId(container, 'explorer-destination-preview-card').textContent).not.toContain('Older Preview');
   });
 
   it('renders richer destination cards when a campaign already has destinations', async () => {

--- a/src/components/__tests__/ExplorerAdminPanel.test.tsx
+++ b/src/components/__tests__/ExplorerAdminPanel.test.tsx
@@ -20,6 +20,7 @@ const trpcMocks = vi.hoisted(() => ({
         displayOrder: number;
         sourceUrl: string | null;
         stravaSegmentId: string;
+        createdAt: string | null;
         distance: number | null;
         averageGrade: number | null;
         city: string | null;
@@ -273,7 +274,7 @@ describe('ExplorerAdminPanel', () => {
     expect(queryByTestId(container, 'explorer-create-campaign-form')).toBeNull();
   });
 
-  it('previews, accepts, and rejects destinations while preserving the latest flash message timer', async () => {
+  it('auto-previews, accepts, and rejects destinations while preserving the latest flash message timer', async () => {
     vi.useFakeTimers();
     trpcMocks.campaignQuery.data = {
       id: 41,
@@ -301,7 +302,10 @@ describe('ExplorerAdminPanel', () => {
       getByTestId(container, 'explorer-source-url-input') as HTMLInputElement,
       '  https://www.strava.com/segments/2234642  '
     );
-    await clickElement(getByTestId(container, 'explorer-preview-destination-button'));
+    await act(async () => {
+      vi.advanceTimersByTime(150);
+      await Promise.resolve();
+    });
 
     expect(getByTestId(container, 'explorer-destination-preview-card').textContent).toContain('Box Hill KOM');
     expect(getByTestId(container, 'explorer-destination-preview-card').textContent).toContain('2.93 km');
@@ -309,14 +313,20 @@ describe('ExplorerAdminPanel', () => {
     await clickElement(getByTestId(container, 'explorer-reject-preview-button'));
     expect(queryByTestId(container, 'explorer-destination-preview-card')).toBeNull();
 
-    await clickElement(getByTestId(container, 'explorer-preview-destination-button'));
+    await setValue(
+      getByTestId(container, 'explorer-source-url-input') as HTMLInputElement,
+      'https://www.strava.com/segments/2234642'
+    );
+    await act(async () => {
+      vi.advanceTimersByTime(150);
+      await Promise.resolve();
+    });
     await clickElement(getByTestId(container, 'explorer-accept-preview-button'));
 
     expect(getByTestId(container, 'explorer-admin-message').textContent).toContain('placeholder metadata');
     expect(trpcMocks.addDestination).toHaveBeenNthCalledWith(1, {
       explorerCampaignId: 41,
       sourceUrl: 'https://www.strava.com/segments/2234642',
-      displayLabel: null,
     });
 
     await act(async () => {
@@ -327,14 +337,12 @@ describe('ExplorerAdminPanel', () => {
       getByTestId(container, 'explorer-source-url-input') as HTMLInputElement,
       'https://www.strava.com/segments/2234642'
     );
-    await setValue(
-      getByTestId(container, 'explorer-display-label-input') as HTMLInputElement,
-      '  Box Hill opener  '
-    );
-    await clickElement(getByTestId(container, 'explorer-preview-destination-button'));
+    await act(async () => {
+      vi.advanceTimersByTime(150);
+      await Promise.resolve();
+    });
 
-    expect(getByTestId(container, 'explorer-preview-name').textContent).toContain('Box Hill opener');
-    expect(getByTestId(container, 'explorer-preview-segment-name').textContent).toContain('Box Hill KOM');
+    expect(getByTestId(container, 'explorer-preview-name').textContent).toContain('Box Hill KOM');
 
     await clickElement(getByTestId(container, 'explorer-accept-preview-button'));
 
@@ -342,7 +350,6 @@ describe('ExplorerAdminPanel', () => {
     expect(trpcMocks.addDestination).toHaveBeenNthCalledWith(2, {
       explorerCampaignId: 41,
       sourceUrl: 'https://www.strava.com/segments/2234642',
-      displayLabel: 'Box Hill opener',
     });
 
     await act(async () => {
@@ -372,6 +379,7 @@ describe('ExplorerAdminPanel', () => {
           displayOrder: 0,
           sourceUrl: 'https://www.strava.com/segments/2234642',
           stravaSegmentId: '2234642',
+          createdAt: '2026-04-17 13:15:00',
           distance: 2931,
           averageGrade: 5.4,
           city: 'Dorking',
@@ -384,10 +392,13 @@ describe('ExplorerAdminPanel', () => {
     const { container } = await renderPanel();
 
     expect(getByTestId(container, 'explorer-destination-row-99').textContent).toContain('Box Hill opener');
-    expect(getByTestId(container, 'explorer-destination-row-99').textContent).toContain('Segment name: Box Hill KOM');
     expect(getByTestId(container, 'explorer-destination-row-99').textContent).toContain('2.93 km');
     expect(getByTestId(container, 'explorer-destination-row-99').textContent).toContain('5.4% avg grade');
     expect(getByTestId(container, 'explorer-destination-row-99').textContent).toContain('Dorking, Surrey, United Kingdom');
-    expect(getByTestId(container, 'explorer-destination-row-99').textContent).toContain('Open original Strava segment');
+
+    await clickElement(getByTestId(container, 'explorer-destination-toggle-99'));
+
+    expect(getByTestId(container, 'explorer-destination-row-99').textContent).toContain('Original segment name: Box Hill KOM');
+    expect(getByTestId(container, 'explorer-destination-row-99').textContent).toContain('Added');
   });
 });

--- a/src/components/__tests__/ExplorerAdminPanel.test.tsx
+++ b/src/components/__tests__/ExplorerAdminPanel.test.tsx
@@ -4,7 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Season } from '../../types';
 import ExplorerAdminPanel from '../ExplorerAdminPanel';
 
-globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
 const trpcMocks = vi.hoisted(() => ({
   campaignQuery: {
@@ -15,17 +15,33 @@ const trpcMocks = vi.hoisted(() => ({
       destinations: Array<{
         id: number;
         displayLabel: string;
+        customLabel: string | null;
+        segmentName: string;
         displayOrder: number;
         sourceUrl: string | null;
         stravaSegmentId: string;
+        distance: number | null;
+        averageGrade: number | null;
+        city: string | null;
+        state: string | null;
+        country: string | null;
       }>;
     },
     error: null as Error | null,
     isLoading: false,
   },
   invalidate: vi.fn(async () => undefined),
-  createCampaign: vi.fn(async () => ({ id: 1 })),
-  addDestination: vi.fn(async () => ({
+  validateSegment: vi.fn(async () => ({
+    strava_segment_id: '2234642',
+    name: 'Box Hill KOM',
+    distance: 2931,
+    average_grade: 5.4,
+    city: 'Dorking',
+    state: 'Surrey',
+    country: 'United Kingdom',
+  })),
+  createCampaign: vi.fn(async (_input?: unknown) => ({ id: 1 })),
+  addDestination: vi.fn(async (_input?: unknown) => ({
     id: 1,
     cached_name: 'Segment 1',
     strava_segment_id: '1',
@@ -36,6 +52,13 @@ const trpcMocks = vi.hoisted(() => ({
 vi.mock('../../utils/trpc', () => ({
   trpc: {
     useUtils: () => ({
+      client: {
+        segment: {
+          validate: {
+            query: trpcMocks.validateSegment,
+          },
+        },
+      },
       explorerAdmin: {
         getCampaignForSeason: {
           invalidate: trpcMocks.invalidate,
@@ -168,12 +191,29 @@ async function submitForm(form: HTMLElement) {
   });
 }
 
+async function clickElement(element: HTMLElement) {
+  await act(async () => {
+    element.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await Promise.resolve();
+  });
+}
+
 describe('ExplorerAdminPanel', () => {
   beforeEach(() => {
     trpcMocks.campaignQuery.data = null;
     trpcMocks.campaignQuery.error = null;
     trpcMocks.campaignQuery.isLoading = false;
     trpcMocks.invalidate.mockClear();
+    trpcMocks.validateSegment.mockReset();
+    trpcMocks.validateSegment.mockResolvedValue({
+      strava_segment_id: '2234642',
+      name: 'Box Hill KOM',
+      distance: 2931,
+      average_grade: 5.4,
+      city: 'Dorking',
+      state: 'Surrey',
+      country: 'United Kingdom',
+    });
     trpcMocks.createCampaign.mockReset();
     trpcMocks.createCampaign.mockResolvedValue({ id: 1 });
     trpcMocks.addDestination.mockReset();
@@ -181,6 +221,7 @@ describe('ExplorerAdminPanel', () => {
       id: 1,
       cached_name: 'Segment 2234642',
       strava_segment_id: '2234642',
+      usedPlaceholderMetadata: false,
     });
     vi.useRealTimers();
   });
@@ -232,7 +273,7 @@ describe('ExplorerAdminPanel', () => {
     expect(queryByTestId(container, 'explorer-create-campaign-form')).toBeNull();
   });
 
-  it('adds destinations with trimmed values and preserves the latest flash message timer', async () => {
+  it('previews, accepts, and rejects destinations while preserving the latest flash message timer', async () => {
     vi.useFakeTimers();
     trpcMocks.campaignQuery.data = {
       id: 41,
@@ -260,7 +301,16 @@ describe('ExplorerAdminPanel', () => {
       getByTestId(container, 'explorer-source-url-input') as HTMLInputElement,
       '  https://www.strava.com/segments/2234642  '
     );
-    await submitForm(getByTestId(container, 'explorer-add-destination-form'));
+    await clickElement(getByTestId(container, 'explorer-preview-destination-button'));
+
+    expect(getByTestId(container, 'explorer-destination-preview-card').textContent).toContain('Box Hill KOM');
+    expect(getByTestId(container, 'explorer-destination-preview-card').textContent).toContain('2.93 km');
+
+    await clickElement(getByTestId(container, 'explorer-reject-preview-button'));
+    expect(queryByTestId(container, 'explorer-destination-preview-card')).toBeNull();
+
+    await clickElement(getByTestId(container, 'explorer-preview-destination-button'));
+    await clickElement(getByTestId(container, 'explorer-accept-preview-button'));
 
     expect(getByTestId(container, 'explorer-admin-message').textContent).toContain('placeholder metadata');
     expect(trpcMocks.addDestination).toHaveBeenNthCalledWith(1, {
@@ -281,7 +331,12 @@ describe('ExplorerAdminPanel', () => {
       getByTestId(container, 'explorer-display-label-input') as HTMLInputElement,
       '  Box Hill opener  '
     );
-    await submitForm(getByTestId(container, 'explorer-add-destination-form'));
+    await clickElement(getByTestId(container, 'explorer-preview-destination-button'));
+
+    expect(getByTestId(container, 'explorer-preview-name').textContent).toContain('Box Hill opener');
+    expect(getByTestId(container, 'explorer-preview-segment-name').textContent).toContain('Box Hill KOM');
+
+    await clickElement(getByTestId(container, 'explorer-accept-preview-button'));
 
     expect(getByTestId(container, 'explorer-admin-message').textContent).toContain('Destination added to the Explorer campaign.');
     expect(trpcMocks.addDestination).toHaveBeenNthCalledWith(2, {
@@ -301,5 +356,38 @@ describe('ExplorerAdminPanel', () => {
     });
 
     expect(queryByTestId(container, 'explorer-admin-message')).toBeNull();
+  });
+
+  it('renders richer destination cards when a campaign already has destinations', async () => {
+    trpcMocks.campaignQuery.data = {
+      id: 41,
+      name: 'Spring 2026 Explorer',
+      rulesBlurb: 'Ride every destination once.',
+      destinations: [
+        {
+          id: 99,
+          displayLabel: 'Box Hill opener',
+          customLabel: 'Box Hill opener',
+          segmentName: 'Box Hill KOM',
+          displayOrder: 0,
+          sourceUrl: 'https://www.strava.com/segments/2234642',
+          stravaSegmentId: '2234642',
+          distance: 2931,
+          averageGrade: 5.4,
+          city: 'Dorking',
+          state: 'Surrey',
+          country: 'United Kingdom',
+        },
+      ],
+    };
+
+    const { container } = await renderPanel();
+
+    expect(getByTestId(container, 'explorer-destination-row-99').textContent).toContain('Box Hill opener');
+    expect(getByTestId(container, 'explorer-destination-row-99').textContent).toContain('Segment name: Box Hill KOM');
+    expect(getByTestId(container, 'explorer-destination-row-99').textContent).toContain('2.93 km');
+    expect(getByTestId(container, 'explorer-destination-row-99').textContent).toContain('5.4% avg grade');
+    expect(getByTestId(container, 'explorer-destination-row-99').textContent).toContain('Dorking, Surrey, United Kingdom');
+    expect(getByTestId(container, 'explorer-destination-row-99').textContent).toContain('Open original Strava segment');
   });
 });


### PR DESCRIPTION
## Summary
This PR closes out the current Explorer admin UX refinement phase and adds a durable leaderboard design-system reference so future Explorer UI work starts from the correct end-user patterns.

## What changed
- refines the Explorer Admin destination preview and accepted-destination cards
- aligns Explorer destination rendering with the Schedule page segment-card style
- removes destination numbering noise and reduces nested card boxing in the Explorer destination list
- documents the canonical Weekly, Season, Schedule, Segment, and segment-profile UI patterns in a new leaderboard design-system guide
- adds repo-local guidance so future agents and implementation work use the documented design system instead of older admin CSS by default

## Notable implementation details
- Explorer destination cards now use the larger Schedule-style linked title treatment with the inline external-link affordance
- the design-system documentation now explicitly distinguishes between leaderboard row cards, hero header cards, compact segment-object cards, and schedule-style segment entries
- repo instruction surfaces and a local audit skill now point back to the canonical design doc

## Validation
- focused Vitest coverage for Explorer admin passed
- targeted Playwright Explorer admin flow passed
- `npm run typecheck`
- `npm run lint`
- `npm run build`

## Follow-up
A separate planning pass is still needed for the newly noticed season/campaign model issue before the next Explorer phase is scoped.