### PR TITLE
Decouple Explorer campaigns from competition seasons

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -191,22 +191,25 @@ The `webhookAdminRouter` provides procedures for monitoring and managing Strava 
 
 ## Explorer (tRPC)
 
-The `explorerRouter` provides the read paths for the season-attached Explorer campaign MVP.
+The `explorerRouter` provides the read paths for the campaign-first Explorer MVP.
 
-- `trpc.explorer.getActiveCampaign` — Returns the currently active Explorer campaign for the open season, including ordered destinations. Campaigns without destinations are hidden from the athlete-facing surface.
+- `trpc.explorer.getActiveCampaign` — Returns the currently active Explorer campaign by campaign-owned date window, including ordered destinations. Campaigns without destinations are hidden from the athlete-facing surface.
 - `trpc.explorer.getCampaignProgress` — Returns the authenticated athlete's completion state for a campaign, including completed destinations and the source Strava activity IDs for recorded matches.
 
 ## Explorer Admin (tRPC)
 
-The `explorerAdminRouter` provides the Phase 4A admin-only write paths for Explorer campaign setup.
+The `explorerAdminRouter` provides the admin-only campaign management paths for Explorer setup.
 
 Relationship model:
 
-- One season can have one Explorer campaign in v1.
+- Explorer campaigns own their own `startAt` and `endAt` window in v1.
+- Explorer campaigns must not overlap in v1.
 - One Explorer campaign can contain many destinations.
 - A given Strava segment can appear only once within the same campaign.
 
-- `trpc.explorerAdmin.createCampaign` — Creates the single Explorer campaign allowed for a season in v1. Rejects duplicate campaigns for the same season.
+- `trpc.explorerAdmin.getCampaigns` — Returns all Explorer campaigns for admin editing, ordered by campaign start date with nested destinations.
+- `trpc.explorerAdmin.createCampaign` — Creates a new Explorer campaign from a date window plus optional display copy. Rejects overlapping campaign windows.
+- `trpc.explorerAdmin.updateCampaign` — Updates an Explorer campaign's date window and display copy while enforcing the no-overlap rule.
 - `trpc.explorerAdmin.addDestination` — Adds a destination to an Explorer campaign from a validated Strava segment URL, persists the source URL plus Explorer-local cached display metadata, and appends the destination at the next display order.
 
 Current 4A contract notes:

--- a/docs/DATABASE_DESIGN.md
+++ b/docs/DATABASE_DESIGN.md
@@ -1,7 +1,7 @@
 # Database Design
 
 ## Overview
-This document describes the SQLite database schema for tracking weekly cycling competition results and the season-attached Explorer campaign feature based on Strava activities.
+This document describes the SQLite database schema for tracking weekly cycling competition results and the campaign-first Explorer feature based on Strava activities.
 
 **Scale:** Designed for <100 participants. SQLite is perfect for this - simple, fast, no separate database server needed.
 
@@ -18,7 +18,7 @@ The database is managed using **Drizzle ORM**. The source of truth for the schem
 - **`activity`**: The best qualifying Strava activity for a participant in a given week.
 - **`segment_effort`**: Individual laps/efforts extracted from a qualifying activity.
 - **`result`**: Calculated rankings and times (points are computed on-read).
-- **`explorer_campaign`**: A season-attached Explorer campaign that becomes athlete-visible when its parent season is open and the campaign has at least one destination.
+- **`explorer_campaign`**: A date-bounded Explorer campaign with its own `start_at` and `end_at` window that becomes athlete-visible when the campaign is currently active and has at least one destination.
 - **`explorer_destination`**: Ordered campaign destinations keyed to Strava segment IDs, with Explorer-local cached display metadata.
 - **`explorer_destination_match`**: Durable per-athlete destination completions within a campaign.
 - **`participant_token`**: Encrypted OAuth tokens for Strava API access.
@@ -131,17 +131,18 @@ ORDER BY total_points DESC;
 
 ### Explorer Campaign Matching
 1. A webhook or refresh path hydrates activity segment efforts.
-2. The system finds Explorer campaigns whose parent season contains the activity timestamp.
+2. The system finds Explorer campaigns whose own `start_at` and `end_at` window contains the activity timestamp.
 3. Activity segment IDs are compared against configured `explorer_destination.strava_segment_id` values.
 4. Each matching destination inserts at most one `explorer_destination_match` row per athlete per campaign.
 5. Explorer progress is computed on read from `explorer_destination_match` rather than a cached summary table in v1.
 
 ### Explorer Admin Authoring
-1. Admin setup creates at most one `explorer_campaign` row per season in v1.
-2. Destination authoring accepts validated Strava segment URLs and extracts the canonical segment ID from the URL path.
-3. `explorer_destination` stores both the source URL and Explorer-local cached display metadata so authoring and display stay stable even if shared segment metadata changes later.
-4. Destination creation can proceed with the parsed segment ID and source URL even if live metadata enrichment is temporarily unavailable.
-5. Each campaign can contain a given Strava segment only once, enforced by both service validation and a unique database index.
+1. Admin setup creates Explorer campaigns with their own `start_at` and `end_at` window in v1.
+2. Campaign windows must not overlap in v1.
+3. Destination authoring accepts validated Strava segment URLs and extracts the canonical segment ID from the URL path.
+4. `explorer_destination` stores both the source URL and Explorer-local cached display metadata so authoring and display stay stable even if shared segment metadata changes later.
+5. Destination creation can proceed with the parsed segment ID and source URL even if live metadata enrichment is temporarily unavailable.
+6. Each campaign can contain a given Strava segment only once, enforced by both service validation and a unique database index.
 
 ## Migration from Current Schema
 
@@ -169,7 +170,7 @@ CREATE INDEX idx_activity_week_participant ON activities(week_id, strava_athlete
 CREATE INDEX idx_segment_effort_activity ON segment_efforts(activity_id);
 CREATE INDEX idx_result_week ON results(week_id);
 CREATE INDEX idx_result_participant ON results(strava_athlete_id);
-CREATE UNIQUE INDEX idx_explorer_campaign_season ON explorer_campaign(season_id);
+CREATE INDEX idx_explorer_campaign_window ON explorer_campaign(start_at, end_at);
 CREATE INDEX idx_explorer_destination_campaign ON explorer_destination(explorer_campaign_id);
 CREATE UNIQUE INDEX idx_explorer_destination_campaign_segment ON explorer_destination(explorer_campaign_id, strava_segment_id);
 CREATE INDEX idx_explorer_match_campaign_athlete ON explorer_destination_match(explorer_campaign_id, strava_athlete_id);

--- a/docs/prds/wmv-explorer-destinations-phases.md
+++ b/docs/prds/wmv-explorer-destinations-phases.md
@@ -36,9 +36,9 @@ Out of scope:
 - Explorer admin setup
 - Forcing activity delete or athlete deauthorization into the same handler abstraction before the activity path is stable
 
-## Phase 2: Season Campaign Model Correction
+## Phase 2: Campaign-First Model Correction
 
-Goal: correct Explorer from a weekly-first design to a season-attached campaign model, and remove optional mini-campaign complexity from MVP planning.
+Goal: correct Explorer from a weekly-first design to a campaign-first model with campaign-owned date boundaries, and remove optional overlapping or nested campaign complexity from MVP planning.
 
 Status: complete in the current planning set. Future work should build on the corrected model rather than reopen the weekly-first design unless product intent changes again.
 
@@ -46,8 +46,10 @@ Historical note: this planning correction was necessary because an earlier plann
 
 Scope:
 
-- Rewrite PRD, tech spec, worklog, and readiness checklist around a season-attached Explorer campaign
-- Remove mini-campaigns from MVP scope and record them as future optional work
+- Rewrite PRD, tech spec, worklog, and readiness checklist around a campaign-first Explorer model
+- Return `Season` to competition-only semantics in Explorer planning
+- Remove overlapping or nested campaign structures from MVP scope and record them as future optional work
+- Lock the v1 no-overlap rule for Explorer campaigns
 - Remove explicit `draft` / `active` / `archived` workflow from MVP unless later implementation proves it is necessary
 - Define the smallest safe follow-on implementation slice against the corrected model
 
@@ -55,33 +57,33 @@ Scope:
 
 Goal: add Explorer campaign, destination, and match storage plus the shared matching service used by both webhooks and refresh actions.
 
-Status: complete on the merged backend slice. Schema, matching, webhook integration, and the initial read routes now exist and should be treated as the base for later Explorer work.
+Status: implemented on the merged backend slice, but on a now-superseded season-attached model. Follow-on Explorer work should treat this as a structural correction surface rather than as a finished long-term base.
 
 Scope:
 
-- Schema additions for a season-attached campaign model
+- Schema additions for the initial Explorer campaign model
 - Explorer matching service
 - Admin or service-level refresh path
 - Idempotent storage rules
 
 ## Phase 4: Explorer Admin Setup
 
-Goal: let admins create or manage the season campaign without exposing Explorer to end users before release.
+Goal: let admins create or manage Explorer campaigns without exposing Explorer to end users before release.
 
 ### Slice 4A: Admin Backend
 
-Goal: add the minimal Explorer admin service and tRPC surface needed to create a campaign for a season and add destinations safely.
+Goal: add the minimal Explorer admin service and tRPC surface needed to create a campaign and add destinations safely.
 
-Status: complete on the admin-backend slice. The backend now supports admin-authenticated campaign creation, Strava segment URL validation, destination creation with metadata fallback, and the one-campaign-per-season plus no-duplicate-segment-within-a-campaign guards defined for 4A.
+Status: complete on the admin-backend slice, but implemented against the older season-attached campaign model. The next approved slice should correct that model before more Explorer UI expansion continues.
 
 Scope:
 
 - Explorer admin service and router surface for campaign creation and add-destination flow
-- Enforce one Explorer campaign per season without constraining future multi-season operation
+- Initial campaign creation and add-destination flow, subject to the later campaign-first correction
 - Strava segment URL parsing and validation for destination setup; do not expose raw segment-ID authoring in 4A
 - Explorer-local source URL and cached metadata persistence needed for stable authoring and display
 - Allow destination creation to proceed when URL parsing succeeds but live metadata enrichment is unavailable
-- Add-destination behavior that works before or during the season without resetting prior progress
+- Add-destination behavior that works before or during the campaign without resetting prior progress
 - Backend tests for auth, validation, campaign creation, destination creation, and in-season additions
 
 Out of scope:
@@ -131,55 +133,54 @@ Scope:
 - Create-campaign and add-destination flows using the approved 4A backend contract
 - Targeted browser coverage for admin setup flows on top of the hardened E2E harness
 - Keep all Explorer entry points hidden from non-admin users until there is an explicit release decision for the athlete-facing hub
-- Campaign setup attached to a season
-- Add-destination workflow that works before or during the season
+- Initial campaign setup using the then-current backend contract
+- Add-destination workflow that works before or during the campaign
 
 Follow-on planning note:
 
 - Treat richer admin guidance, stronger client-side segment validation, and broader card or component-system refinement as the next planning surface, not as open-ended scope creep inside 4B-2.
 
-### Slice 4B-3: Admin UX Refinement (Card-First Destination Authoring)
+### Slice 4B-3: Campaign Decoupling And Unified Admin Shell
 
-Goal: refine Explorer admin setup into a more interactive, card-first authoring experience that mirrors the existing WMV leaderboard surfaces and supports repeated paste-and-add destination setup without widening into the full later admin-management backlog.
+Goal: correct the shipped season-attached Explorer model by moving Explorer campaigns onto their own date boundaries, then reshape the admin surface into a more all-in-one leaderboard-style campaign editor before additional Explorer UI polish continues.
 
-Status: ready for implementation from updated `main` on a dedicated feature branch now that 4B-2 is merged.
+Status: ready for implementation from updated `main` on a dedicated feature branch now that the campaign-first correction is closed in planning.
 
 Scope:
 
-- Reuse existing WMV card patterns where practical for Explorer admin hierarchy instead of continuing with bespoke form-block presentation.
-- Keep the season and campaign framing at the top of the screen, but restyle it into the same card language used by the leaderboard, weekly, season, and schedule surfaces.
-- Replace the plain add-destination form with an interactive authoring card that supports repeated paste-and-add work:
-	- parse and validate a pasted Strava segment URL quickly using the existing validation seam
-	- show an immediate preview card with segment details before persistence
-	- provide icon-first accept and reject controls for the previewed destination, with accessible text or `aria-label` support
-	- defer optional Explorer display-label overrides until a later slice instead of reintroducing a heavier follow-up form into 4B-3
-- Render already-added campaign destinations as richer cards instead of a plain list so admins can see what is already in the campaign at a glance.
-- Extend Explorer admin read-side data only as needed to support richer accepted-destination cards, including the currently available distance, average grade, city, state, country, and source URL values.
-- Make the original Strava segment source clearly clickable from the accepted destination card without falling back to button-like link treatment.
+- Move Explorer campaign boundaries from competition `Season` to campaign-owned start and end dates.
+- Enforce the no-overlap Explorer campaign rule in v1 without adding a heavier publish-status model.
+- Update matching, query, and admin creation flows so they operate on campaign dates rather than season selection.
+- Rework the Explorer admin screen into a more all-in-one leaderboard-style campaign editor:
+	- one expandable campaign card for campaign metadata and date selection
+	- destination authoring inside the same Explorer admin surface rather than split competition-style admin links
+	- reuse the documented leaderboard design system for hierarchy, chips, cards, and linked destination treatment
+- Keep the existing preview-first paste-and-add destination flow, and continue deferring optional display-label overrides if they are not required for this correction slice.
 
 Out of scope:
 
 - Strava segment search or discovery workflows
-- Persisted edit, remove, or reorder flows for already-added destinations
-- Refresh or backfill mutations
+- Persisted edit, remove, or reorder flows for already-added destinations unless one is required to keep the campaign editor coherent
+- Refresh or backfill mutations unless one is required to keep the structural correction coherent
 - Athlete-facing Explorer hub work
 - Public Explorer navigation or release exposure
+- Reporting alignment between Explorer campaigns and competition seasons
 
 Validation:
 
-- Frontend unit tests for the authoring-card state flow, including paste, validation, preview, accept, reject, and repeated add behavior
-- Focused backend service or router tests only if the Explorer admin read shape is expanded for richer destination cards
-- Targeted Playwright coverage for the admin paste-validate-preview-add flow and the accepted-destination card rendering
+- Backend tests for campaign date-boundary matching, no-overlap enforcement, and corrected admin creation or query flows
+- Frontend unit tests for the unified Explorer admin campaign card, including date editing and preview-first destination authoring
+- Targeted Playwright coverage for creating or editing a campaign with dates plus the destination preview-add flow
 - Slice-normal `npm run lint`, `npm run typecheck`, and targeted build verification
 
 Implementation note:
 
-- If the slice later grows to include persisted inline editing for accepted destination cards, that should be called out explicitly as a scope change because it pulls in new admin mutations rather than remaining a UI refinement only.
+- Production Explorer data does not currently justify compatibility scaffolding. Migrations should prioritize boot safety and a clean model correction over preserving disposable Explorer campaign rows.
 - True map plotting is not part of 4B-3. The current shared segment model carries location text fields, but a future map slice may still require coordinate or geometry storage if the product needs real map pins rather than text-only place context.
 
 ## Phase 5: Explorer Hub MVP
 
-Goal: ship the athlete-facing season Explorer view only after the admin flow is stable and Explorer is approved for end-user release.
+Goal: ship the athlete-facing Explorer view only after the admin flow is stable and Explorer is approved for end-user release.
 
 Scope:
 
@@ -195,7 +196,7 @@ Goal: stabilize the Explorer feature and prepare later work.
 
 Candidate items:
 
-- Optional mini-campaigns attached to a season
+- Optional sub-campaigns or campaign templates
 - Better admin search and validation tooling
 - Explorer profile rollups
 - Badges and themed campaigns

--- a/docs/prds/wmv-explorer-destinations-prd.md
+++ b/docs/prds/wmv-explorer-destinations-prd.md
@@ -12,9 +12,9 @@
 
 ## 1. Executive Summary
 
-WMV Explorer Destinations is a new offseason participation feature for the WMV Cycling Series app. Instead of rewarding speed or rank, it gives athletes a season-long set of admin-curated Strava segment destinations to visit. Each matched destination counts once for the season campaign, and the primary experience is personal progress: how many destinations an athlete has completed, which ones remain, and whether they finished the full season set.
+WMV Explorer Destinations is a new offseason participation feature for the WMV Cycling Series app. Instead of rewarding speed or rank, it gives athletes a date-bounded set of admin-curated Strava segment destinations to visit. Each matched destination counts once for the active Explorer campaign, and the primary experience is personal progress: how many destinations an athlete has completed, which ones remain, and whether they finished the full set.
 
-The feature is designed to work for both outdoor and virtual riding, as long as the destination is represented by a Strava segment. This makes the experience more inclusive for riders doing real-world routes, Zwift routes, or a mix of both. The MVP should treat the season-long campaign as the primary unit. Smaller time-boxed mini-campaigns within a season are optional future work rather than required MVP structure.
+The feature is designed to work for both outdoor and virtual riding, as long as the destination is represented by a Strava segment. This makes the experience more inclusive for riders doing real-world routes, Zwift routes, or a mix of both. The MVP should treat the Explorer campaign as the primary unit, with campaign-owned start and end dates rather than inherited competition-season boundaries. Overlapping or nested Explorer campaign structures are optional future work rather than required MVP structure.
 
 ## 2. Problem Statement
 
@@ -24,21 +24,21 @@ Existing gaps include:
 
 - Participation is currently framed mainly as competition rather than exploration.
 - There is no product area for season-long destination-based riding goals.
-- There is no persistent record of exploration-style accomplishments across an entire season campaign.
+- There is no persistent record of exploration-style accomplishments across an entire Explorer campaign.
 - The current UI does not support a simple personal-progress model such as checklist completion or progress bars.
 - The current webhook processor is already serving multiple purposes and needs a cleaner extension path before adding Explorer matching.
 
-WMV Explorer Destinations addresses these problems by adding a progress-first season experience that reuses Strava activity data and admin curation without forcing riders into a race-style leaderboard.
+WMV Explorer Destinations addresses these problems by adding a progress-first campaign experience that reuses Strava activity data and admin curation without forcing riders into a race-style leaderboard.
 
 ## 3. Goals & Objectives
 
 | Goal | Description | Success Signal |
 | --- | --- | --- |
 | Inclusive offseason participation | Give riders a way to participate without needing to compete on speed | Riders can engage through weekly destination completion rather than race ranking |
-| Season-long motivation | Provide a clear set of season riding goals | Athletes can see season progress and a destination checklist across the active season |
-| Low admin friction | Let admins create a season Explorer campaign from Strava segments | Admin can attach an Explorer campaign to a season and configure destinations in one workflow |
+| Season-long motivation | Provide a clear set of riding goals across a bounded Explorer campaign | Athletes can see campaign progress and a destination checklist across the active campaign window |
+| Low admin friction | Let admins create an Explorer campaign from Strava segments | Admin can define campaign dates and configure destinations in one workflow |
 | Reuse current WMV systems | Build on existing Strava auth and ingestion patterns | No manual athlete submissions required for normal use |
-| Preserve future flexibility | Keep room for optional mini-campaigns later without complicating MVP | Future season-attached mini-campaigns can be added without rewriting core Explorer progress |
+| Preserve future flexibility | Keep room for optional sub-campaigns or campaign templates later without complicating MVP | Future campaign-first expansions can be added without rewriting core Explorer progress |
 | Avoid regression in competition features | Add Explorer without breaking current leaderboard and scoring behavior | Current competition routes and scoring remain unchanged |
 
 ## 4. Target Audience
@@ -56,32 +56,32 @@ WMV Explorer Destinations addresses these problems by adding a progress-first se
 
 | ID | User Story | Priority | Acceptance Criteria |
 | --- | --- | --- | --- |
-| US-01 | As an athlete, I want to see the active Explorer season campaign so I know what destinations are available now | Must | The current season Explorer campaign is clearly visible in the Challenges hub |
-| US-02 | As an athlete, I want to see the season destination list so I know what segments count | Must | Destination list shows all configured segments for the active season campaign |
-| US-03 | As an athlete, I want to see my Explorer progress as a progress bar so I can quickly tell how far along I am | Must | Progress bar shows completed destinations versus total destinations for the season campaign |
+| US-01 | As an athlete, I want to see the active Explorer campaign so I know what destinations are available now | Must | The current active Explorer campaign is clearly visible in the Challenges hub |
+| US-02 | As an athlete, I want to see the current campaign destination list so I know what segments count | Must | Destination list shows all configured segments for the active campaign |
+| US-03 | As an athlete, I want to see my Explorer progress as a progress bar so I can quickly tell how far along I am | Must | Progress bar shows completed destinations versus total destinations for the active campaign |
 | US-04 | As an athlete, I want a checklist of completed and remaining destinations so I can track what I still need | Must | Each destination shows complete or incomplete state for the logged-in athlete |
-| US-05 | As an athlete, I want each matched destination to count once for the season campaign so the rules are easy to understand | Must | Repeated visits to the same destination during the same season campaign do not increase progress |
+| US-05 | As an athlete, I want each matched destination to count once for the active campaign so the rules are easy to understand | Must | Repeated visits to the same destination during the same campaign do not increase progress |
 | US-06 | As an athlete, I want virtual and outdoor Strava segments to count equally as destinations so the feature feels inclusive | Must | Eligibility depends on matching configured Strava segments, not whether a ride is virtual or outdoor |
-| US-07 | As an athlete, I want to know if I completed all destinations for the season so I can celebrate finishing the set | Must | Full completion state is visible when all campaign destinations are matched |
+| US-07 | As an athlete, I want to know if I completed all destinations for the current campaign so I can celebrate finishing the set | Must | Full completion state is visible when all campaign destinations are matched |
 
 ### 5.2 Club Visibility
 
 | ID | User Story | Priority | Acceptance Criteria |
 | --- | --- | --- | --- |
-| US-08 | As a club member, I want to know whether anyone completed the full season destination set so the feature feels communal | Must | Explorer view includes a completers summary showing all athlete names who completed the full set |
+| US-08 | As a club member, I want to know whether anyone completed the full Explorer destination set so the feature feels communal | Must | Explorer view includes a completers summary showing all athlete names who completed the full set |
 | US-09 | As a club member, I do not want the Explorer hub to feel like another race leaderboard | Must | Weekly view emphasizes progress and completion, not rank ordering |
 
 ### 5.3 Admin Experience
 
 | ID | User Story | Priority | Acceptance Criteria |
 | --- | --- | --- | --- |
-| US-10 | As an admin, I want to create an Explorer campaign attached to a season so the feature can run for the entire season without depending on race weeks | Must | Admin can attach one Explorer campaign to a season and configure destinations for it |
+| US-10 | As an admin, I want to create an Explorer campaign with its own start and end dates so the feature can run independently from competition weeks and seasons | Must | Admin can create one date-bounded Explorer campaign, define its dates, and configure destinations for it |
 | US-11 | As an admin, I want to add destinations from Strava URLs so setup matches the regular admin panel workflow | Must | Admin can paste one Strava segment URL at a time and the system extracts the segment ID |
-| US-12 | As an admin, I want to add labels to destinations so the season campaign is presented clearly | Must | Destinations support optional labels in addition to the underlying segment metadata |
-| US-13 | As an admin, I want to reorder destinations so the season campaign is presented clearly | Should | Destinations support display order |
+| US-12 | As an admin, I want to add labels to destinations so the campaign is presented clearly | Must | Destinations support optional labels in addition to the underlying segment metadata |
+| US-13 | As an admin, I want to reorder destinations so the campaign is presented clearly | Should | Destinations support display order |
 | US-14 | As an admin, I want to refresh Explorer matching so I can recover missed or late-connected activities | Must | Admin can trigger a reprocess path for Explorer data |
 | US-15 | As an admin, I want Explorer setup to be separate from race week setup so the two products do not get mixed together | Must | Explorer management uses its own admin surface or clearly separated section |
-| US-16 | As an admin, I want to add new destinations during the season without resetting progress | Must | Newly added destinations become part of the current season campaign and existing completions remain intact |
+| US-16 | As an admin, I want to add new destinations during the campaign without resetting progress | Must | Newly added destinations become part of the current campaign and existing completions remain intact |
 
 ## 6. MoSCoW Prioritization
 
@@ -90,18 +90,18 @@ WMV Explorer Destinations addresses these problems by adding a progress-first se
 | Item | User Stories | Rationale |
 | --- | --- | --- |
 | Separate Challenges hub | US-01, US-10 | Explorer must feel distinct from race competition |
-| Active Explorer season campaign view | US-01, US-02 | Core season experience |
+| Active Explorer campaign view | US-01, US-02 | Core campaign experience |
 | Progress bar + checklist UX | US-03, US-04 | Primary interaction model |
 | One point per matched destination | US-05 | Simple, explainable rule set |
 | Virtual and outdoor segment support | US-06 | Inclusion requirement |
 | Season completion state | US-07 | Key motivator for the feature |
 | Completers summary with all athlete names | US-08 | Light communal visibility without ranking |
-| Separate Explorer season admin flow | US-10, US-15 | Keeps data model and UI boundaries clear |
+| Separate Explorer campaign admin flow | US-10, US-15 | Keeps data model and UI boundaries clear |
 | Strava URL-based destination setup | US-11 | Matches existing admin workflow |
 | Destination labels | US-12 | Needed for flexible curation and presentation |
-| Add destinations before or during the season | US-16 | Supports real admin workflows without extra status complexity |
+| Add destinations before or during the campaign | US-16 | Supports real admin workflows without extra status complexity |
 | Refresh or backfill action | US-14 | Operational recovery and late joins |
-| Persistent Explorer history across the season | — | Required for season progress and future optional sub-campaigns |
+| Persistent Explorer history across campaigns | — | Required for campaign progress and future optional sub-campaigns |
 | Delegated webhook ingestion path | — | Required to add Explorer without further overloading the webhook processor |
 
 ### Should Have (Enhanced Experience)
@@ -117,7 +117,7 @@ WMV Explorer Destinations addresses these problems by adding a progress-first se
 
 | Item | User Stories | Rationale |
 | --- | --- | --- |
-| Destination categories such as scenic, climb, or event | — | Adds editorial character to season Explorer campaigns |
+| Destination categories such as scenic, climb, or event | — | Adds editorial character to Explorer campaigns |
 | Celebration treatment on full completion | US-07 | Reinforces motivation without adding competition |
 | Destination category chips or themed labels | US-12 | Adds editorial polish without changing core rules |
 
@@ -127,7 +127,7 @@ WMV Explorer Destinations addresses these problems by adding a progress-first se
 | --- | --- |
 | Rank-ordered Explorer leaderboard | Explorer is progress-first in v1 |
 | Bonus scoring beyond one point per destination | Keep the rules simple first |
-| Weekly or mini-campaign Explorer UI | Deferred until the season campaign model is stable |
+| Overlapping or nested Explorer campaign structures | Deferred until the campaign-first model is stable |
 | Shared-segment mini-races | Separate future feature |
 | Badge system | Defer until core Explorer behavior is validated |
 | Out-of-process worker or CLI handoff for webhooks | In-process delegated handlers are sufficient for v1 |
@@ -136,9 +136,9 @@ WMV Explorer Destinations addresses these problems by adding a progress-first se
 
 ### 7.1 Layout
 
-The Explorer hub should present one season campaign at a time, with a progress-first layout:
+The Explorer hub should present one active campaign at a time, with a progress-first layout:
 
-- Header area with Explorer campaign title, season context, and short rules summary.
+- Header area with Explorer campaign title, date context, and short rules summary.
 - Progress section with a visible progress bar showing completed destinations versus total destinations.
 - Destination checklist showing all campaign destinations with completed or remaining state for the current athlete.
 - Completion summary showing all athletes who completed the full set.
@@ -149,7 +149,7 @@ The Explorer hub should present one season campaign at a time, with a progress-f
 | Principle | Description |
 | --- | --- |
 | Progress over ranking | The page should feel like a challenge checklist, not a leaderboard |
-| Clear season framing | Athletes should immediately understand what counts during the active season campaign |
+| Clear campaign framing | Athletes should immediately understand what counts during the active campaign window |
 | Inclusive destination model | Virtual and outdoor destinations should be presented as equally valid |
 | Low cognitive load | Rules should be understandable in seconds |
 | Additive navigation | Explorer should feel like a new section, not a replacement for competition views |
@@ -176,9 +176,9 @@ The Explorer hub should present one season campaign at a time, with a progress-f
 
 | Requirement | Target | Validation |
 | --- | --- | --- |
-| Durable season history | Explorer progress remains queryable after the season ends | Automated integration tests |
-| Correct season boundaries | Only activities inside the Explorer campaign's parent season count | Backend tests for start and end edge cases |
-| One completion per destination per athlete per season campaign | Multiple visits do not overcount | Backend tests |
+| Durable campaign history | Explorer progress remains queryable after a campaign ends | Automated integration tests |
+| Correct campaign boundaries | Only activities inside the Explorer campaign date window count | Backend tests for start and end edge cases |
+| One completion per destination per athlete per campaign | Multiple visits do not overcount | Backend tests |
 
 ### 8.3 Accessibility
 
@@ -209,23 +209,23 @@ The Explorer hub should present one season campaign at a time, with a progress-f
 
 The v1 release is successful if:
 
-1. Admins can create an Explorer campaign for a season and assign Strava segment destinations.
-2. Admins can add destinations before or during the season without resetting campaign progress.
-3. Athletes can see a season progress bar and destination checklist in the Challenges hub.
-4. Each matched destination counts once per athlete per season campaign.
+1. Admins can create an Explorer campaign with its own dates and assign Strava segment destinations.
+2. Admins can add destinations before or during the campaign without resetting campaign progress.
+3. Athletes can see a campaign progress bar and destination checklist in the Challenges hub.
+4. Each matched destination counts once per athlete per campaign.
 5. Virtual and outdoor segment destinations both work when configured.
 6. The hub includes a completers summary showing all completer names without presenting a rank-ordered leaderboard.
-7. Explorer history persists across the season and can support future optional mini-campaigns or later rollups.
+7. Explorer history persists across campaigns and can support future optional sub-campaigns or later rollups.
 8. Existing competition features continue to behave correctly.
 
 ## 11. Future Considerations (Post v1.0)
 
 | Future Item | Priority | Notes |
 | --- | --- | --- |
-| Optional mini-campaigns attached to a season | Medium | Deferred until the season campaign model is stable |
-| Season-wide Explorer rollups | Medium | Enabled by stored season campaign history |
+| Optional sub-campaigns or campaign templates | Medium | Deferred until the campaign-first model is stable |
+| Cross-campaign Explorer rollups | Medium | Enabled by stored campaign history |
 | Explorer badges and streaks | Medium | Depends on stable weekly participation data |
-| Themed destination campaigns | Medium | Adds editorial depth to season campaigns |
+| Themed destination campaigns | Medium | Adds editorial depth to Explorer campaigns |
 | Shared-segment mini-races | High | Requires broader segment aggregation strategy |
 | Destination search and richer admin tools | Medium | Improves authoring workflow after v1 |
 
@@ -247,9 +247,9 @@ The technical specification for Explorer Destinations is documented in [wmv-expl
 
 ### 13.2 Launch Checklist
 
-- Explorer campaign creation for a season works in admin UI.
+- Explorer campaign creation with start and end dates works in admin UI.
 - Destination setup accepts and validates Strava segment URLs.
-- Active Explorer season campaign renders in the Challenges hub.
+- Active Explorer campaign renders in the Challenges hub.
 - Athlete progress bar and checklist render correctly.
 - Completers summary is visible and shows names.
 - Manual refresh or backfill works.

--- a/docs/prds/wmv-explorer-destinations-tech-spec.md
+++ b/docs/prds/wmv-explorer-destinations-tech-spec.md
@@ -5,7 +5,7 @@
 This specification translates the Explorer Destinations PRD into an implementation-oriented design for the current WMV Cycling Series codebase. It preserves the key planning decisions:
 
 - Explorer is a separate product area from the current race leaderboard.
-- Explorer uses a separate season-attached campaign model rather than overloading the current competition week model.
+- Explorer uses a campaign-first model with campaign-owned date boundaries rather than overloading the current competition `Season` or week models.
 - Season UX is progress bar plus checklist plus completers summary.
 - Strava segments are the canonical destination type, regardless of whether they represent outdoor or virtual riding.
 - Webhook ingestion remains in-process but is refactored into delegated handlers so Explorer can be added without further overloading the current webhook processor.
@@ -14,15 +14,15 @@ This specification translates the Explorer Destinations PRD into an implementati
 
 ### In Scope
 
-- Separate Explorer campaign model attached to an existing WMV season
+- Separate Explorer campaign model with its own date boundaries
 - Admin-defined Explorer destinations from Strava segment URLs or IDs
 - Explorer matching from ingested Strava activities
 - One completion per destination per athlete per Explorer campaign
-- Season athlete progress queries
-- Season completers summary queries with all completer names
-- Stored Explorer history across the season
+- Campaign athlete progress queries
+- Campaign completers summary queries with all completer names
+- Stored Explorer history across campaigns
 - Reusable refresh or backfill path
-- Allowing admins to add destinations during the season without resetting progress
+- Allowing admins to add destinations during the campaign without resetting progress
 
 ### Out of Scope
 
@@ -50,7 +50,7 @@ This specification translates the Explorer Destinations PRD into an implementati
 - Do not modify the canonical race scoring model in [docs/SCORING.md](../SCORING.md).
 - Do not overload current competition week records with Explorer semantics.
 - Keep Explorer additive so existing leaderboard, season, and admin flows remain intact.
-- Prefer attaching Explorer to the existing `season` concept rather than inventing a second top-level season model for MVP.
+- Keep Explorer and competition `Season` separate at the product-model level; the MVP does not require a shared abstraction between them.
 
 ## 4. Recommended Architecture
 
@@ -100,7 +100,7 @@ The repository already has partially reusable building blocks for segment-based 
 - batch refresh handling in [server/src/services/BatchFetchService.ts](../../server/src/services/BatchFetchService.ts)
 - late metric hydration in [server/src/services/HydrationService.ts](../../server/src/services/HydrationService.ts)
 
-Explorer should not introduce a second copy of this segment-based matching flow. The first corrected implementation slice should extract only the shared seam needed for a season campaign model while preserving current Competition behavior.
+Explorer should not introduce a second copy of this segment-based matching flow. The corrected implementation slice should extract only the shared seam needed for a campaign-first model while preserving current Competition behavior.
 
 ### 4.3 MVP simplification
 
@@ -108,11 +108,12 @@ For MVP, do not introduce a separate Explorer week lifecycle or explicit `draft`
 
 Use these simpler rules instead:
 
-- the Explorer campaign attaches to an existing WMV season
-- the campaign is considered active when the parent season is open
+- the Explorer campaign owns its own start and end dates
+- the campaign is considered active when the current time falls inside its date window
 - the athlete-facing Explorer surface should only render when the campaign has at least one destination
-- admins may add destinations before or during the season
-- optional mini-campaigns within a season are deferred until after the season-first model is stable
+- admins may add destinations before or during the campaign
+- v1 disallows overlapping Explorer campaigns so active-campaign lookup stays unambiguous
+- optional sub-campaigns or templates are deferred until after the campaign-first model is stable
 
 ## 5. Proposed Data Model
 
@@ -122,14 +123,15 @@ Recommended Explorer tables or equivalent schema concepts:
 
 - ExplorerCampaign
   - id
-  - seasonId
+  - startAt
+  - endAt
   - optional displayName or rules blurb if needed later
   - createdAt
   - updatedAt
 
-MVP rule: an ExplorerCampaign is attached to one season. The campaign becomes athlete-visible only when its parent season is open and it has at least one ExplorerDestination.
+MVP rule: an ExplorerCampaign is its own top-level Explorer container. The campaign becomes athlete-visible only when its own date window is active and it has at least one ExplorerDestination.
 
-For v1 admin authoring, enforce one campaign per season. This should not block future support for multiple seasons each having their own campaign, but it should prevent multiple campaigns competing within the same season.
+For v1 admin authoring, disallow overlapping Explorer campaigns. This keeps active-campaign lookup deterministic without inventing a heavier publish-status or priority model.
 
 - ExplorerDestination
   - id
@@ -167,7 +169,7 @@ For v1, ExplorerAthleteCampaignSummary is computed on read. `ExplorerDestination
 
 - One athlete can match a given destination at most once per Explorer campaign.
 - Multiple rides over the same destination in the same campaign do not increase progress.
-- Matches are constrained to the parent season date range.
+- Matches are constrained to the campaign date range.
 - Explorer records must survive after the season ends so future rollups or optional mini-campaigns can aggregate them.
 
 ### 5.3 Segment source model
@@ -182,13 +184,13 @@ If URL parsing succeeds but live Strava metadata enrichment fails, 4A should sti
 
 ### 5.4 V1 decision lock
 
-- Primary product model: season-attached Explorer campaign
+- Primary product model: campaign-first Explorer model with campaign-owned dates
 - Summary model: computed on read
 - Destination metadata strategy: hybrid shared-segment reuse plus Explorer-local cached display metadata
-- Campaign cardinality per season: exactly one Explorer campaign per season in v1
+- Campaign overlap rule in v1: no overlapping Explorer campaigns
 - Admin destination authoring input for 4A: validated Strava segment URLs only
 - Metadata enrichment failure policy: allow creation when parsing succeeds and preserve segment ID plus source URL
-- Optional mini-campaigns within a season: deferred
+- Optional sub-campaigns or templates: deferred
 - Explicit Explorer publish-status workflow: deferred unless later implementation proves it is needed
 - Refresh or backfill admin mutations: deferred out of 4A
 
@@ -199,7 +201,7 @@ If URL parsing succeeds but live Strava metadata enrichment fails, 4A should sti
 Responsibilities:
 
 - Receive normalized activity data plus athlete context.
-- Determine which Explorer campaign is active for the activity timestamp by looking at the parent season.
+- Determine which Explorer campaign is active for the activity timestamp by looking at campaign-owned date boundaries.
 - Compare activity segment efforts to configured Explorer destination segment IDs for that campaign.
 - Create missing ExplorerDestinationMatch records idempotently.
 - Return summary information about newly matched destinations.
@@ -220,7 +222,7 @@ Responsibilities:
 
 Responsibilities:
 
-- Create and update Explorer campaigns for a season.
+- Create and update Explorer campaigns with their own dates.
 - Add, edit, remove, and reorder Explorer destinations.
 - Validate or enrich destination metadata from Strava where possible.
 - Trigger refresh or backfill actions.
@@ -266,7 +268,7 @@ This surface remains deferred until Explorer is approved for end-user release.
 Recommended user-facing sections:
 
 - Challenges hub route
-- Active Explorer season campaign header
+- Active Explorer campaign header
 - Progress bar
 - Destination checklist
 - Completers summary
@@ -277,20 +279,20 @@ During early admin slices, any Explorer UI should remain admin-gated and should 
 
 Recommended initial admin capabilities:
 
-- Attach Explorer campaign to a season
+- Create or edit one Explorer campaign with start and end dates
 - Add one destination at a time by pasting a Strava segment URL and parsing the segment ID
 - Edit destination display label and ordering
-- Allow adding destinations before or during the season
+- Allow adding destinations before or during the campaign
 - Run refresh for a campaign or athlete
 
-The first admin UI should optimize for repeated paste-and-add authoring sessions rather than heavy per-destination form filling, but that UX work belongs to 4B rather than 4A.
+The next admin UI should optimize for an all-in-one campaign editor with leaderboard-style card hierarchy, including an expandable campaign card for dates and campaign metadata plus repeated paste-and-add authoring beneath it.
 
 ## 9. Matching Rules
 
 ### V1 rules
 
-- A destination is a Strava segment configured on an Explorer campaign attached to a season.
-- A destination counts when the athlete has a qualifying activity containing that segment during the parent season window.
+- A destination is a Strava segment configured on an Explorer campaign.
+- A destination counts when the athlete has a qualifying activity containing that segment during the campaign date window.
 - Each destination is worth one point internally.
 - The athlete's visible progress is completed destinations divided by total destinations.
 - Repeated visits do not add progress beyond the first match.
@@ -301,7 +303,7 @@ The first admin UI should optimize for repeated paste-and-add authoring sessions
 - Whether to display segment source labels like virtual or outdoor in the checklist
 - Whether a deleted activity should remove an Explorer match if it was the only source of completion
 - Whether to compute historical rollups on read or cache them incrementally
-- Whether optional mini-campaigns should later exist as freestanding season-attached sub-campaigns
+- Whether optional sub-campaigns or campaign templates should later exist on top of the campaign-first model
 
 ## 10. Testing Strategy
 
@@ -309,9 +311,9 @@ The first admin UI should optimize for repeated paste-and-add authoring sessions
 
 Add tests for:
 
-- Explorer campaign boundary handling using the parent season dates
+- Explorer campaign boundary handling using campaign-owned dates
 - Destination match idempotency
-- Duplicate segment visits in one season campaign
+- Duplicate segment visits in one campaign
 - Multiple destinations in one activity
 - Virtual and outdoor segment parity
 - Strava URL parsing and validation
@@ -334,17 +336,17 @@ Add tests for:
 
 Recommended E2E journeys:
 
-- Admin creates Explorer campaign for a season and destinations
+- Admin creates an Explorer campaign with dates and destinations
 - Athlete views active Explorer campaign
 - Athlete completes one destination and sees progress update
-- Admin adds a new destination during the season and the checklist updates without resetting prior completions
-- Athlete completes full season set and sees completion state
+- Admin adds a new destination during the campaign and the checklist updates without resetting prior completions
+- Athlete completes the full campaign set and sees completion state
 - Completers summary reflects at least one full completer
 
 ## 11. Migration and Rollout Sequence
 
 1. Refactor webhook processor toward delegated handlers without changing current competition behavior.
-2. Correct the planning model to a season-attached Explorer campaign.
+2. Correct the planning model to a campaign-first Explorer model with campaign-owned dates.
 3. Add Explorer schema and backend services for the campaign model.
 4. Implement Explorer matching handler and shared refresh path.
 5. Add Explorer tRPC routes.
@@ -362,24 +364,24 @@ Recommended E2E journeys:
   Mitigation: mirror the existing admin-panel parsing approach and test it directly.
 
 - Risk: Explorer begins to inherit competition UX by accident.
-  Mitigation: avoid ranked lists in the primary season surface.
+  Mitigation: avoid ranked lists in the primary campaign surface.
 
-- Risk: the MVP is overcomplicated by adding mini-campaigns or explicit status workflows too early.
-  Mitigation: keep the first model season-first, attach it to the existing season, and defer mini-campaigns plus explicit publish states until they solve a real problem.
+- Risk: the MVP is overcomplicated by overlapping campaigns, sub-campaigns, or explicit status workflows too early.
+  Mitigation: keep the first model campaign-first, disallow overlap in v1, and defer sub-campaigns plus explicit publish states until they solve a real problem.
 
 - Risk: Webhook processor becomes more complex during transition.
   Mitigation: refactor to delegated handlers before layering in Explorer logic.
 
 ## 13. Suggested Handoff Notes
 
-If this moves to implementation after the planning correction, the first engineering slice should be the season-attached Explorer campaign schema plus matching and query corrections. That is the structural work that determines whether the rest of the feature can be added cleanly.
+If this moves to implementation after the planning correction, the first engineering slice should be Explorer campaign schema decoupling plus matching, query, and admin-flow corrections. That is the structural work that determines whether the rest of the feature can be added cleanly.
 
 The next slice should be the smallest end-to-end Explorer loop:
 
-- one Explorer campaign attached to a season
+- one Explorer campaign with its own dates
 - one or more destinations
 - one athlete progress query
 - one completers summary query
-- one admin refresh action
+- one campaign editor shell for dates and destination authoring
 
 That would validate the model before building more UI.

--- a/docs/prds/wmv-explorer-execution-briefing.md
+++ b/docs/prds/wmv-explorer-execution-briefing.md
@@ -180,7 +180,7 @@ Prompts should remain narrow and convenient.
 ### Slice-splitting note for 4B
 
 - The earlier 4B split is now complete: 4B-1 hardened the portable E2E harness and 4B-2 landed the minimal admin-only Explorer UI.
-- Follow-on work should now start from updated `main` on a fresh branch for the approved 4B-3 admin UX refinement slice rather than reopening the already-merged split work.
+- Follow-on work should now start from updated `main` on a fresh branch for the approved 4B-3 campaign decoupling and unified admin-shell slice rather than reopening the already-merged split work.
 
 ### Slice completion discipline
 

--- a/docs/prds/wmv-explorer-readiness-checklist.md
+++ b/docs/prds/wmv-explorer-readiness-checklist.md
@@ -17,23 +17,23 @@ The ideas backlog is intentionally excluded from v1 implementation scope. It exi
 
 ## Current Go Decision
 
-**Status:** Phase 1 Complete; Season-Campaign Correction Landed; Backend Campaign Slice Merged; Phase 4A Admin Backend Complete; Phase 4B-1 E2E Harness Hardening Merged; Phase 4B-2 Minimal Admin UI Merged; Ready For Phase 4B-3 Admin UX Refinement
+**Status:** Phase 1 Complete; Campaign-First Explorer Correction Landed; Explorer Structural Decoupling Required; Ready For Phase 4B-3 Campaign Decoupling And Unified Admin Shell
 
-Explorer has completed the narrow Phase 1 webhook-orchestration slice that preserves current competition behavior while introducing delegated in-process handlers. The planning set on this branch now corrects the MVP to a season-campaign-first model attached to an existing WMV season, with optional mini-campaigns and explicit publish-status workflows deferred. The backend campaign slice is merged, the 4A admin backend slice is landed, the 4B-1 portable harness work is merged, and the 4B-2 admin-gated UI is now merged as a minimal setup surface. The next recommended work is a bounded 4B-3 admin UX refinement slice that improves repeated paste-and-add authoring and card presentation without widening into the later admin-management backlog.
+Explorer has completed the narrow Phase 1 webhook-orchestration slice that preserves current competition behavior while introducing delegated in-process handlers. The planning set now corrects Explorer to a campaign-first model with campaign-owned date boundaries, returns `Season` to competition-only semantics, defers overlapping or nested campaign structures, and locks a no-overlap Explorer rule for v1. The previously merged backend and minimal admin UI slices were implemented on the older season-attached model, so the next recommended work is a bounded 4B-3 structural correction slice that decouples Explorer from competition seasons and reshapes the admin surface into a unified campaign editor before more Explorer UI expansion continues.
 
-The current 4B-3 boundary is now explicit: no persisted inline card editing in this slice, icon-first preview actions with accessible labels, accepted destination cards that surface the existing distance, average grade, location, and source-link metadata, and no attempt to solve true map plotting until a later slice defines any needed coordinate or geometry storage.
+The current 4B-3 boundary is now explicit: move campaign boundaries onto Explorer campaigns, enforce the no-overlap rule, keep the admin surface all-in-one and leaderboard-styled, preserve preview-first destination authoring, and avoid adding broader management, reporting, or map-geometry work in the same slice.
 
 ## Current Status Summary
 
 | Area | Status | Notes |
 | --- | --- | --- |
-| Product framing | Ready | The PRD is clear on goals, users, must-haves, non-goals, and success criteria. |
-| Execution phasing | Ready For Phase 4B-3 | The phases doc now treats 4B-2 as merged and names 4B-3 as the bounded admin UX refinement slice. |
-| Architecture closure | Ready For Phase 4B-3 | The technical spec and landed slices are sufficient for the next admin UX improvement slice without reopening the campaign model or harness work, though true map rendering remains a later non-blocking data-shape question. |
-| Open questions handling | Ready | The worklog now records the corrected model plus the remaining non-blocking questions. |
-| Blocking research closure | Ready For Phase 4B-3 | The product-intent correction is closed for this branch. |
-| Test planning | Ready For Phase 4B-3 | The next test-planning work is attached to the bounded admin UX refinement slice rather than to a broad continuation of 4B-2. |
-| Documentation impact plan | Ready For Phase 4B-3 | The next documentation impact is the 4B-3 planning handoff plus any Explorer admin read-contract notes needed for richer destination cards. |
+| Product framing | Ready | The PRD is now aligned to a campaign-first Explorer model with campaign-owned dates and competition-only `Season` semantics. |
+| Execution phasing | Ready For Phase 4B-3 | The phases doc now names 4B-3 as the campaign decoupling and unified admin-shell slice. |
+| Architecture closure | Needs 4B-3 Structural Correction | The current shipped Explorer backend and admin UI still reflect the older season-attached model and should be corrected before broader Explorer UI work resumes. |
+| Open questions handling | Ready | The worklog now records the superseded season-attached decision and the locked no-overlap rule. |
+| Blocking research closure | Ready For Phase 4B-3 | The product-model correction is closed for this branch. |
+| Test planning | Ready For Phase 4B-3 | The next test-planning work is attached to the bounded campaign-decoupling slice rather than to more season-based UI refinement. |
+| Documentation impact plan | Ready For Phase 4B-3 | The next documentation impact is the 4B-3 planning handoff plus any Explorer API or schema notes needed for campaign-owned date boundaries. |
 
 ## Must Resolve Before Broad Implementation
 
@@ -87,9 +87,9 @@ The current 4B-3 boundary is now explicit: no persisted inline card editing in t
 | --- | --- |
 | Status | Ready |
 | Gate | Must Resolve |
-| Why it matters | The team needs a shared rule for what can proceed now versus what must wait for the season-model correction. |
-| Evidence | The implemented webhook seam remains valid, the backend campaign slice is merged, the 4A admin backend contract is landed, the 4B-2 minimal admin UI is merged, and the next slice is now re-approved as Phase 4B-3 admin UX refinement against the corrected season campaign model. |
-| Acceptance criteria | The readiness artifacts clearly state that Explorer is ready for one bounded admin-UX slice next and identify what remains out of scope. |
+| Why it matters | The team needs a shared rule for what can proceed now versus what must wait for the campaign-first correction to land in code. |
+| Evidence | The implemented webhook seam remains valid, the older backend campaign slice is merged, the 4A admin backend contract and 4B-2 minimal admin UI are landed on the superseded season-attached model, and the next slice is now re-approved as Phase 4B-3 campaign decoupling plus unified admin shell. |
+| Acceptance criteria | The readiness artifacts clearly state that Explorer is ready for one bounded structural-correction slice next and identify what remains out of scope. |
 | Next action | Keep the current go decision updated as additional corrected Explorer slices are approved or deferred, and close slice-local planning state in the implementation PR when the slice changes readiness or phase status. |
 
 ## Should Resolve Before 4A And 4B Expand
@@ -114,7 +114,7 @@ The current 4B-3 boundary is now explicit: no persisted inline card editing in t
 | Why it matters | Explorer admin UI flows and the existing Playwright suite need repeatable end-to-end coverage, and the current code path reaches outbound Strava services from the backend during destination authoring and some read flows. |
 | Evidence | The backend now has an explicit E2E mode in [server/src/config.ts](../../server/src/config.ts), the E2E database resets from the committed sanitized fixture [server/data/wmv_e2e_fixture.db](../../server/data/wmv_e2e_fixture.db), and deterministic read-side Strava behavior now flows through explicit providers in [server/src/services/segmentMetadataProvider.ts](../../server/src/services/segmentMetadataProvider.ts) and [server/src/services/stravaReadProvider.ts](../../server/src/services/stravaReadProvider.ts) rather than through scattered service-level `isE2EMode()` branches. Full validation is green, including `npm test`, `npm run test:e2e`, `npm run typecheck`, `npm run lint`, and `npm run build`. |
 | Acceptance criteria | Explorer and existing E2E scenarios run against an explicit backend E2E mode, deterministic campaign and leaderboard data are provisioned without copying a contributor's local development database, and outbound Strava-dependent behavior is selected through explicit providers rather than scattered feature-level short-circuits. |
-| Next action | Preserve the centralized E2E-mode and explicit-provider discipline as 4B-3 refines the admin UX on top of the merged harness baseline. |
+| Next action | Preserve the centralized E2E-mode and explicit-provider discipline as 4B-3 corrects the campaign model and unified admin shell on top of the merged harness baseline. |
 
 ### 3. Documentation Impact Plan
 
@@ -123,9 +123,9 @@ The current 4B-3 boundary is now explicit: no persisted inline card editing in t
 | Status | Ready For Phase 4B-3 |
 | Gate | Should Resolve |
 | Why it matters | Explorer touches admin, athlete, API, database, and release-note surfaces. That work should be visible before coding. |
-| Evidence | The 4A slice updated `docs/API.md`, `docs/DATABASE_DESIGN.md`, and the slice-local planning docs while still deferring user-facing release-note files. The 4B-3 slice may also need `docs/API.md` updates if richer Explorer admin destination cards require extra read-side fields. |
+| Evidence | The 4A slice updated `docs/API.md`, `docs/DATABASE_DESIGN.md`, and the slice-local planning docs while still deferring user-facing release-note files. The 4B-3 slice may also need `docs/API.md` and schema notes if campaign-owned Explorer date fields or overlap constraints change the backend contract. |
 | Acceptance criteria | The worklog or implementation slice names the docs expected to change when the slice lands, including any slice-local planning docs needed to close the state transition. |
-| Next action | Keep the documentation-impact checklist current and treat 4B-3 planning-state maintenance plus any slice-local API notes as the next expected update set. |
+| Next action | Keep the documentation-impact checklist current and treat 4B-3 planning-state maintenance plus any slice-local API or schema notes as the next expected update set. |
 
 ### 4. Smallest End-To-End Slice
 
@@ -144,7 +144,7 @@ The current 4B-3 boundary is now explicit: no persisted inline card editing in t
 | --- | --- | --- | --- |
 | Virtual versus outdoor labels in the checklist | Deferred | Safe To Defer | Not required for v1 matching correctness. |
 | Match retraction when a source activity is deleted | Partial | Safe To Defer | Can remain an explicit unresolved rule if v1 behavior is documented. |
-| Season-wide rollup caching strategy | Deferred | Safe To Defer | Campaign history durability matters first. |
+| Cross-campaign rollup caching strategy | Deferred | Safe To Defer | Campaign history durability matters first. |
 | Post-MVP ideas from the ideas backlog | Deferred | Safe To Defer | Keep them isolated in the ideas file. |
 
 ## Execution Preconditions For The Next Slice
@@ -164,12 +164,12 @@ If a slice is expected to change the approved next step, readiness wording, or p
 | Decision | Current State |
 | --- | --- |
 | Phase 1 Complete | Yes |
-| Season-Campaign Correction Landed | Yes |
-| Backend Campaign Slice Merged | Yes |
+| Campaign-First Explorer Correction Landed | Yes |
+| Explorer Structural Decoupling Required | Yes |
 | Phase 4A Admin Backend Complete | Yes |
 | Phase 4B-1 E2E Harness Hardening Merged | Yes |
 | Phase 4B-2 Minimal Admin UI Merged | Yes |
-| Ready For Phase 4B-3 Admin UX Refinement | Yes |
+| Ready For Phase 4B-3 Campaign Decoupling And Unified Admin Shell | Yes |
 | Ready For Broad Feature Implementation | No |
 
-If this file says anything stronger than **Phase 1 Complete; Season-Campaign Correction Landed; Backend Campaign Slice Merged; Phase 4A Admin Backend Complete; Phase 4B-1 E2E Harness Hardening Merged; Phase 4B-2 Minimal Admin UI Merged; Ready For Phase 4B-3 Admin UX Refinement**, the linked worklog should show exactly what changed to justify that shift.
+If this file says anything stronger than **Phase 1 Complete; Campaign-First Explorer Correction Landed; Explorer Structural Decoupling Required; Phase 4A Admin Backend Complete; Phase 4B-1 E2E Harness Hardening Merged; Phase 4B-2 Minimal Admin UI Merged; Ready For Phase 4B-3 Campaign Decoupling And Unified Admin Shell**, the linked worklog should show exactly what changed to justify that shift.

--- a/docs/prds/wmv-explorer-worklog.md
+++ b/docs/prds/wmv-explorer-worklog.md
@@ -4,15 +4,15 @@ This worklog is the active operating log for Explorer. The readiness checklist i
 
 ## Current Focus
 
-- Preserve the checkpointed functional 4B-3 admin UX work while documenting the leaderboard design system before more Explorer UX polish continues.
-- Keep the next slice focused on Weekly, Season, and Schedule UI audit and documentation so future Explorer surfaces start from the right public-facing primitives.
+- Correct Explorer from the superseded season-attached model to a campaign-first model with campaign-owned date boundaries.
+- Define the next slice as structural decoupling plus a more all-in-one leaderboard-styled Explorer admin shell rather than as more season-based admin polish.
 - Keep any pre-release Explorer UI admin-gated until there is an explicit end-user release decision.
-- Keep the next handoff and implementation brief aligned with the landed backend authoring contract plus the existing `segment.validate` preview seam.
+- Keep the next handoff and implementation brief aligned with the existing `segment.validate` preview seam plus the campaign-first model correction.
 
 ## Current Go State
 
-- **Readiness:** Phase 1 Complete; Season-Campaign Correction Landed; Backend Campaign Slice Merged; Phase 4A Admin Backend Complete; Phase 4B-1 E2E Harness Hardening Merged; Phase 4B-2 Minimal Admin UI Merged; Ready For Phase 4B-3 Admin UX Refinement
-- **Immediate scope:** document the canonical leaderboard design system and wire that guidance into future Explorer implementation before resuming UX-polish work on top of the checkpointed 4B-3 branch state
+- **Readiness:** Phase 1 Complete; Campaign-First Explorer Correction Landed; Explorer Structural Decoupling Required; Phase 4A Admin Backend Complete; Phase 4B-1 E2E Harness Hardening Merged; Phase 4B-2 Minimal Admin UI Merged; Ready For Phase 4B-3 Campaign Decoupling And Unified Admin Shell
+- **Immediate scope:** land the campaign-first planning correction and hand off one bounded structural-correction slice before more Explorer UI expansion continues
 - **Not yet in scope:** public athlete-facing Explorer release, public navigation to Explorer, mini-campaigns, or explicit publish-status workflows
 
 ## Decisions Made
@@ -26,12 +26,13 @@ This worklog is the active operating log for Explorer. The readiness checklist i
 - Phase 1 is approved only as a structural webhook slice: preserve current behavior first, add Explorer matching later.
 - Phase 1 is complete on this branch: the shared activity-ingestion context, sequential delegated handlers, explicit handler order, and preservation tests are in place.
 - The previous Explorer planning set and PR #23 used the wrong primary model: weekly Explorer challenges first, with season-wide support deferred.
-- MVP should instead be season-campaign-first, attached to an existing WMV season, with optional mini-campaigns deferred.
-- MVP does not currently justify explicit Explorer `draft` / `active` / `archived` workflow complexity; season dates and destination presence should control visibility unless later implementation proves otherwise.
+- MVP should instead be campaign-first, with campaign-owned date boundaries and optional sub-campaigns deferred.
+- MVP does not currently justify explicit Explorer `draft` / `active` / `archived` workflow complexity; campaign dates and destination presence should control visibility unless later implementation proves otherwise.
 - V1 athlete campaign summary is computed on read, with `ExplorerDestinationMatch` as the durable source of truth.
 - V1 destination metadata uses a hybrid strategy: reuse shared segment data when present, while storing Explorer-local cached display metadata and source URL values for stable setup and rendering.
 - If Explorer UI is touched before public release, it stays admin-only and does not add public navigation.
-- V1 permits exactly one Explorer campaign per season; this should be enforced in the admin backend without blocking future multi-season support.
+- `Season` should remain competition-only for Explorer planning and implementation purposes.
+- V1 permits Explorer campaigns with their own date windows, but does not permit overlapping Explorer campaigns.
 - 4A destination authoring accepts validated Strava segment URLs, not raw segment IDs.
 - If URL parsing succeeds but live Strava metadata enrichment fails, destination creation still succeeds with stored segment ID and source URL.
 - Refresh and backfill admin mutations are deferred out of 4A.
@@ -43,8 +44,8 @@ This worklog is the active operating log for Explorer. The readiness checklist i
 
 | Question | Status | Blocks Implementation | Notes |
 | --- | --- | --- | --- |
-| Should Explorer be season-campaign-first or weekly-first in MVP? | Closed | Yes | Closed in favor of season-campaign-first attached to the existing season model. |
-| Should optional mini-campaigns within a season remain in MVP? | Closed | Yes | Closed in favor of removing them from MVP and deferring them to later planning. |
+| Should Explorer be campaign-first or weekly-first in MVP? | Closed | Yes | Closed in favor of a campaign-first Explorer model with campaign-owned date boundaries. |
+| Should optional nested campaign structures remain in MVP? | Closed | Yes | Closed in favor of removing them from MVP and deferring them to later planning. |
 | Does MVP need an explicit Explorer status workflow such as `draft` or `archived`? | Closed For MVP | Yes | Closed in favor of no explicit status field unless later implementation proves it is needed. |
 | Should athlete campaign summaries be computed on read or stored in a cached summary table for v1? | Closed For v1 | No | V1 uses computed-on-read summaries with `ExplorerDestinationMatch` as the durable source of truth. |
 | Should Explorer reuse the existing segment table, store Explorer-local cached metadata, or do both? | Closed For v1 | No | V1 uses a hybrid strategy: shared segment reuse when present plus Explorer-local cached display metadata. |
@@ -52,7 +53,8 @@ This worklog is the active operating log for Explorer. The readiness checklist i
 | What is the exact E2E data strategy for Explorer flows? | Closed For 4B-1 | No | The baseline data source is the committed sanitized fixture at `server/data/wmv_e2e_fixture.db`, with deterministic backend Strava reads selected through explicit providers. |
 | Should deleted source activities retract Explorer completions in v1? | Open | No | Safe to defer if behavior is documented. |
 | Should pre-release Explorer UI remain admin-gated until launch approval? | Closed | No | Yes. Do not expose Explorer UI to non-admin users before a viable release decision. |
-| Should there be more than one Explorer campaign per season in v1? | Closed | No | No. Enforce one campaign per season in 4A while leaving room for future multi-season support. |
+| Should Explorer depend on the competition `Season` model in v1? | Closed | Yes | No. `Season` returns to competition-only semantics and Explorer uses campaign-owned dates. |
+| Should overlapping Explorer campaigns be allowed in v1? | Closed | Yes | No. Disallow overlap so active-campaign lookup stays deterministic without adding a heavier publish-status model. |
 | Should 4A accept raw segment IDs as an admin authoring input? | Closed | No | No. Use validated Strava segment URLs only in the 4A backend contract. |
 | What happens if URL parsing succeeds but live metadata enrichment fails? | Closed | No | Allow creation and preserve segment ID plus source URL for later repair. |
 | Do refresh and backfill admin mutations belong in 4A? | Closed | No | No. Defer them to a later admin slice. |
@@ -63,8 +65,8 @@ This worklog is the active operating log for Explorer. The readiness checklist i
 
 ### Must Resolve Before Broad Implementation
 
-1. Correct the primary Explorer model to season-campaign-first across the planning set.
-2. Re-scope MVP so optional mini-campaigns are explicitly deferred.
+1. Correct the primary Explorer model to campaign-first across the planning set.
+2. Re-scope MVP so overlapping or nested campaign structures are explicitly deferred.
 3. Re-approve the next implementation slice against the corrected model before more Explorer coding continues.
 
 Resolution:
@@ -127,72 +129,77 @@ The current preservation target is backed by:
 ### Completed Backend Campaign Slice
 
 - Phase: Phase 3
-- Goal: establish the season-attached Explorer campaign backend model, matching flow, and initial read surface as the base for later admin and hub work
-- Why this matters: 4A should now build on the merged backend slice rather than reopening campaign-model work
+- Goal: establish the initial Explorer campaign backend model, matching flow, and read surface
+- Why this matters: this backend slice is merged, but it now sits on the superseded season-attached model and should be treated as the correction surface for the next slice rather than as a finished long-term base
 
 ### Completed Admin Backend Slice
 
 - Phase: Slice 4A
-- Goal: add the minimal Explorer admin service and tRPC surface needed to create a campaign for a season and add destinations safely
+- Goal: add the minimal Explorer admin service and tRPC surface needed to create a campaign and add destinations safely
 - Outcome:
-	- `explorerAdmin.createCampaign` now creates the single Explorer campaign allowed per season in v1.
+	- `explorerAdmin.createCampaign` currently creates Explorer campaigns against the superseded season-attached model and is part of the next correction surface.
 	- `explorerAdmin.addDestination` now accepts validated Strava segment URLs, persists source URL plus cached display metadata, and appends destinations in display order.
-	- One-campaign-per-season and no-duplicate-segment-within-a-campaign rules are enforced in both service logic and the database.
+	- No-duplicate-segment-within-a-campaign protection is enforced in both service logic and the database.
 	- Destination creation can proceed when URL parsing succeeds even if live metadata enrichment is temporarily unavailable.
-	- Backend coverage now includes focused admin service and router tests for auth, validation, duplicate protection, metadata fallback, and in-season additions.
+	- Backend coverage now includes focused admin service and router tests for auth, validation, duplicate protection, metadata fallback, and in-campaign additions.
 
 ### Recommended Next PR
 
-- Start from the checkpointed 4B-3 branch state on a dedicated documentation or design-system branch.
-- Keep the next implementation PR scoped to the leaderboard design-system audit and documentation slice:
-	- document the canonical Weekly, Season, and Schedule design language in one durable reference
-	- identify which shared primitives Explorer should reuse by default
-	- record gaps where the public leaderboard does not yet define a stable form or admin-control pattern
-	- wire the documented guidance into repo instructions or agent-facing surfaces so future Explorer work reads it first
-	- avoid further piecemeal Explorer restyling until that guide exists
+- Start from updated `main` on a dedicated implementation branch.
+- Keep the next implementation PR scoped to the campaign decoupling and unified admin-shell slice:
+	- move Explorer campaign boundaries onto campaign-owned start and end dates
+	- remove Explorer's dependency on the competition `Season` model
+	- enforce the v1 no-overlap campaign rule
+	- reshape the Explorer admin surface into a more all-in-one leaderboard-styled campaign editor with an expandable campaign card for dates and metadata
+	- preserve the existing preview-first destination authoring flow inside that unified shell
 - Validation path for the next PR:
-	- document review against the authoritative source files
-	- verify agent-facing references point to the new guide
-	- no product-code validation beyond any touched markdown or instruction surfaces unless the slice expands again
+	- focused backend tests for campaign boundaries and overlap enforcement
+	- frontend unit tests for the unified campaign card and preview-first destination authoring flow
+	- targeted Playwright for campaign date editing or creation plus destination preview-add behavior
+	- `npm run lint`, `npm run typecheck`, and targeted build verification
 - Planning and documentation surfaces likely to change when 4B-3 lands:
-	- `docs/LEADERBOARD_DESIGN_SYSTEM.md`
+	- `docs/API.md`
+	- `docs/DATABASE_DESIGN.md`
 	- `docs/prds/wmv-explorer-destinations-phases.md`
 	- `docs/prds/wmv-explorer-worklog.md`
 	- `docs/prds/wmv-explorer-readiness-checklist.md`
-	- repo instruction surfaces such as `AGENTS.md`, `AGENT_USAGE.md`, or `.github/copilot-instructions.md`
+	- `docs/prds/wmv-explorer-execution-briefing.md` if the slice changes the approved next step again
 
 ### 4B-3 Implementation Handoff
 
 - Slice: Phase 4B-3 only.
 - Branch start point: updated `main`, then a dedicated feature branch before coding.
-- Governing scope: card-first destination authoring and richer accepted-destination cards on top of the already-merged 4B-1 harness and 4B-2 minimal UI baseline.
+- Governing scope: campaign-first structural correction plus a more all-in-one leaderboard-styled Explorer admin shell on top of the already-merged 4B-1 harness and 4B-2 minimal UI baseline.
 - UI rule: prefer reuse of the existing WMV leaderboard card language and component patterns where that reuse clarifies hierarchy, rather than layering more bespoke Explorer-only form styling.
 - Authoring flow recommendation:
-	- admin pastes a Strava segment URL
+	- the admin manages campaign dates and campaign metadata in one expandable campaign card
+	- the admin pastes a Strava segment URL inside the same Explorer surface
 	- the UI parses and validates promptly through the existing `segment.validate` seam
 	- a preview card appears with segment metadata before persistence
 	- the admin explicitly accepts or rejects the preview
-	- optional Explorer display-label entry is deferred from the shipped 4B-3 preview-add flow
+	- optional Explorer display-label entry remains deferred unless this correction slice proves it is required
 - Backend expectation:
-	- keep the existing `explorerAdmin.addDestination` write contract
-	- expand Explorer admin read-side destination fields only if needed for richer accepted-card rendering
-	- do not add persisted edit, remove, reorder, refresh, or search mutations in this slice
+	- remove Explorer's dependency on competition `Season`
+	- give Explorer campaigns their own start and end dates
+	- enforce the no-overlap rule in v1
+	- keep the existing `explorerAdmin.addDestination` write contract unless the campaign correction forces a narrow contract update
+	- do not add persisted edit, remove, reorder, refresh, or search mutations in this slice unless one is required to keep the campaign editor coherent
 - Existing Playwright impact:
 	- preserve the admin-only route and navigation behavior
-	- add or adjust browser coverage only for the interactive preview-add flow and accepted-card presentation
+	- add or adjust browser coverage for campaign date editing or creation plus the interactive preview-add flow and accepted-card presentation
 	- continue using the hardened E2E harness rather than local-only assumptions
 
 ### 4B-3 Branch-Ready Task List
 
-1. Rework the Explorer admin screen so season summary, campaign summary, authoring, and accepted destinations follow a coherent card hierarchy aligned with the current WMV leaderboard surfaces.
-2. Replace the plain add-destination form with a fast paste-validate-preview-add interaction using the existing segment-validation seam.
-3. Extend accepted-destination cards to show richer segment details already known to the system, such as distance, grade, and location, plus Explorer-specific label context.
-4. Keep campaign creation visually consistent with the updated card hierarchy without widening into broader management workflows.
-5. Update slice-local tests and planning docs so the merged outcome clearly records 4B-3 completion and the next approved Explorer step.
+1. Move Explorer campaign boundaries from competition `Season` to campaign-owned start and end dates.
+2. Enforce the no-overlap Explorer campaign rule for v1 without introducing a heavier publish-status model.
+3. Rework the Explorer admin screen into an all-in-one campaign editor that follows the WMV leaderboard design language.
+4. Preserve and nest the preview-first paste-validate-preview-add destination flow inside that campaign editor.
+5. Update slice-local tests and planning docs so the merged outcome clearly records the model correction and the next approved Explorer step.
 
 ### 4B-3 Implementation Brief
 
-- Phase: 4B-3 Admin UX Refinement
+- Phase: 4B-3 Campaign Decoupling And Unified Admin Shell
 - Readiness state: approved to implement now; no blocking planning questions remain for this slice
 - Branch start point: commit the current planning-doc updates on `main`, then create a fresh feature branch from updated `main` before any product-code changes
 
@@ -204,11 +211,12 @@ Primary governing references:
 
 Goal:
 
-- Turn the minimal Explorer admin setup screen into a more interactive, modern, card-first authoring experience that matches the existing WMV card language and makes repeated paste-and-add destination setup feel fast and obvious.
+- Correct the shipped season-attached Explorer model by moving Explorer onto campaign-owned dates, then turn the minimal Explorer admin setup screen into a more unified, modern, card-first campaign editor that matches the existing WMV card language.
 
 Required outcome:
 
-- The Explorer admin screen keeps season and campaign framing at the top, but uses a clearer card hierarchy consistent with the leaderboard, weekly, season, and schedule surfaces.
+- The Explorer admin screen uses Explorer campaign framing at the top, not competition season framing, and follows a clearer card hierarchy consistent with the leaderboard, weekly, season, and schedule surfaces.
+- The campaign card includes editable start and end dates in an expandable shell.
 - Destination authoring becomes a preview-first flow:
 	- the admin pastes a Strava segment URL
 	- the UI validates through the existing `segment.validate` seam
@@ -239,17 +247,18 @@ Expected code surfaces:
 
 Implementation constraints:
 
-- Do not add persisted edit, remove, reorder, refresh, or search flows in this slice.
+- Do not add persisted edit, remove, reorder, refresh, or search flows in this slice unless one is required to keep the corrected campaign editor coherent.
 - Do not add public Explorer exposure.
 - Do not convert links into generic button-styled actions when a normal link is clearer.
 - Keep icon-first actions accessible with visible context and `aria-label` support where needed.
+- Keep production migration simple and boot-safe; Explorer campaign rows do not currently require data-preservation work.
 - Treat map plotting as deferred. Location text should be surfaced now, but real coordinate or geometry storage is not part of 4B-3.
 
 Validation path:
 
-- Frontend unit tests covering preview state, validation success and failure, accept, reject, and repeated add behavior
-- Focused backend tests only if the Explorer admin read shape changes
-- Targeted Playwright coverage for the admin paste-validate-preview-add flow and richer accepted-card rendering
+- Frontend unit tests covering campaign date editing plus preview state, validation success and failure, accept, reject, and repeated add behavior
+- Focused backend tests for campaign boundary matching, overlap enforcement, and any Explorer admin contract changes
+- Targeted Playwright coverage for campaign date editing or creation plus the admin paste-validate-preview-add flow and accepted-card rendering
 - `npm run lint`
 - `npm run typecheck`
 - targeted build verification for the touched UI
@@ -258,7 +267,7 @@ Documentation expectations when 4B-3 lands:
 
 - update `docs/prds/wmv-explorer-destinations-phases.md` to mark 4B-3 complete if the slice lands as approved
 - update `docs/prds/wmv-explorer-worklog.md` and `docs/prds/wmv-explorer-readiness-checklist.md` to record the new next step
-- update `docs/API.md` only if the Explorer admin read contract expands
+- update `docs/API.md` and `docs/DATABASE_DESIGN.md` if campaign-owned dates or overlap constraints change the backend contract or schema
 
 Non-blockers to leave alone:
 
@@ -272,7 +281,7 @@ Non-blockers to leave alone:
 
 These decisions are now closed for the 4A implementation handoff.
 
-1. Enforce one campaign per season in 4A. Prefer database protection plus service-layer validation.
+1. The earlier one-campaign-per-season rule is superseded by campaign-owned dates plus a no-overlap rule in v1.
 2. Accept validated Strava segment URLs only in 4A.
 3. Allow creation when URL parsing succeeds even if live metadata enrichment fails.
 4. Defer refresh and backfill mutations to a later admin slice.

--- a/e2e/tests/explorer-admin.authenticated.spec.ts
+++ b/e2e/tests/explorer-admin.authenticated.spec.ts
@@ -1,22 +1,15 @@
 import { test, expect, type Page } from '@playwright/test';
 import { loginAsE2EUser } from '../fixtures/test-helpers';
 
-async function selectFirstSeason(page: Page) {
-  const seasonSelect = page.getByTestId('season-select');
-  await expect(seasonSelect).toBeVisible();
-
-  const firstSeasonValue = await seasonSelect.locator('option').first().getAttribute('value');
-  expect(firstSeasonValue).not.toBeNull();
-
-  await seasonSelect.selectOption(firstSeasonValue!);
-}
-
 async function ensureCampaignExists(page: Page) {
-  if (await page.getByTestId('explorer-create-campaign-form').isVisible()) {
+  if (await page.getByTestId('explorer-campaign-stack').count() === 0) {
+    await page.getByTestId('explorer-display-name-input').fill('Fall 2025 Explorer');
+    await page.getByTestId('explorer-start-date-input').fill('2025-10-01');
+    await page.getByTestId('explorer-end-date-input').fill('2025-10-31');
     await page.getByTestId('explorer-create-campaign-button').click();
   }
 
-  await expect(page.getByTestId('explorer-campaign-summary-card')).toBeVisible();
+  await expect(page.getByTestId('explorer-campaign-stack')).toBeVisible();
 }
 
 test.describe('Explorer Admin Setup', () => {
@@ -36,11 +29,11 @@ test.describe('Explorer Admin Setup', () => {
   test('admin can create a campaign and add a destination', async ({ page }) => {
     await page.goto('/explorer-admin');
 
-    await selectFirstSeason(page);
-
     await expect(page.getByTestId('explorer-create-campaign-form')).toBeVisible();
 
     await page.getByTestId('explorer-display-name-input').fill('Fall 2025 Explorer');
+    await page.getByTestId('explorer-start-date-input').fill('2025-10-01');
+    await page.getByTestId('explorer-end-date-input').fill('2025-10-31');
     await page.getByTestId('explorer-rules-blurb-input').fill('Ride each featured segment once.');
     await page.getByTestId('explorer-create-campaign-button').click();
 
@@ -61,8 +54,6 @@ test.describe('Explorer Admin Setup', () => {
 
   test('admin sees invalid URL and duplicate destination states', async ({ page }) => {
     await page.goto('/explorer-admin');
-
-    await selectFirstSeason(page);
 
     await ensureCampaignExists(page);
 

--- a/server/drizzle/0011_explorer_campaign_dates.sql
+++ b/server/drizzle/0011_explorer_campaign_dates.sql
@@ -1,0 +1,41 @@
+PRAGMA foreign_keys=OFF;
+--> statement-breakpoint
+CREATE TABLE `__new_explorer_campaign` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`start_at` integer NOT NULL,
+	`end_at` integer NOT NULL,
+	`display_name` text,
+	`rules_blurb` text,
+	`created_at` text DEFAULT (CURRENT_TIMESTAMP),
+	`updated_at` text DEFAULT (CURRENT_TIMESTAMP)
+);
+--> statement-breakpoint
+INSERT INTO `__new_explorer_campaign` (
+	`id`,
+	`start_at`,
+	`end_at`,
+	`display_name`,
+	`rules_blurb`,
+	`created_at`,
+	`updated_at`
+)
+SELECT
+	`explorer_campaign`.`id`,
+	COALESCE(`season`.`start_at`, 0),
+	COALESCE(`season`.`end_at`, 0),
+	`explorer_campaign`.`display_name`,
+	`explorer_campaign`.`rules_blurb`,
+	`explorer_campaign`.`created_at`,
+	`explorer_campaign`.`updated_at`
+FROM `explorer_campaign`
+LEFT JOIN `season` ON `season`.`id` = `explorer_campaign`.`season_id`;
+--> statement-breakpoint
+DROP TABLE `explorer_campaign`;
+--> statement-breakpoint
+ALTER TABLE `__new_explorer_campaign` RENAME TO `explorer_campaign`;
+--> statement-breakpoint
+DROP INDEX IF EXISTS `idx_explorer_campaign_season`;
+--> statement-breakpoint
+CREATE INDEX `idx_explorer_campaign_window` ON `explorer_campaign` (`start_at`, `end_at`);
+--> statement-breakpoint
+PRAGMA foreign_keys=ON;

--- a/server/drizzle/meta/_journal.json
+++ b/server/drizzle/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1776174000000,
       "tag": "0010_explorer_admin_backend",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "6",
+      "when": 1776600000000,
+      "tag": "0011_explorer_campaign_dates",
+      "breakpoints": true
     }
   ]
 }

--- a/server/src/__tests__/ExplorerAdminService.test.ts
+++ b/server/src/__tests__/ExplorerAdminService.test.ts
@@ -3,7 +3,7 @@ import { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
 import { eq } from 'drizzle-orm';
 import { explorerCampaign, explorerDestination } from '../db/schema';
 import { ExplorerAdminService, type ExplorerSegmentMetadataService } from '../services/ExplorerAdminService';
-import { clearAllData, createSeason, setupTestDb, teardownTestDb } from './testDataHelpers';
+import { clearAllData, setupTestDb, teardownTestDb } from './testDataHelpers';
 
 describe('ExplorerAdminService', () => {
   let db: Database;
@@ -29,46 +29,85 @@ describe('ExplorerAdminService', () => {
     service = new ExplorerAdminService(drizzleDb, segmentMetadataService);
   });
 
-  it('creates one campaign for a season', () => {
-    const seasonRecord = createSeason(drizzleDb, 'Explorer Season');
-
+  it('creates one campaign with its own date window', () => {
     const campaign = service.createCampaign({
-      seasonId: seasonRecord.id,
+      startAt: 1748736000,
+      endAt: 1751327999,
       displayName: 'Explorer 2026',
       rulesBlurb: 'Ride the set.',
     });
 
-    expect(campaign.season_id).toBe(seasonRecord.id);
+    expect(campaign.start_at).toBe(1748736000);
+    expect(campaign.end_at).toBe(1751327999);
     expect(campaign.display_name).toBe('Explorer 2026');
     expect(campaign.rules_blurb).toBe('Ride the set.');
   });
 
-  it('rejects a second campaign for the same season', () => {
-    const seasonRecord = createSeason(drizzleDb, 'Explorer Season');
-    service.createCampaign({ seasonId: seasonRecord.id });
+  it('rejects overlapping campaign windows', () => {
+    service.createCampaign({ startAt: 1748736000, endAt: 1751327999 });
 
-    expect(() => service.createCampaign({ seasonId: seasonRecord.id })).toThrow(
-      'Explorer campaign already exists for this season'
-    );
+    expect(() => service.createCampaign({
+      startAt: 1750464000,
+      endAt: 1753055999,
+    })).toThrow('Explorer campaigns cannot overlap in v1');
   });
 
-  it('allows different seasons to have their own campaigns', () => {
-    const seasonOne = createSeason(drizzleDb, 'Season One');
-    const seasonTwo = createSeason(drizzleDb, 'Season Two', true, {
-      startAt: 1767225600,
-      endAt: 1798761599,
+  it('allows non-overlapping campaign windows', () => {
+    service.createCampaign({ startAt: 1748736000, endAt: 1751327999 });
+    const secondCampaign = service.createCampaign({
+      startAt: 1751414400,
+      endAt: 1754006399,
     });
 
-    service.createCampaign({ seasonId: seasonOne.id });
-    const secondCampaign = service.createCampaign({ seasonId: seasonTwo.id });
-
-    expect(secondCampaign.season_id).toBe(seasonTwo.id);
+    expect(secondCampaign.start_at).toBe(1751414400);
     expect(drizzleDb.select().from(explorerCampaign).all()).toHaveLength(2);
   });
 
+  it('rejects a campaign whose end is before its start', () => {
+    expect(() => service.createCampaign({
+      startAt: 1751327999,
+      endAt: 1748736000,
+    })).toThrow('Campaign end date must be on or after the start date');
+  });
+
+  it('updates an existing campaign and preserves non-overlap', () => {
+    const firstCampaign = service.createCampaign({
+      startAt: 1748736000,
+      endAt: 1751327999,
+      displayName: 'Spring Explorer',
+    });
+    service.createCampaign({
+      startAt: 1751414400,
+      endAt: 1754006399,
+      displayName: 'Summer Explorer',
+    });
+
+    const updatedCampaign = service.updateCampaign({
+      explorerCampaignId: firstCampaign.id,
+      startAt: 1748822400,
+      endAt: 1751241599,
+      displayName: 'Updated Spring Explorer',
+      rulesBlurb: 'Still no overlap.',
+    });
+
+    expect(updatedCampaign.display_name).toBe('Updated Spring Explorer');
+    expect(updatedCampaign.rules_blurb).toBe('Still no overlap.');
+    expect(updatedCampaign.start_at).toBe(1748822400);
+  });
+
+  it('rejects updates that would create overlap', () => {
+    const firstCampaign = service.createCampaign({ startAt: 1748736000, endAt: 1751327999 });
+    service.createCampaign({ startAt: 1751414400, endAt: 1754006399 });
+
+    expect(() => service.updateCampaign({
+      explorerCampaignId: firstCampaign.id,
+      startAt: 1750464000,
+      endAt: 1753055999,
+    })).toThrow('Explorer campaigns cannot overlap in v1');
+  });
+
   it('adds a destination from a valid Strava segment URL and assigns display order', async () => {
-    const seasonRecord = createSeason(drizzleDb, 'Explorer Season');
-    const campaign = service.createCampaign({ seasonId: seasonRecord.id });
+    const campaign = service.createCampaign({ startAt: 1748736000, endAt: 1751327999 });
     segmentMetadataService.fetchAndStoreSegmentMetadata.mockResolvedValue({
       strava_segment_id: '12744502',
       name: 'Mocked Segment',
@@ -93,8 +132,7 @@ describe('ExplorerAdminService', () => {
   });
 
   it('allows creation when metadata enrichment falls back to placeholder data', async () => {
-    const seasonRecord = createSeason(drizzleDb, 'Explorer Season');
-    const campaign = service.createCampaign({ seasonId: seasonRecord.id });
+    const campaign = service.createCampaign({ startAt: 1748736000, endAt: 1751327999 });
     segmentMetadataService.fetchAndStoreSegmentMetadata.mockResolvedValue({
       strava_segment_id: '12744502',
       name: 'Segment 12744502',
@@ -109,8 +147,7 @@ describe('ExplorerAdminService', () => {
   });
 
   it('rejects duplicate segment destinations in the same campaign', async () => {
-    const seasonRecord = createSeason(drizzleDb, 'Explorer Season');
-    const campaign = service.createCampaign({ seasonId: seasonRecord.id });
+    const campaign = service.createCampaign({ startAt: 1748736000, endAt: 1751327999 });
     segmentMetadataService.fetchAndStoreSegmentMetadata.mockResolvedValue({
       strava_segment_id: '12744502',
       name: 'Mocked Segment',
@@ -130,8 +167,7 @@ describe('ExplorerAdminService', () => {
   });
 
   it('rejects invalid non-segment URLs', async () => {
-    const seasonRecord = createSeason(drizzleDb, 'Explorer Season');
-    const campaign = service.createCampaign({ seasonId: seasonRecord.id });
+    const campaign = service.createCampaign({ startAt: 1748736000, endAt: 1751327999 });
 
     await expect(
       service.addDestination({
@@ -142,8 +178,7 @@ describe('ExplorerAdminService', () => {
   });
 
   it('accepts segment URLs with surrounding whitespace when called directly', async () => {
-    const seasonRecord = createSeason(drizzleDb, 'Explorer Season');
-    const campaign = service.createCampaign({ seasonId: seasonRecord.id });
+    const campaign = service.createCampaign({ startAt: 1748736000, endAt: 1751327999 });
     segmentMetadataService.fetchAndStoreSegmentMetadata.mockResolvedValue({
       strava_segment_id: '12744502',
       name: 'Mocked Segment',
@@ -159,8 +194,7 @@ describe('ExplorerAdminService', () => {
   });
 
   it('increments display order for later destinations', async () => {
-    const seasonRecord = createSeason(drizzleDb, 'Explorer Season');
-    const campaign = service.createCampaign({ seasonId: seasonRecord.id });
+    const campaign = service.createCampaign({ startAt: 1748736000, endAt: 1751327999 });
 
     segmentMetadataService.fetchAndStoreSegmentMetadata.mockResolvedValueOnce({
       strava_segment_id: '12744502',

--- a/server/src/__tests__/ExplorerMatchingService.test.ts
+++ b/server/src/__tests__/ExplorerMatchingService.test.ts
@@ -6,7 +6,6 @@ import {
   createExplorerCampaign,
   createExplorerDestination,
   createParticipant,
-  createSeason,
   setupTestDb,
   teardownTestDb,
 } from './testDataHelpers';
@@ -40,12 +39,9 @@ describe('ExplorerMatchingService', () => {
 
   it('records one match per destination even when a ride repeats the same segment', async () => {
     createParticipant(drizzleDb, '2001', 'Explorer Rider');
-    const seasonRecord = createSeason(drizzleDb, 'Explorer Season', true, {
+    const campaign = createExplorerCampaign(drizzleDb, {
       startAt: 1748736000,
       endAt: 1751327999,
-    });
-    const campaign = createExplorerCampaign(drizzleDb, {
-      seasonId: seasonRecord.id,
       displayName: 'Summer Explorer',
     });
 
@@ -95,12 +91,9 @@ describe('ExplorerMatchingService', () => {
 
   it('is idempotent when the same activity is processed more than once', async () => {
     createParticipant(drizzleDb, '2002', 'Repeat Rider');
-    const seasonRecord = createSeason(drizzleDb, 'Explorer Season', true, {
+    const campaign = createExplorerCampaign(drizzleDb, {
       startAt: 1748736000,
       endAt: 1751327999,
-    });
-    const campaign = createExplorerCampaign(drizzleDb, {
-      seasonId: seasonRecord.id,
     });
 
     createExplorerDestination(drizzleDb, {
@@ -135,12 +128,9 @@ describe('ExplorerMatchingService', () => {
 
   it('hydrates missing segment efforts during campaign refresh and matches newly added destinations', async () => {
     createParticipant(drizzleDb, '2003', 'Refresh Rider');
-    const seasonRecord = createSeason(drizzleDb, 'Explorer Season', true, {
+    const campaign = createExplorerCampaign(drizzleDb, {
       startAt: 1749513600,
       endAt: 1750118399,
-    });
-    const campaign = createExplorerCampaign(drizzleDb, {
-      seasonId: seasonRecord.id,
     });
 
     createExplorerDestination(drizzleDb, {

--- a/server/src/__tests__/explorerActivityHandler.test.ts
+++ b/server/src/__tests__/explorerActivityHandler.test.ts
@@ -5,7 +5,6 @@ import {
   createExplorerCampaign,
   createExplorerDestination,
   createParticipant,
-  createSeason,
   setupTestDb,
   teardownTestDb,
 } from './testDataHelpers';
@@ -38,12 +37,9 @@ describe('explorerActivityHandler', () => {
 
   it('records Explorer matches from webhook activity data', async () => {
     createParticipant(drizzleDb, '4001', 'Webhook Rider');
-    const seasonRecord = createSeason(drizzleDb, 'Explorer Season', true, {
+    const campaign = createExplorerCampaign(drizzleDb, {
       startAt: 1748736000,
       endAt: 1751327999,
-    });
-    const campaign = createExplorerCampaign(drizzleDb, {
-      seasonId: seasonRecord.id,
     });
 
     createExplorerDestination(drizzleDb, {

--- a/server/src/__tests__/repairLegacyExplorerSchema.test.ts
+++ b/server/src/__tests__/repairLegacyExplorerSchema.test.ts
@@ -60,6 +60,61 @@ function replaceExplorerTablesWithLegacySchema(db: Database) {
   `);
 }
 
+function replaceExplorerTablesWithCampaignSchema(db: Database) {
+  db.exec(`
+    DROP TABLE IF EXISTS explorer_destination_match;
+    DROP TABLE IF EXISTS explorer_destination;
+    DROP TABLE IF EXISTS explorer_campaign;
+
+    CREATE TABLE explorer_campaign (
+      id integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+      season_id integer NOT NULL,
+      display_name text,
+      rules_blurb text,
+      created_at text DEFAULT (CURRENT_TIMESTAMP),
+      updated_at text DEFAULT (CURRENT_TIMESTAMP),
+      FOREIGN KEY (season_id) REFERENCES season(id) ON UPDATE no action ON DELETE cascade
+    );
+    CREATE UNIQUE INDEX idx_explorer_campaign_season ON explorer_campaign(season_id);
+
+    CREATE TABLE explorer_destination (
+      id integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+      explorer_campaign_id integer NOT NULL,
+      strava_segment_id text NOT NULL,
+      source_url text,
+      cached_name text,
+      display_label text,
+      display_order integer DEFAULT 0 NOT NULL,
+      surface_type text,
+      category text,
+      created_at text DEFAULT (CURRENT_TIMESTAMP),
+      updated_at text DEFAULT (CURRENT_TIMESTAMP),
+      FOREIGN KEY (explorer_campaign_id) REFERENCES explorer_campaign(id) ON UPDATE no action ON DELETE cascade
+    );
+    CREATE INDEX idx_explorer_destination_campaign ON explorer_destination(explorer_campaign_id);
+    CREATE INDEX idx_explorer_destination_segment ON explorer_destination(strava_segment_id);
+    CREATE UNIQUE INDEX idx_explorer_destination_campaign_segment
+      ON explorer_destination(explorer_campaign_id, strava_segment_id);
+
+    CREATE TABLE explorer_destination_match (
+      id integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+      explorer_campaign_id integer NOT NULL,
+      explorer_destination_id integer NOT NULL,
+      strava_athlete_id text NOT NULL,
+      strava_activity_id text NOT NULL,
+      matched_at integer NOT NULL,
+      created_at text DEFAULT (CURRENT_TIMESTAMP),
+      FOREIGN KEY (explorer_campaign_id) REFERENCES explorer_campaign(id) ON UPDATE no action ON DELETE cascade,
+      FOREIGN KEY (explorer_destination_id) REFERENCES explorer_destination(id) ON UPDATE no action ON DELETE cascade,
+      FOREIGN KEY (strava_athlete_id) REFERENCES participant(strava_athlete_id) ON UPDATE no action ON DELETE cascade
+    );
+    CREATE INDEX idx_explorer_match_campaign_athlete ON explorer_destination_match(explorer_campaign_id, strava_athlete_id);
+    CREATE INDEX idx_explorer_match_activity ON explorer_destination_match(strava_activity_id);
+    CREATE UNIQUE INDEX idx_explorer_match_unique
+      ON explorer_destination_match(explorer_campaign_id, explorer_destination_id, strava_athlete_id);
+  `);
+}
+
 describe('repairLegacyExplorerSchema', () => {
   let db: Database;
   let drizzleDb: BetterSQLite3Database;
@@ -152,7 +207,8 @@ describe('repairLegacyExplorerSchema', () => {
     expect(repaired).toBe(true);
 
     const campaign = drizzleDb.select().from(explorerCampaign).get();
-    expect(campaign?.season_id).toBe(seasonRecord.id);
+    expect(campaign?.start_at).toBe(seasonRecord.start_at);
+    expect(campaign?.end_at).toBe(seasonRecord.end_at);
     expect(campaign?.display_name).toBe('Legacy Explorer Week');
 
     const destination = drizzleDb.select().from(explorerDestination).get();
@@ -169,14 +225,15 @@ describe('repairLegacyExplorerSchema', () => {
     expect(match?.strava_athlete_id).toBe('999001');
   });
 
-  it('still succeeds when the legacy schema has 0009 recorded and only 0010 is pending', () => {
-    replaceExplorerTablesWithLegacySchema(db);
-    db.exec('DELETE FROM __drizzle_migrations WHERE rowid >= 11;');
+  it('still succeeds when the legacy schema has 0010 recorded and the later Explorer migrations are pending', () => {
+    replaceExplorerTablesWithCampaignSchema(db);
+    db.exec('DELETE FROM __drizzle_migrations WHERE rowid >= 12;');
 
     const repairState = prepareLegacyExplorerSchemaRepair(db);
 
+    expect(repairState).toBeNull();
     expect(() => migrate(drizzleDb, { migrationsFolder })).not.toThrow();
-    expect(() => finalizeLegacyExplorerSchemaRepair(db, repairState)).not.toThrow();
+    expect(finalizeLegacyExplorerSchemaRepair(db, repairState)).toBe(false);
 
     const campaignTable = db.prepare(
       'SELECT name FROM sqlite_master WHERE type = \'table\' AND name = \'explorer_campaign\''

--- a/server/src/__tests__/testDataHelpers.ts
+++ b/server/src/__tests__/testDataHelpers.ts
@@ -95,7 +95,8 @@ interface CreateWeekWithResultsOptions {
 }
 
 interface CreateExplorerCampaignOptions {
-  seasonId?: number;
+  startAt?: number;
+  endAt?: number;
   displayName?: string | null;
   rulesBlurb?: string | null;
 }
@@ -266,19 +267,15 @@ export function createExplorerCampaign(
   options: CreateExplorerCampaignOptions = {}
 ): SelectExplorerCampaign {
   const {
-    seasonId,
+    startAt = isoToUnix('2025-06-01T00:00:00Z') || 0,
+    endAt = isoToUnix('2025-06-30T23:59:59Z') || 0,
     displayName = 'Explorer Campaign',
     rulesBlurb = null,
   } = options;
 
-  let finalSeasonId = seasonId;
-  if (!finalSeasonId) {
-    const defaultSeason = createSeason(db, 'Explorer Season');
-    finalSeasonId = defaultSeason.id;
-  }
-
   const newCampaignData: InsertExplorerCampaign = {
-    season_id: finalSeasonId,
+    start_at: startAt,
+    end_at: endAt,
     display_name: displayName,
     rules_blurb: rulesBlurb,
   };

--- a/server/src/__tests__/trpc/explorerAdminRouter.test.ts
+++ b/server/src/__tests__/trpc/explorerAdminRouter.test.ts
@@ -222,6 +222,7 @@ describe('explorerAdminRouter', () => {
 
     expect(result).toHaveLength(2);
     expect(result[1]?.name).toBe('Spring Explorer');
+    expect(result[1]?.displayNameRaw).toBe('Spring Explorer');
     expect(result[1]?.rulesBlurb).toBe('Ride every destination once.');
     expect(result[1]?.destinations).toHaveLength(1);
     expect(result[1]?.destinations[0]).toMatchObject({
@@ -233,6 +234,20 @@ describe('explorerAdminRouter', () => {
       state: 'MA',
       country: 'USA',
     });
+  });
+
+  it('preserves a null raw display name for unnamed campaigns', async () => {
+    createExplorerCampaign(drizzleDb, {
+      startAt: 1748736000,
+      endAt: 1751327999,
+      displayName: null,
+    });
+    const caller = getCaller(true);
+
+    const result = await caller.explorerAdmin.getCampaigns();
+
+    expect(result[0]?.name).toBe('Explorer Campaign');
+    expect(result[0]?.displayNameRaw).toBeNull();
   });
 
   it('allows destination creation when metadata enrichment falls back to placeholder data', async () => {

--- a/server/src/__tests__/trpc/explorerAdminRouter.test.ts
+++ b/server/src/__tests__/trpc/explorerAdminRouter.test.ts
@@ -6,7 +6,14 @@ import { createContext } from '../../trpc/context';
 import { explorerCampaign, explorerDestination, participant } from '../../db/schema';
 import { ExplorerAdminService } from '../../services/ExplorerAdminService';
 import { SegmentService } from '../../services/SegmentService';
-import { clearAllData, createExplorerCampaign, createParticipant, createSeason, createSegment, setupTestDb, teardownTestDb } from '../testDataHelpers';
+import {
+  clearAllData,
+  createExplorerCampaign,
+  createParticipant,
+  createSegment,
+  setupTestDb,
+  teardownTestDb,
+} from '../testDataHelpers';
 
 describe('explorerAdminRouter', () => {
   let db: Database;
@@ -53,43 +60,37 @@ describe('explorerAdminRouter', () => {
   };
 
   it('requires admin auth to create a campaign', async () => {
-    const seasonRecord = createSeason(drizzleDb, 'Explorer Season');
     const caller = getCaller(false);
 
     await expect(
-      caller.explorerAdmin.createCampaign({ seasonId: seasonRecord.id })
+      caller.explorerAdmin.createCampaign({ startAt: 1748736000, endAt: 1751327999 })
     ).rejects.toThrow('UNAUTHORIZED');
   });
 
-  it('requires admin auth to read a season campaign', async () => {
-    const seasonRecord = createSeason(drizzleDb, 'Explorer Season');
+  it('requires admin auth to read campaigns', async () => {
     const caller = getCaller(false);
 
-    await expect(
-      caller.explorerAdmin.getCampaignForSeason({ seasonId: seasonRecord.id })
-    ).rejects.toThrow('UNAUTHORIZED');
+    await expect(caller.explorerAdmin.getCampaigns()).rejects.toThrow('UNAUTHORIZED');
   });
 
-  it('returns null when a season has no explorer campaign', async () => {
-    const seasonRecord = createSeason(drizzleDb, 'Explorer Season');
+  it('returns an empty list when no campaigns exist', async () => {
     const caller = getCaller(true);
 
-    await expect(
-      caller.explorerAdmin.getCampaignForSeason({ seasonId: seasonRecord.id })
-    ).resolves.toBeNull();
+    await expect(caller.explorerAdmin.getCampaigns()).resolves.toEqual([]);
   });
 
   it('creates a campaign when called by an admin', async () => {
-    const seasonRecord = createSeason(drizzleDb, 'Explorer Season');
     const caller = getCaller(true);
 
     const result = await caller.explorerAdmin.createCampaign({
-      seasonId: seasonRecord.id,
+      startAt: 1748736000,
+      endAt: 1751327999,
       displayName: 'Explorer 2026',
       rulesBlurb: 'Ride every destination once.',
     });
 
-    expect(result.season_id).toBe(seasonRecord.id);
+    expect(result.start_at).toBe(1748736000);
+    expect(result.end_at).toBe(1751327999);
     expect(result.display_name).toBe('Explorer 2026');
 
     const stored = drizzleDb
@@ -100,31 +101,52 @@ describe('explorerAdminRouter', () => {
     expect(stored?.rules_blurb).toBe('Ride every destination once.');
   });
 
-  it('rejects duplicate campaigns for the same season', async () => {
-    const seasonRecord = createSeason(drizzleDb, 'Explorer Season');
+  it('updates a campaign when called by an admin', async () => {
     const caller = getCaller(true);
+    const campaign = createExplorerCampaign(drizzleDb, {
+      startAt: 1748736000,
+      endAt: 1751327999,
+      displayName: 'Explorer 2026',
+    });
 
-    await caller.explorerAdmin.createCampaign({ seasonId: seasonRecord.id });
+    const result = await caller.explorerAdmin.updateCampaign({
+      explorerCampaignId: campaign.id,
+      startAt: 1748822400,
+      endAt: 1751241599,
+      displayName: 'Updated Explorer 2026',
+      rulesBlurb: 'Updated rules.',
+    });
 
-    await expect(
-      caller.explorerAdmin.createCampaign({ seasonId: seasonRecord.id })
-    ).rejects.toThrow('Explorer campaign already exists for this season');
+    expect(result.display_name).toBe('Updated Explorer 2026');
+    expect(result.start_at).toBe(1748822400);
+    expect(result.end_at).toBe(1751241599);
   });
 
-  it('returns NOT_FOUND when the season does not exist', async () => {
+  it('rejects overlapping campaigns', async () => {
+    const caller = getCaller(true);
+    await caller.explorerAdmin.createCampaign({ startAt: 1748736000, endAt: 1751327999 });
+
+    await expect(
+      caller.explorerAdmin.createCampaign({ startAt: 1750464000, endAt: 1753055999 })
+    ).rejects.toMatchObject({
+      code: 'BAD_REQUEST',
+      message: 'Explorer campaigns cannot overlap in v1',
+    });
+  });
+
+  it('rejects invalid campaign windows', async () => {
     const caller = getCaller(true);
 
     await expect(
-      caller.explorerAdmin.createCampaign({ seasonId: 999999 })
+      caller.explorerAdmin.createCampaign({ startAt: 1751327999, endAt: 1748736000 })
     ).rejects.toMatchObject({
-      code: 'NOT_FOUND',
-      message: 'Season not found',
+      code: 'BAD_REQUEST',
+      message: 'Campaign end date must be on or after the start date',
     });
   });
 
   it('requires admin auth to add a destination', async () => {
-    const seasonRecord = createSeason(drizzleDb, 'Explorer Season');
-    const campaign = createExplorerCampaign(drizzleDb, { seasonId: seasonRecord.id });
+    const campaign = createExplorerCampaign(drizzleDb, { startAt: 1748736000, endAt: 1751327999 });
     const caller = getCaller(false);
 
     await expect(
@@ -136,8 +158,7 @@ describe('explorerAdminRouter', () => {
   });
 
   it('adds a destination and persists source URL plus cached metadata', async () => {
-    const seasonRecord = createSeason(drizzleDb, 'Explorer Season');
-    const campaign = createExplorerCampaign(drizzleDb, { seasonId: seasonRecord.id });
+    const campaign = createExplorerCampaign(drizzleDb, { startAt: 1748736000, endAt: 1751327999 });
     const caller = getCaller(true);
     jest.spyOn(SegmentService.prototype, 'fetchAndStoreSegmentMetadata').mockResolvedValue({
       strava_segment_id: '12744502',
@@ -166,12 +187,17 @@ describe('explorerAdminRouter', () => {
     expect(stored?.display_order).toBe(0);
   });
 
-  it('returns an admin campaign view with destinations for the selected season', async () => {
-    const seasonRecord = createSeason(drizzleDb, 'Explorer Season');
-    const campaign = createExplorerCampaign(drizzleDb, {
-      seasonId: seasonRecord.id,
-      displayName: 'Explorer 2026',
+  it('returns campaigns with destinations in admin view order', async () => {
+    const firstCampaign = createExplorerCampaign(drizzleDb, {
+      startAt: 1748736000,
+      endAt: 1751327999,
+      displayName: 'Spring Explorer',
       rulesBlurb: 'Ride every destination once.',
+    });
+    createExplorerCampaign(drizzleDb, {
+      startAt: 1751414400,
+      endAt: 1754006399,
+      displayName: 'Summer Explorer',
     });
     const caller = getCaller(true);
     createSegment(drizzleDb, '12744502', 'Mocked Segment', {
@@ -187,30 +213,30 @@ describe('explorerAdminRouter', () => {
     } as any);
 
     await caller.explorerAdmin.addDestination({
-      explorerCampaignId: campaign.id,
+      explorerCampaignId: firstCampaign.id,
       sourceUrl: 'https://www.strava.com/segments/12744502',
       displayLabel: 'Hilltown opener',
     });
 
-    const result = await caller.explorerAdmin.getCampaignForSeason({ seasonId: seasonRecord.id });
+    const result = await caller.explorerAdmin.getCampaigns();
 
-    expect(result).not.toBeNull();
-    expect(result?.name).toBe('Explorer 2026');
-    expect(result?.rulesBlurb).toBe('Ride every destination once.');
-    expect(result?.destinations).toHaveLength(1);
-    expect(result?.destinations[0]?.displayLabel).toBe('Hilltown opener');
-    expect(result?.destinations[0]?.segmentName).toBe('Mocked Segment');
-    expect(result?.destinations[0]?.createdAt).toBeTruthy();
-    expect(result?.destinations[0]?.distance).toBe(3210);
-    expect(result?.destinations[0]?.averageGrade).toBe(4.2);
-    expect(result?.destinations[0]?.city).toBe('Northampton');
-    expect(result?.destinations[0]?.state).toBe('MA');
-    expect(result?.destinations[0]?.country).toBe('USA');
+    expect(result).toHaveLength(2);
+    expect(result[1]?.name).toBe('Spring Explorer');
+    expect(result[1]?.rulesBlurb).toBe('Ride every destination once.');
+    expect(result[1]?.destinations).toHaveLength(1);
+    expect(result[1]?.destinations[0]).toMatchObject({
+      displayLabel: 'Hilltown opener',
+      segmentName: 'Mocked Segment',
+      distance: 3210,
+      averageGrade: 4.2,
+      city: 'Northampton',
+      state: 'MA',
+      country: 'USA',
+    });
   });
 
   it('allows destination creation when metadata enrichment falls back to placeholder data', async () => {
-    const seasonRecord = createSeason(drizzleDb, 'Explorer Season');
-    const campaign = createExplorerCampaign(drizzleDb, { seasonId: seasonRecord.id });
+    const campaign = createExplorerCampaign(drizzleDb, { startAt: 1748736000, endAt: 1751327999 });
     const caller = getCaller(true);
     jest.spyOn(SegmentService.prototype, 'fetchAndStoreSegmentMetadata').mockResolvedValue({
       strava_segment_id: '12744502',
@@ -226,8 +252,7 @@ describe('explorerAdminRouter', () => {
   });
 
   it('rejects invalid segment URLs', async () => {
-    const seasonRecord = createSeason(drizzleDb, 'Explorer Season');
-    const campaign = createExplorerCampaign(drizzleDb, { seasonId: seasonRecord.id });
+    const campaign = createExplorerCampaign(drizzleDb, { startAt: 1748736000, endAt: 1751327999 });
     const caller = getCaller(true);
 
     await expect(
@@ -239,34 +264,32 @@ describe('explorerAdminRouter', () => {
   });
 
   it('maps sqlite unique constraint errors to CONFLICT', async () => {
-    const seasonRecord = createSeason(drizzleDb, 'Explorer Season');
     const caller = getCaller(true);
 
     jest.spyOn(ExplorerAdminService.prototype, 'createCampaign').mockImplementation(() => {
-      const error = new Error('UNIQUE constraint failed: explorer_campaign.season_id') as Error & { code: string };
+      const error = new Error('UNIQUE constraint failed: explorer_destination_campaign_segment') as Error & { code: string };
       error.code = 'SQLITE_CONSTRAINT_UNIQUE';
       throw error;
     });
 
     await expect(
-      caller.explorerAdmin.createCampaign({ seasonId: seasonRecord.id })
+      caller.explorerAdmin.createCampaign({ startAt: 1748736000, endAt: 1751327999 })
     ).rejects.toMatchObject({
       code: 'CONFLICT',
-      message: 'UNIQUE constraint failed: explorer_campaign.season_id',
+      message: 'UNIQUE constraint failed: explorer_destination_campaign_segment',
     });
   });
 
   it('does not leak raw internal errors to clients', async () => {
-    const seasonRecord = createSeason(drizzleDb, 'Explorer Season');
     const caller = getCaller(true);
     const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
 
     jest.spyOn(ExplorerAdminService.prototype, 'createCampaign').mockImplementation(() => {
-      throw new Error('SQL query failed near idx_explorer_campaign_season');
+      throw new Error('SQL query failed near idx_explorer_campaign_window');
     });
 
     await expect(
-      caller.explorerAdmin.createCampaign({ seasonId: seasonRecord.id })
+      caller.explorerAdmin.createCampaign({ startAt: 1748736000, endAt: 1751327999 })
     ).rejects.toMatchObject({
       code: 'INTERNAL_SERVER_ERROR',
       message: 'Explorer admin operation failed',

--- a/server/src/__tests__/trpc/explorerRouter.test.ts
+++ b/server/src/__tests__/trpc/explorerRouter.test.ts
@@ -10,7 +10,6 @@ import {
   createExplorerDestination,
   createExplorerMatch,
   createParticipant,
-  createSeason,
   createSegment,
   setupTestDb,
   teardownTestDb,
@@ -66,12 +65,9 @@ describe('explorerRouter', () => {
 
   it('returns the active campaign with ordered destinations and resolved labels', async () => {
     createSegment(drizzleDb, 'seg-401', 'Segment Name From DB');
-    const seasonRecord = createSeason(drizzleDb, '2025 Explorer Season', true, {
+    const campaign = createExplorerCampaign(drizzleDb, {
       startAt: 1748736000,
       endAt: 4102444799,
-    });
-    const campaign = createExplorerCampaign(drizzleDb, {
-      seasonId: seasonRecord.id,
       displayName: 'Explorer Launch',
     });
 
@@ -92,7 +88,6 @@ describe('explorerRouter', () => {
     const result = await caller.explorer.getActiveCampaign();
 
     expect(result?.name).toBe('Explorer Launch');
-    expect(result?.seasonName).toBe('2025 Explorer Season');
     expect(result?.destinations).toHaveLength(2);
     expect(result?.destinations[0]).toMatchObject({
       stravaSegmentId: 'seg-401',
@@ -107,8 +102,7 @@ describe('explorerRouter', () => {
   });
 
   it('requires auth for getCampaignProgress', async () => {
-    const seasonRecord = createSeason(drizzleDb, 'Explorer Season');
-    const campaign = createExplorerCampaign(drizzleDb, { seasonId: seasonRecord.id });
+    const campaign = createExplorerCampaign(drizzleDb, { startAt: 1748736000, endAt: 1751327999 });
     const caller = getCaller();
     await expect(caller.explorer.getCampaignProgress({ campaignId: campaign.id })).rejects.toThrow('UNAUTHORIZED');
   });
@@ -116,12 +110,9 @@ describe('explorerRouter', () => {
   it('returns athlete progress for a campaign', async () => {
     createParticipant(drizzleDb, '3001', 'Progress Rider');
     createSegment(drizzleDb, 'seg-501', 'Forest Road');
-    const seasonRecord = createSeason(drizzleDb, 'Explorer Season', true, {
+    const campaign = createExplorerCampaign(drizzleDb, {
       startAt: 1751328000,
       endAt: 1751932799,
-    });
-    const campaign = createExplorerCampaign(drizzleDb, {
-      seasonId: seasonRecord.id,
       displayName: 'Weekless Explorer',
     });
 

--- a/server/src/db/repairLegacyExplorerSchema.ts
+++ b/server/src/db/repairLegacyExplorerSchema.ts
@@ -34,10 +34,6 @@ interface LegacyMatchRow {
   matched_at: number;
 }
 
-interface SeasonRow {
-  id: number;
-}
-
 function tableExists(db: SqliteDatabase, tableName: string): boolean {
   const row = db.prepare(
     'SELECT name FROM sqlite_master WHERE type = \'table\' AND name = ?'
@@ -68,13 +64,15 @@ function createCampaignExplorerTables(db: SqliteDatabase) {
   db.exec(`
     CREATE TABLE explorer_campaign (
       id integer PRIMARY KEY AUTOINCREMENT NOT NULL,
-      season_id integer NOT NULL,
+      start_at integer NOT NULL,
+      end_at integer NOT NULL,
       display_name text,
       rules_blurb text,
       created_at text DEFAULT (CURRENT_TIMESTAMP),
-      updated_at text DEFAULT (CURRENT_TIMESTAMP),
-      FOREIGN KEY (season_id) REFERENCES season(id) ON UPDATE no action ON DELETE cascade
+      updated_at text DEFAULT (CURRENT_TIMESTAMP)
     );
+
+    CREATE INDEX idx_explorer_campaign_window ON explorer_campaign(start_at, end_at);
 
     CREATE TABLE explorer_destination (
       id integer PRIMARY KEY AUTOINCREMENT NOT NULL,
@@ -127,15 +125,8 @@ function migrateLegacyExplorerRows(db: SqliteDatabase) {
      ORDER BY id ASC`
   ).all() as LegacyMatchRow[];
 
-  const findSeasonForWeek = db.prepare(
-    `SELECT id
-     FROM season
-     WHERE start_at <= ? AND end_at >= ?
-     ORDER BY start_at DESC, id DESC
-     LIMIT 1`
-  );
   const insertCampaign = db.prepare(
-    'INSERT INTO explorer_campaign (season_id, display_name, rules_blurb) VALUES (?, ?, ?)'
+    'INSERT INTO explorer_campaign (start_at, end_at, display_name, rules_blurb) VALUES (?, ?, ?, ?)'
   );
   const insertDestination = db.prepare(
     `INSERT INTO explorer_destination (
@@ -159,27 +150,17 @@ function migrateLegacyExplorerRows(db: SqliteDatabase) {
     ) VALUES (?, ?, ?, ?, ?)`
   );
 
-  const campaignIdBySeasonId = new Map<number, number>();
   const campaignIdByLegacyWeekId = new Map<number, number>();
   const nextDisplayOrderByCampaignId = new Map<number, number>();
   const destinationIdByLegacyDestinationId = new Map<number, number>();
   const destinationIdByCampaignSegmentKey = new Map<string, number>();
 
   for (const legacyWeek of legacyWeeks) {
-    const seasonRecord = findSeasonForWeek.get(legacyWeek.start_at, legacyWeek.end_at) as SeasonRow | undefined;
-    if (!seasonRecord) {
-      continue;
-    }
-
-    let campaignId = campaignIdBySeasonId.get(seasonRecord.id);
-    if (!campaignId) {
-      const inserted = insertCampaign.run(seasonRecord.id, legacyWeek.name, null);
-      campaignId = Number(inserted.lastInsertRowid);
-      campaignIdBySeasonId.set(seasonRecord.id, campaignId);
-      nextDisplayOrderByCampaignId.set(campaignId, 0);
-    }
+    const inserted = insertCampaign.run(legacyWeek.start_at, legacyWeek.end_at, legacyWeek.name, null);
+    const campaignId = Number(inserted.lastInsertRowid);
 
     campaignIdByLegacyWeekId.set(legacyWeek.id, campaignId);
+    nextDisplayOrderByCampaignId.set(campaignId, 0);
   }
 
   for (const legacyDestination of legacyDestinations) {

--- a/server/src/db/schema.ts
+++ b/server/src/db/schema.ts
@@ -154,14 +154,15 @@ export const webhookSubscription = sqliteTable('webhook_subscription', {
 
 export const explorerCampaign = sqliteTable('explorer_campaign', {
   id: integer().primaryKey({ autoIncrement: true }),
-  season_id: integer('season_id').notNull().references(() => season.id, { onDelete: 'cascade' }),
+  start_at: integer('start_at').notNull(),
+  end_at: integer('end_at').notNull(),
   display_name: text('display_name'),
   rules_blurb: text('rules_blurb'),
   created_at: text('created_at').default('sql`(CURRENT_TIMESTAMP)`'),
   updated_at: text('updated_at').default('sql`(CURRENT_TIMESTAMP)`'),
 },
 (t) => [
-  uniqueIndex('idx_explorer_campaign_season').on(t.season_id),
+  index('idx_explorer_campaign_window').on(t.start_at, t.end_at),
 ]);
 
 export const explorerDestination = sqliteTable('explorer_destination', {

--- a/server/src/routers/explorerAdmin.ts
+++ b/server/src/routers/explorerAdmin.ts
@@ -18,7 +18,12 @@ function mapExplorerAdminError(error: unknown): TRPCError {
     return new TRPCError({ code: 'NOT_FOUND', message });
   }
 
-  if (message.includes('valid Strava segment URL')) {
+  if (
+    message.includes('valid Strava segment URL') ||
+    message.includes('Campaign end date') ||
+    message.includes('Campaign dates must be valid timestamps') ||
+    message.includes('cannot overlap')
+  ) {
     return new TRPCError({ code: 'BAD_REQUEST', message });
   }
 
@@ -31,15 +36,13 @@ function mapExplorerAdminError(error: unknown): TRPCError {
 }
 
 export const explorerAdminRouter = router({
-  getCampaignForSeason: adminProcedure
-    .input(z.object({
-      seasonId: z.number().int().positive(),
-    }))
-    .query(async ({ ctx, input }) => {
+  getCampaigns: adminProcedure
+    .input(z.void())
+    .query(async ({ ctx }) => {
       const service = new ExplorerQueryService(ctx.orm);
 
       try {
-        return await service.getCampaignForSeason(input.seasonId);
+        return service.getAdminCampaigns();
       } catch (error) {
         throw mapExplorerAdminError(error);
       }
@@ -47,7 +50,8 @@ export const explorerAdminRouter = router({
 
   createCampaign: adminProcedure
     .input(z.object({
-      seasonId: z.number().int().positive(),
+      startAt: z.number().int().positive(),
+      endAt: z.number().int().positive(),
       displayName: z.string().trim().max(255).nullable().optional(),
       rulesBlurb: z.string().trim().max(2000).nullable().optional(),
     }))
@@ -56,6 +60,24 @@ export const explorerAdminRouter = router({
 
       try {
         return service.createCampaign(input);
+      } catch (error) {
+        throw mapExplorerAdminError(error);
+      }
+    }),
+
+  updateCampaign: adminProcedure
+    .input(z.object({
+      explorerCampaignId: z.number().int().positive(),
+      startAt: z.number().int().positive(),
+      endAt: z.number().int().positive(),
+      displayName: z.string().trim().max(255).nullable().optional(),
+      rulesBlurb: z.string().trim().max(2000).nullable().optional(),
+    }))
+    .mutation(async ({ ctx, input }) => {
+      const service = new ExplorerAdminService(ctx.orm);
+
+      try {
+        return service.updateCampaign(input);
       } catch (error) {
         throw mapExplorerAdminError(error);
       }

--- a/server/src/services/ExplorerAdminService.ts
+++ b/server/src/services/ExplorerAdminService.ts
@@ -1,6 +1,6 @@
-import { and, eq, max } from 'drizzle-orm';
+import { and, eq, gte, lte, max, ne } from 'drizzle-orm';
 import { type BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
-import { explorerCampaign, explorerDestination, season, type Segment } from '../db/schema';
+import { explorerCampaign, explorerDestination, type Segment } from '../db/schema';
 import { SegmentService } from './SegmentService';
 
 interface ExplorerSegmentMetadataService {
@@ -13,7 +13,16 @@ interface ExplorerSegmentMetadataService {
 }
 
 interface CreateCampaignInput {
-  seasonId: number;
+  startAt: number;
+  endAt: number;
+  displayName?: string | null;
+  rulesBlurb?: string | null;
+}
+
+interface UpdateCampaignInput {
+  explorerCampaignId: number;
+  startAt: number;
+  endAt: number;
   displayName?: string | null;
   rulesBlurb?: string | null;
 }
@@ -39,6 +48,16 @@ interface AddDestinationResult {
 function normalizeNullableText(value?: string | null): string | null {
   const trimmed = value?.trim();
   return trimmed ? trimmed : null;
+}
+
+function validateCampaignWindow(startAt: number, endAt: number): void {
+  if (!Number.isInteger(startAt) || !Number.isInteger(endAt)) {
+    throw new Error('Campaign dates must be valid timestamps');
+  }
+
+  if (endAt < startAt) {
+    throw new Error('Campaign end date must be on or after the start date');
+  }
 }
 
 function parseStravaSegmentUrl(sourceUrl: string): string {
@@ -70,34 +89,65 @@ export class ExplorerAdminService {
     private readonly segmentService: ExplorerSegmentMetadataService = new SegmentService(db)
   ) {}
 
-  createCampaign(input: CreateCampaignInput) {
-    const seasonRecord = this.db
-      .select({ id: season.id })
-      .from(season)
-      .where(eq(season.id, input.seasonId))
-      .get();
-
-    if (!seasonRecord) {
-      throw new Error('Season not found');
-    }
-
-    const existingCampaign = this.db
+  private ensureNoOverlap(startAt: number, endAt: number, excludedCampaignId?: number): void {
+    const overlappingCampaign = this.db
       .select({ id: explorerCampaign.id })
       .from(explorerCampaign)
-      .where(eq(explorerCampaign.season_id, input.seasonId))
+      .where(
+        and(
+          lte(explorerCampaign.start_at, endAt),
+          gte(explorerCampaign.end_at, startAt),
+          excludedCampaignId === undefined ? undefined : ne(explorerCampaign.id, excludedCampaignId)
+        )
+      )
       .get();
 
-    if (existingCampaign) {
-      throw new Error('Explorer campaign already exists for this season');
+    if (overlappingCampaign) {
+      throw new Error('Explorer campaigns cannot overlap in v1');
     }
+  }
+
+  createCampaign(input: CreateCampaignInput) {
+    validateCampaignWindow(input.startAt, input.endAt);
+    this.ensureNoOverlap(input.startAt, input.endAt);
 
     return this.db
       .insert(explorerCampaign)
       .values({
-        season_id: input.seasonId,
+        start_at: input.startAt,
+        end_at: input.endAt,
         display_name: normalizeNullableText(input.displayName),
         rules_blurb: normalizeNullableText(input.rulesBlurb),
       })
+      .returning()
+      .get();
+  }
+
+  updateCampaign(input: UpdateCampaignInput) {
+    validateCampaignWindow(input.startAt, input.endAt);
+
+    const existingCampaign = this.db
+      .select({ id: explorerCampaign.id })
+      .from(explorerCampaign)
+      .where(eq(explorerCampaign.id, input.explorerCampaignId))
+      .get();
+
+    if (!existingCampaign) {
+      throw new Error('Explorer campaign not found');
+    }
+
+    this.ensureNoOverlap(input.startAt, input.endAt, input.explorerCampaignId);
+
+    return this.db
+      .update(explorerCampaign)
+      .set({
+        start_at: input.startAt,
+        end_at: input.endAt,
+        display_name: normalizeNullableText(input.displayName),
+        rules_blurb: normalizeNullableText(input.rulesBlurb),
+        updated_at: new Date().toISOString(),
+      })
+      .where(eq(explorerCampaign.id, input.explorerCampaignId))
       .returning()
       .get();
   }
@@ -168,4 +218,10 @@ export class ExplorerAdminService {
   }
 }
 
-export type { CreateCampaignInput, AddDestinationInput, AddDestinationResult, ExplorerSegmentMetadataService };
+export type {
+  CreateCampaignInput,
+  UpdateCampaignInput,
+  AddDestinationInput,
+  AddDestinationResult,
+  ExplorerSegmentMetadataService,
+};

--- a/server/src/services/ExplorerMatchingService.ts
+++ b/server/src/services/ExplorerMatchingService.ts
@@ -4,7 +4,6 @@ import {
   explorerCampaign,
   explorerDestination,
   explorerDestinationMatch,
-  season,
 } from '../db/schema';
 import {
   getActivity,
@@ -27,11 +26,10 @@ interface RefreshAthleteCampaignResult {
 
 interface CampaignWindowRecord {
   id: number;
-  season_id: number;
+  start_at: number;
+  end_at: number;
   display_name: string | null;
   rules_blurb: string | null;
-  season_start_at: number;
-  season_end_at: number;
 }
 
 function getActivityTimestamp(activityData: StravaActivity): number | null {
@@ -80,18 +78,16 @@ export class ExplorerMatchingService {
     const activeCampaigns = this.db
       .select({
         id: explorerCampaign.id,
-        season_id: explorerCampaign.season_id,
+        start_at: explorerCampaign.start_at,
+        end_at: explorerCampaign.end_at,
         display_name: explorerCampaign.display_name,
         rules_blurb: explorerCampaign.rules_blurb,
-        season_start_at: season.start_at,
-        season_end_at: season.end_at,
       })
       .from(explorerCampaign)
-      .innerJoin(season, eq(explorerCampaign.season_id, season.id))
       .where(
         and(
-          lte(season.start_at, activityTimestamp),
-          gte(season.end_at, activityTimestamp)
+          lte(explorerCampaign.start_at, activityTimestamp),
+          gte(explorerCampaign.end_at, activityTimestamp)
         )
       )
       .all();
@@ -107,14 +103,12 @@ export class ExplorerMatchingService {
     const campaignRecord = this.db
       .select({
         id: explorerCampaign.id,
-        season_id: explorerCampaign.season_id,
+        start_at: explorerCampaign.start_at,
+        end_at: explorerCampaign.end_at,
         display_name: explorerCampaign.display_name,
         rules_blurb: explorerCampaign.rules_blurb,
-        season_start_at: season.start_at,
-        season_end_at: season.end_at,
       })
       .from(explorerCampaign)
-      .innerJoin(season, eq(explorerCampaign.season_id, season.id))
       .where(eq(explorerCampaign.id, explorerCampaignId))
       .get();
 
@@ -128,8 +122,8 @@ export class ExplorerMatchingService {
 
     const activities = await listAthleteActivities(
       accessToken,
-      campaignRecord.season_start_at,
-      campaignRecord.season_end_at,
+      campaignRecord.start_at,
+      campaignRecord.end_at,
       {
         includeAllEfforts: true,
       }

--- a/server/src/services/ExplorerQueryService.ts
+++ b/server/src/services/ExplorerQueryService.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, gte, lte } from 'drizzle-orm';
+import { and, asc, desc, eq, gte, inArray, lte } from 'drizzle-orm';
 import { type BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
 import {
   explorerCampaign,
@@ -38,6 +38,7 @@ interface ActiveExplorerCampaignView extends ExplorerCampaignBaseView {
 }
 
 interface ExplorerAdminCampaignView extends ExplorerCampaignBaseView {
+  displayNameRaw: string | null;
   destinations: ExplorerDestinationView[];
 }
 
@@ -83,9 +84,56 @@ function resolveSegmentName(destination: {
 export class ExplorerQueryService {
   constructor(private readonly db: BetterSQLite3Database) {}
 
-  private listDestinations(explorerCampaignId: number): ExplorerDestinationView[] {
+  private mapDestination(destination: {
+    id: number;
+    strava_segment_id: string;
+    display_label: string | null;
+    cached_name: string | null;
+    source_url: string | null;
+    created_at: string | null;
+    surface_type: string | null;
+    category: string | null;
+    display_order: number;
+    segment_name: string | null;
+    distance: number | null;
+    average_grade: number | null;
+    city: string | null;
+    state: string | null;
+    country: string | null;
+  }): ExplorerDestinationView {
+    return {
+      id: destination.id,
+      stravaSegmentId: destination.strava_segment_id,
+      displayLabel: resolveDestinationLabel(destination),
+      customLabel: destination.display_label,
+      segmentName: resolveSegmentName(destination),
+      sourceUrl: destination.source_url,
+      createdAt: destination.created_at,
+      distance: destination.distance,
+      averageGrade: destination.average_grade,
+      city: destination.city,
+      state: destination.state,
+      country: destination.country,
+      surfaceType: destination.surface_type,
+      category: destination.category,
+      displayOrder: destination.display_order,
+    };
+  }
+
+  private listDestinationsByCampaignIds(explorerCampaignIds: number[]): Map<number, ExplorerDestinationView[]> {
+    const destinationsByCampaignId = new Map<number, ExplorerDestinationView[]>();
+
+    for (const explorerCampaignId of explorerCampaignIds) {
+      destinationsByCampaignId.set(explorerCampaignId, []);
+    }
+
+    if (explorerCampaignIds.length === 0) {
+      return destinationsByCampaignId;
+    }
+
     const destinations = this.db
       .select({
+        explorer_campaign_id: explorerDestination.explorer_campaign_id,
         id: explorerDestination.id,
         strava_segment_id: explorerDestination.strava_segment_id,
         display_label: explorerDestination.display_label,
@@ -104,27 +152,29 @@ export class ExplorerQueryService {
       })
       .from(explorerDestination)
       .leftJoin(segment, eq(explorerDestination.strava_segment_id, segment.strava_segment_id))
-      .where(eq(explorerDestination.explorer_campaign_id, explorerCampaignId))
-      .orderBy(asc(explorerDestination.display_order), asc(explorerDestination.id))
+      .where(inArray(explorerDestination.explorer_campaign_id, explorerCampaignIds))
+      .orderBy(
+        asc(explorerDestination.explorer_campaign_id),
+        asc(explorerDestination.display_order),
+        asc(explorerDestination.id)
+      )
       .all();
 
-    return destinations.map((destination) => ({
-      id: destination.id,
-      stravaSegmentId: destination.strava_segment_id,
-      displayLabel: resolveDestinationLabel(destination),
-      customLabel: destination.display_label,
-      segmentName: resolveSegmentName(destination),
-      sourceUrl: destination.source_url,
-      createdAt: destination.created_at,
-      distance: destination.distance,
-      averageGrade: destination.average_grade,
-      city: destination.city,
-      state: destination.state,
-      country: destination.country,
-      surfaceType: destination.surface_type,
-      category: destination.category,
-      displayOrder: destination.display_order,
-    }));
+    for (const destination of destinations) {
+      const campaignDestinations = destinationsByCampaignId.get(destination.explorer_campaign_id);
+
+      if (!campaignDestinations) {
+        continue;
+      }
+
+      campaignDestinations.push(this.mapDestination(destination));
+    }
+
+    return destinationsByCampaignId;
+  }
+
+  private listDestinations(explorerCampaignId: number): ExplorerDestinationView[] {
+    return this.listDestinationsByCampaignIds([explorerCampaignId]).get(explorerCampaignId) ?? [];
   }
 
   getAdminCampaigns(): ExplorerAdminCampaignView[] {
@@ -140,13 +190,18 @@ export class ExplorerQueryService {
       .orderBy(desc(explorerCampaign.start_at), desc(explorerCampaign.id))
       .all();
 
+    const destinationsByCampaignId = this.listDestinationsByCampaignIds(
+      campaigns.map((campaign) => campaign.id)
+    );
+
     return campaigns.map((campaign) => ({
       id: campaign.id,
       name: resolveCampaignName(campaign.display_name),
+      displayNameRaw: campaign.display_name,
       startAt: campaign.start_at,
       endAt: campaign.end_at,
       rulesBlurb: campaign.rules_blurb,
-      destinations: this.listDestinations(campaign.id),
+      destinations: destinationsByCampaignId.get(campaign.id) ?? [],
     }));
   }
 

--- a/server/src/services/ExplorerQueryService.ts
+++ b/server/src/services/ExplorerQueryService.ts
@@ -4,7 +4,6 @@ import {
   explorerCampaign,
   explorerDestination,
   explorerDestinationMatch,
-  season,
   segment,
 } from '../db/schema';
 
@@ -26,18 +25,21 @@ interface ExplorerDestinationView {
   displayOrder: number;
 }
 
-interface ActiveExplorerCampaignView {
+interface ExplorerCampaignBaseView {
   id: number;
-  seasonId: number;
   name: string;
-  seasonName: string;
   startAt: number;
   endAt: number;
   rulesBlurb: string | null;
+}
+
+interface ActiveExplorerCampaignView extends ExplorerCampaignBaseView {
   destinations: ExplorerDestinationView[];
 }
 
-type ExplorerAdminCampaignView = ActiveExplorerCampaignView;
+interface ExplorerAdminCampaignView extends ExplorerCampaignBaseView {
+  destinations: ExplorerDestinationView[];
+}
 
 interface ExplorerProgressDestinationView extends ExplorerDestinationView {
   completed: boolean;
@@ -46,15 +48,7 @@ interface ExplorerProgressDestinationView extends ExplorerDestinationView {
 }
 
 interface ExplorerCampaignProgressView {
-  campaign: {
-    id: number;
-    seasonId: number;
-    name: string;
-    seasonName: string;
-    startAt: number;
-    endAt: number;
-    rulesBlurb: string | null;
-  };
+  campaign: ExplorerCampaignBaseView;
   completedDestinations: number;
   totalDestinations: number;
   destinations: ExplorerProgressDestinationView[];
@@ -74,8 +68,8 @@ function resolveDestinationLabel(destination: {
   );
 }
 
-function resolveCampaignName(displayName: string | null, seasonName: string): string {
-  return displayName || seasonName;
+function resolveCampaignName(displayName: string | null): string {
+  return displayName || 'Explorer Campaign';
 }
 
 function resolveSegmentName(destination: {
@@ -89,185 +83,7 @@ function resolveSegmentName(destination: {
 export class ExplorerQueryService {
   constructor(private readonly db: BetterSQLite3Database) {}
 
-  getCampaignForSeason(seasonId: number): ExplorerAdminCampaignView | null {
-    const campaignRecord = this.db
-      .select({
-        id: explorerCampaign.id,
-        season_id: explorerCampaign.season_id,
-        display_name: explorerCampaign.display_name,
-        rules_blurb: explorerCampaign.rules_blurb,
-        season_name: season.name,
-        season_start_at: season.start_at,
-        season_end_at: season.end_at,
-      })
-      .from(explorerCampaign)
-      .innerJoin(season, eq(explorerCampaign.season_id, season.id))
-      .where(eq(explorerCampaign.season_id, seasonId))
-      .get();
-
-    if (!campaignRecord) {
-      return null;
-    }
-
-    const destinations = this.db
-      .select({
-        id: explorerDestination.id,
-        strava_segment_id: explorerDestination.strava_segment_id,
-        display_label: explorerDestination.display_label,
-        cached_name: explorerDestination.cached_name,
-        source_url: explorerDestination.source_url,
-        created_at: explorerDestination.created_at,
-        surface_type: explorerDestination.surface_type,
-        category: explorerDestination.category,
-        display_order: explorerDestination.display_order,
-        segment_name: segment.name,
-        distance: segment.distance,
-        average_grade: segment.average_grade,
-        city: segment.city,
-        state: segment.state,
-        country: segment.country,
-      })
-      .from(explorerDestination)
-      .leftJoin(segment, eq(explorerDestination.strava_segment_id, segment.strava_segment_id))
-      .where(eq(explorerDestination.explorer_campaign_id, campaignRecord.id))
-      .orderBy(asc(explorerDestination.display_order), asc(explorerDestination.id))
-      .all();
-
-    return {
-      id: campaignRecord.id,
-      seasonId: campaignRecord.season_id,
-      name: resolveCampaignName(campaignRecord.display_name, campaignRecord.season_name),
-      seasonName: campaignRecord.season_name,
-      startAt: campaignRecord.season_start_at,
-      endAt: campaignRecord.season_end_at,
-      rulesBlurb: campaignRecord.rules_blurb,
-      destinations: destinations.map((destination) => ({
-        id: destination.id,
-        stravaSegmentId: destination.strava_segment_id,
-        displayLabel: resolveDestinationLabel(destination),
-        customLabel: destination.display_label,
-        segmentName: resolveSegmentName(destination),
-        sourceUrl: destination.source_url,
-        createdAt: destination.created_at,
-        distance: destination.distance,
-        averageGrade: destination.average_grade,
-        city: destination.city,
-        state: destination.state,
-        country: destination.country,
-        surfaceType: destination.surface_type,
-        category: destination.category,
-        displayOrder: destination.display_order,
-      })),
-    };
-  }
-
-  async getActiveCampaign(
-    nowTimestamp: number = Math.floor(Date.now() / 1000)
-  ): Promise<ActiveExplorerCampaignView | null> {
-    const campaignRecords = this.db
-      .select({
-        id: explorerCampaign.id,
-        season_id: explorerCampaign.season_id,
-        display_name: explorerCampaign.display_name,
-        rules_blurb: explorerCampaign.rules_blurb,
-        season_name: season.name,
-        season_start_at: season.start_at,
-        season_end_at: season.end_at,
-      })
-      .from(explorerCampaign)
-      .innerJoin(season, eq(explorerCampaign.season_id, season.id))
-      .where(
-        and(
-          lte(season.start_at, nowTimestamp),
-          gte(season.end_at, nowTimestamp)
-        )
-      )
-      .orderBy(desc(season.start_at))
-      .all();
-
-    for (const campaignRecord of campaignRecords) {
-      const destinations = this.db
-        .select({
-          id: explorerDestination.id,
-          strava_segment_id: explorerDestination.strava_segment_id,
-          display_label: explorerDestination.display_label,
-          cached_name: explorerDestination.cached_name,
-          source_url: explorerDestination.source_url,
-          created_at: explorerDestination.created_at,
-          surface_type: explorerDestination.surface_type,
-          category: explorerDestination.category,
-          display_order: explorerDestination.display_order,
-          segment_name: segment.name,
-          distance: segment.distance,
-          average_grade: segment.average_grade,
-          city: segment.city,
-          state: segment.state,
-          country: segment.country,
-        })
-        .from(explorerDestination)
-        .leftJoin(segment, eq(explorerDestination.strava_segment_id, segment.strava_segment_id))
-        .where(eq(explorerDestination.explorer_campaign_id, campaignRecord.id))
-        .orderBy(asc(explorerDestination.display_order), asc(explorerDestination.id))
-        .all();
-
-      if (destinations.length === 0) {
-        continue;
-      }
-
-      return {
-        id: campaignRecord.id,
-        seasonId: campaignRecord.season_id,
-        name: resolveCampaignName(campaignRecord.display_name, campaignRecord.season_name),
-        seasonName: campaignRecord.season_name,
-        startAt: campaignRecord.season_start_at,
-        endAt: campaignRecord.season_end_at,
-        rulesBlurb: campaignRecord.rules_blurb,
-        destinations: destinations.map((destination) => ({
-          id: destination.id,
-          stravaSegmentId: destination.strava_segment_id,
-          displayLabel: resolveDestinationLabel(destination),
-          customLabel: destination.display_label,
-          segmentName: resolveSegmentName(destination),
-          sourceUrl: destination.source_url,
-          createdAt: destination.created_at,
-          distance: destination.distance,
-          averageGrade: destination.average_grade,
-          city: destination.city,
-          state: destination.state,
-          country: destination.country,
-          surfaceType: destination.surface_type,
-          category: destination.category,
-          displayOrder: destination.display_order,
-        })),
-      };
-    }
-
-    return null;
-  }
-
-  async getCampaignProgress(
-    explorerCampaignId: number,
-    athleteId: string
-  ): Promise<ExplorerCampaignProgressView | null> {
-    const campaignRecord = this.db
-      .select({
-        id: explorerCampaign.id,
-        season_id: explorerCampaign.season_id,
-        display_name: explorerCampaign.display_name,
-        rules_blurb: explorerCampaign.rules_blurb,
-        season_name: season.name,
-        season_start_at: season.start_at,
-        season_end_at: season.end_at,
-      })
-      .from(explorerCampaign)
-      .innerJoin(season, eq(explorerCampaign.season_id, season.id))
-      .where(eq(explorerCampaign.id, explorerCampaignId))
-      .get();
-
-    if (!campaignRecord) {
-      return null;
-    }
-
+  private listDestinations(explorerCampaignId: number): ExplorerDestinationView[] {
     const destinations = this.db
       .select({
         id: explorerDestination.id,
@@ -292,6 +108,110 @@ export class ExplorerQueryService {
       .orderBy(asc(explorerDestination.display_order), asc(explorerDestination.id))
       .all();
 
+    return destinations.map((destination) => ({
+      id: destination.id,
+      stravaSegmentId: destination.strava_segment_id,
+      displayLabel: resolveDestinationLabel(destination),
+      customLabel: destination.display_label,
+      segmentName: resolveSegmentName(destination),
+      sourceUrl: destination.source_url,
+      createdAt: destination.created_at,
+      distance: destination.distance,
+      averageGrade: destination.average_grade,
+      city: destination.city,
+      state: destination.state,
+      country: destination.country,
+      surfaceType: destination.surface_type,
+      category: destination.category,
+      displayOrder: destination.display_order,
+    }));
+  }
+
+  getAdminCampaigns(): ExplorerAdminCampaignView[] {
+    const campaigns = this.db
+      .select({
+        id: explorerCampaign.id,
+        start_at: explorerCampaign.start_at,
+        end_at: explorerCampaign.end_at,
+        display_name: explorerCampaign.display_name,
+        rules_blurb: explorerCampaign.rules_blurb,
+      })
+      .from(explorerCampaign)
+      .orderBy(desc(explorerCampaign.start_at), desc(explorerCampaign.id))
+      .all();
+
+    return campaigns.map((campaign) => ({
+      id: campaign.id,
+      name: resolveCampaignName(campaign.display_name),
+      startAt: campaign.start_at,
+      endAt: campaign.end_at,
+      rulesBlurb: campaign.rules_blurb,
+      destinations: this.listDestinations(campaign.id),
+    }));
+  }
+
+  async getActiveCampaign(
+    nowTimestamp: number = Math.floor(Date.now() / 1000)
+  ): Promise<ActiveExplorerCampaignView | null> {
+    const campaignRecords = this.db
+      .select({
+        id: explorerCampaign.id,
+        start_at: explorerCampaign.start_at,
+        end_at: explorerCampaign.end_at,
+        display_name: explorerCampaign.display_name,
+        rules_blurb: explorerCampaign.rules_blurb,
+      })
+      .from(explorerCampaign)
+      .where(
+        and(
+          lte(explorerCampaign.start_at, nowTimestamp),
+          gte(explorerCampaign.end_at, nowTimestamp)
+        )
+      )
+      .orderBy(desc(explorerCampaign.start_at), desc(explorerCampaign.id))
+      .all();
+
+    for (const campaignRecord of campaignRecords) {
+      const destinations = this.listDestinations(campaignRecord.id);
+
+      if (destinations.length === 0) {
+        continue;
+      }
+
+      return {
+        id: campaignRecord.id,
+        name: resolveCampaignName(campaignRecord.display_name),
+        startAt: campaignRecord.start_at,
+        endAt: campaignRecord.end_at,
+        rulesBlurb: campaignRecord.rules_blurb,
+        destinations,
+      };
+    }
+
+    return null;
+  }
+
+  async getCampaignProgress(
+    explorerCampaignId: number,
+    athleteId: string
+  ): Promise<ExplorerCampaignProgressView | null> {
+    const campaignRecord = this.db
+      .select({
+        id: explorerCampaign.id,
+        start_at: explorerCampaign.start_at,
+        end_at: explorerCampaign.end_at,
+        display_name: explorerCampaign.display_name,
+        rules_blurb: explorerCampaign.rules_blurb,
+      })
+      .from(explorerCampaign)
+      .where(eq(explorerCampaign.id, explorerCampaignId))
+      .get();
+
+    if (!campaignRecord) {
+      return null;
+    }
+
+    const destinations = this.listDestinations(explorerCampaignId);
     const matches = this.db
       .select({
         explorer_destination_id: explorerDestinationMatch.explorer_destination_id,
@@ -308,40 +228,23 @@ export class ExplorerQueryService {
       .all();
 
     const matchesByDestinationId = new Map(matches.map((match) => [match.explorer_destination_id, match]));
-
     const progressDestinations = destinations.map((destination) => {
       const match = matchesByDestinationId.get(destination.id);
 
       return {
-        id: destination.id,
-        stravaSegmentId: destination.strava_segment_id,
-        displayLabel: resolveDestinationLabel(destination),
-        customLabel: destination.display_label,
-        segmentName: resolveSegmentName(destination),
-        sourceUrl: destination.source_url,
-        createdAt: destination.created_at,
-        distance: destination.distance,
-        averageGrade: destination.average_grade,
-        city: destination.city,
-        state: destination.state,
-        country: destination.country,
-        surfaceType: destination.surface_type,
-        category: destination.category,
-        displayOrder: destination.display_order,
+        ...destination,
         completed: Boolean(match),
-        matchedAt: match?.matched_at || null,
-        stravaActivityId: match?.strava_activity_id || null,
+        matchedAt: match?.matched_at ?? null,
+        stravaActivityId: match?.strava_activity_id ?? null,
       };
     });
 
     return {
       campaign: {
         id: campaignRecord.id,
-        seasonId: campaignRecord.season_id,
-        name: resolveCampaignName(campaignRecord.display_name, campaignRecord.season_name),
-        seasonName: campaignRecord.season_name,
-        startAt: campaignRecord.season_start_at,
-        endAt: campaignRecord.season_end_at,
+        name: resolveCampaignName(campaignRecord.display_name),
+        startAt: campaignRecord.start_at,
+        endAt: campaignRecord.end_at,
         rulesBlurb: campaignRecord.rules_blurb,
       },
       completedDestinations: progressDestinations.filter((destination) => destination.completed).length,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -265,12 +265,7 @@ function AppContent() {
             />
           } />
           <Route path="/explorer-admin" element={
-            <ExplorerAdminPanel
-              isAdmin={isAdmin}
-              seasons={seasons}
-              selectedSeasonId={adminSeasonId}
-              onSeasonChange={setAdminSeasonId}
-            />
+            <ExplorerAdminPanel isAdmin={isAdmin} />
           } />
           <Route path="/roles" element={<AdminRoleManager />} />
           <Route path="/participants" element={<ParticipantStatus />} />

--- a/src/components/ExplorerAdminPanel.css
+++ b/src/components/ExplorerAdminPanel.css
@@ -1,6 +1,6 @@
 .explorer-admin-panel {
   width: 100%;
-  max-width: 1080px;
+  max-width: 1120px;
   margin: 0 auto;
   display: flex;
   flex-direction: column;
@@ -8,19 +8,12 @@
 }
 
 .explorer-admin-access-denied,
-.explorer-empty-state,
-.explorer-season-summary {
+.explorer-empty-state {
   background: var(--wmv-white);
   border: 1px solid var(--wmv-border);
-  border-radius: 12px;
+  border-radius: 16px;
   padding: 1.5rem;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
-}
-
-.explorer-card,
-.explorer-preview-card,
-.explorer-destination-card {
-  padding: 1.5rem;
+  box-shadow: 0 12px 32px rgba(15, 23, 42, 0.06);
 }
 
 .explorer-admin-access-denied {
@@ -28,16 +21,39 @@
 }
 
 .explorer-admin-access-denied h2,
-.explorer-empty-state h2,
+.explorer-empty-state h3,
+.explorer-card h2,
 .explorer-card h3,
-.explorer-season-summary h2 {
-  margin: 0 0 0.5rem;
-  color: var(--wmv-purple);
+.explorer-card h4 {
+  margin: 0;
+  color: var(--wmv-text-dark);
+}
+
+.explorer-card {
+  padding: 1.5rem;
+  border-radius: 20px;
+  border: 1px solid rgba(245, 96, 4, 0.14);
+  box-shadow: 0 16px 40px rgba(15, 23, 42, 0.08);
+}
+
+.explorer-admin-hero {
+  display: grid;
+  grid-template-columns: minmax(0, 0.95fr) minmax(0, 1.05fr);
+  gap: 1.25rem;
+  background:
+    radial-gradient(circle at top left, rgba(245, 96, 4, 0.14), transparent 45%),
+    linear-gradient(135deg, rgba(255, 247, 237, 0.92), rgba(255, 255, 255, 0.98));
+}
+
+.explorer-create-shell {
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.98), rgba(255, 247, 237, 0.8)),
+    var(--wmv-white);
 }
 
 .explorer-message {
   padding: 0.9rem 1rem;
-  border-radius: 10px;
+  border-radius: 12px;
   font-weight: 600;
 }
 
@@ -59,29 +75,79 @@
   color: #9a3412;
 }
 
-.explorer-season-summary,
 .explorer-card-header,
-.explorer-preview-header {
+.explorer-preview-header,
+.explorer-campaign-toggle,
+.explorer-campaign-toggle-main {
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
   gap: 1rem;
 }
 
+.explorer-campaign-toggle {
+  width: 100%;
+  padding: 0;
+  border: none;
+  background: transparent;
+  text-align: left;
+  cursor: pointer;
+}
+
+.explorer-campaign-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.explorer-campaign-shell {
+  padding-bottom: 1.25rem;
+  background:
+    linear-gradient(180deg, rgba(255, 251, 235, 0.56), rgba(255, 255, 255, 0.98)),
+    var(--wmv-white);
+}
+
+.explorer-campaign-details {
+  margin-top: 1.25rem;
+  padding: 1.25rem 0 0;
+  border-top: 1px solid rgba(148, 163, 184, 0.22);
+}
+
+.explorer-campaign-editor-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.explorer-campaign-editor-block,
+.explorer-destination-section,
+.explorer-preview-card {
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.92);
+  padding: 1.125rem;
+}
+
+.explorer-destination-section {
+  margin-top: 1rem;
+}
+
 .explorer-section-label {
   margin: 0 0 0.35rem;
   font-size: var(--font-xs);
-  font-weight: 700;
+  font-weight: 800;
   letter-spacing: 0.08em;
   text-transform: uppercase;
   color: var(--wmv-orange);
 }
 
-.explorer-season-window,
 .explorer-card-header p,
 .explorer-muted-copy,
 .explorer-rules-blurb,
-.explorer-destination-meta {
+.explorer-destination-meta,
+.explorer-input-help,
+.explorer-preview-subtitle,
+.explorer-preview-status {
   margin: 0;
   color: var(--wmv-text-light);
 }
@@ -91,6 +157,16 @@
   flex-direction: column;
   gap: 1rem;
   margin-top: 1rem;
+}
+
+.explorer-form-tight {
+  margin-top: 0.875rem;
+}
+
+.explorer-form-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.85rem;
 }
 
 .explorer-form-group {
@@ -108,11 +184,11 @@
 .explorer-form-group textarea {
   width: 100%;
   padding: 0.8rem 0.95rem;
-  border: 1px solid var(--wmv-border);
-  border-radius: 10px;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  border-radius: 12px;
   font-size: var(--font-base);
   color: var(--wmv-text-dark);
-  background: var(--wmv-white);
+  background: rgba(255, 255, 255, 0.98);
 }
 
 .explorer-form-group input:focus,
@@ -122,27 +198,63 @@
   box-shadow: 0 0 0 3px rgba(245, 96, 4, 0.12);
 }
 
+.explorer-form-actions {
+  display: flex;
+  justify-content: flex-start;
+}
+
+.explorer-submit-button {
+  appearance: none;
+  border: none;
+  border-radius: 999px;
+  padding: 0.85rem 1.25rem;
+  background: linear-gradient(135deg, #ea580c, #f97316);
+  color: #fff;
+  font-weight: 700;
+  cursor: pointer;
+  transition: transform 0.18s ease, box-shadow 0.18s ease, opacity 0.18s ease;
+  box-shadow: 0 10px 24px rgba(234, 88, 12, 0.24);
+}
+
+.explorer-submit-button:hover:not(:disabled) {
+  transform: translateY(-1px);
+}
+
+.explorer-submit-button:disabled {
+  opacity: 0.68;
+  cursor: not-allowed;
+}
+
+.explorer-chip-cluster,
+.explorer-destination-chip-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.explorer-chip-icon,
 .explorer-button-icon {
   width: 1rem;
   height: 1rem;
 }
 
-.explorer-spin {
-  animation: explorer-spin 1s linear infinite;
+.explorer-status-chip {
+  border-color: transparent;
 }
 
-.explorer-input-help,
-.explorer-preview-subtitle,
-.explorer-preview-error,
-.explorer-preview-status {
-  margin: 0;
-  font-size: 0.9rem;
+.explorer-status-active {
+  background: rgba(22, 163, 74, 0.12);
+  color: #166534;
 }
 
-.explorer-input-help,
-.explorer-preview-subtitle,
-.explorer-preview-status {
-  color: var(--wmv-text-light);
+.explorer-status-upcoming {
+  background: rgba(234, 88, 12, 0.12);
+  color: #9a3412;
+}
+
+.explorer-status-completed {
+  background: rgba(71, 85, 105, 0.12);
+  color: #334155;
 }
 
 .explorer-preview-status {
@@ -151,22 +263,16 @@
   gap: 0.5rem;
 }
 
+.explorer-inline-status {
+  padding: 0.45rem 0.7rem;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.04);
+}
+
 .explorer-preview-error {
+  margin: 0;
   color: #b91c1c;
   font-weight: 600;
-}
-
-.explorer-preview-card {
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
-  margin-top: 1rem;
-}
-
-.explorer-destination-section {
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
 }
 
 .explorer-preview-actions {
@@ -174,74 +280,23 @@
   gap: 0.75rem;
 }
 
-.explorer-destination-card {
-  margin-top: 1rem;
-}
-
-.explorer-destination-surface {
-  background-color: var(--wmv-white);
-  border-radius: 16px;
-  padding: 24px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
-  border: 1px solid transparent;
-}
-
-.explorer-destination-summary-card {
-  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
-}
-
-.explorer-destination-summary-card:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
-}
-
-.explorer-destination-card[data-expanded='true'] .explorer-destination-summary-card {
-  border-color: var(--wmv-orange);
-}
-
-.explorer-destination-hero-title {
-  margin: 0;
-  font-size: var(--font-2xl);
-  line-height: 1.2;
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  flex-wrap: wrap;
-}
-
-.explorer-destination-list-title {
-  padding-right: 16px;
-}
-
-.explorer-destination-surface-link {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  color: var(--wmv-orange);
-  text-decoration: none;
-}
-
-.explorer-destination-surface-link:hover {
-  text-decoration: underline;
-}
-
-.explorer-destination-surface-link svg {
-  width: 20px;
-  height: 20px;
-}
-
 .explorer-icon-button {
   width: 2.75rem;
   height: 2.75rem;
   border-radius: 999px;
-  border: 1px solid var(--wmv-border);
-  background: var(--wmv-white);
+  border: 1px solid rgba(148, 163, 184, 0.34);
+  background: #fff;
   color: var(--wmv-text-dark);
   display: inline-flex;
   align-items: center;
   justify-content: center;
   cursor: pointer;
-  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+  transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease;
+}
+
+.explorer-icon-button:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 8px 18px rgba(15, 23, 42, 0.08);
 }
 
 .explorer-icon-button svg {
@@ -249,20 +304,9 @@
   height: 1.25rem;
 }
 
-.explorer-icon-button:hover {
-  transform: translateY(-1px);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
-}
-
 .explorer-icon-button-accept {
   border-color: #86efac;
   color: #166534;
-}
-
-.explorer-icon-button-accept:disabled,
-.explorer-icon-button-reject:disabled {
-  cursor: not-allowed;
-  opacity: 0.6;
 }
 
 .explorer-icon-button-reject {
@@ -270,11 +314,25 @@
   color: #b91c1c;
 }
 
-.explorer-destination-chip-row {
+.explorer-icon-button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.explorer-destination-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
   display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-  margin-top: 8px;
+  flex-direction: column;
+  gap: 0.85rem;
+}
+
+.explorer-destination-card {
+  border-radius: 16px;
+  overflow: hidden;
+  background: rgba(248, 250, 252, 0.78);
+  border: 1px solid rgba(148, 163, 184, 0.16);
 }
 
 .explorer-destination-summary {
@@ -287,40 +345,61 @@
   outline: none;
 }
 
-.explorer-destination-list {
-  list-style: none;
+.explorer-destination-surface {
+  background-color: transparent;
+  padding: 1.1rem 1.15rem;
+}
+
+.explorer-destination-summary-card {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: flex-start;
+  transition: background-color 0.18s ease;
+}
+
+.explorer-destination-card[data-expanded='true'] .explorer-destination-summary-card {
+  background: rgba(255, 247, 237, 0.92);
+}
+
+.explorer-destination-hero-title {
   margin: 0;
-  padding: 0;
+  font-size: var(--font-xl);
+  line-height: 1.2;
+}
+
+.explorer-destination-list-title {
+  padding-right: 0.75rem;
+}
+
+.explorer-destination-surface-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  color: var(--wmv-orange);
+  text-decoration: none;
+}
+
+.explorer-destination-surface-link:hover {
+  text-decoration: underline;
+}
+
+.explorer-destination-surface-link svg {
+  width: 1rem;
+  height: 1rem;
 }
 
 .explorer-destination-label {
   color: var(--wmv-text-dark);
-  font-weight: 600;
-  font-size: var(--font-2xl);
-  line-height: 1.2;
-}
-
-.explorer-destination-meta {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.35rem;
-  margin: 0;
-  color: var(--wmv-text-light);
-  font-size: var(--font-sm);
-}
-
-.explorer-destination-meta svg {
-  width: 0.95rem;
-  height: 0.95rem;
-  flex-shrink: 0;
+  font-weight: 700;
 }
 
 .explorer-destination-chevron {
   flex-shrink: 0;
-  width: 24px;
-  height: 24px;
+  width: 1.4rem;
+  height: 1.4rem;
   color: var(--wmv-text-light);
-  transition: transform 0.2s ease;
+  transition: transform 0.18s ease;
 }
 
 .explorer-destination-chevron.is-expanded {
@@ -328,13 +407,13 @@
 }
 
 .explorer-destination-details {
-  margin: -8px 16px 16px;
-  border: 1px solid var(--wmv-border);
-  border-top: none;
-  border-bottom-left-radius: 16px;
-  border-bottom-right-radius: 16px;
-  background-color: #f9fafb;
-  padding-top: 32px;
+  padding: 0 1.15rem 1rem;
+}
+
+.explorer-destination-detail-block {
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
 }
 
 .explorer-destination-detail-row {
@@ -344,10 +423,17 @@
   align-items: center;
 }
 
-.explorer-destination-detail-block {
-  display: flex;
-  flex-direction: column;
-  gap: 0.65rem;
+.explorer-destination-meta {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: var(--font-sm);
+}
+
+.explorer-destination-meta svg {
+  width: 0.95rem;
+  height: 0.95rem;
+  flex-shrink: 0;
 }
 
 .explorer-detail-label {
@@ -357,6 +443,10 @@
   letter-spacing: 0.08em;
   text-transform: uppercase;
   color: var(--wmv-text-light);
+}
+
+.explorer-spin {
+  animation: explorer-spin 1s linear infinite;
 }
 
 @keyframes explorer-spin {
@@ -369,25 +459,25 @@
   }
 }
 
+@media (max-width: 900px) {
+  .explorer-admin-hero,
+  .explorer-campaign-editor-grid,
+  .explorer-form-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
 @media (max-width: 768px) {
-  .explorer-season-summary,
   .explorer-card-header,
   .explorer-preview-header,
+  .explorer-campaign-toggle,
+  .explorer-campaign-toggle-main,
   .explorer-destination-summary-card {
     flex-direction: column;
-  }
-
-  .explorer-destination-surface {
-    padding: 20px;
   }
 
   .explorer-preview-actions {
     width: 100%;
     justify-content: flex-start;
-  }
-
-  .explorer-destination-hero-title,
-  .explorer-destination-label {
-    font-size: var(--font-xl);
   }
 }

--- a/src/components/ExplorerAdminPanel.tsx
+++ b/src/components/ExplorerAdminPanel.tsx
@@ -66,6 +66,7 @@ interface AdminCampaignDestination {
 interface AdminCampaign {
   id: number;
   name: string;
+  displayNameRaw: string | null;
   startAt: number;
   endAt: number;
   rulesBlurb: string | null;
@@ -154,7 +155,7 @@ function createEmptyCampaignForm(): CampaignFormState {
 
 function createCampaignFormFromRecord(campaign: AdminCampaign): CampaignFormState {
   return {
-    displayName: campaign.name === 'Explorer Campaign' ? '' : campaign.name,
+    displayName: campaign.displayNameRaw ?? '',
     rulesBlurb: campaign.rulesBlurb ?? '',
     startDate: unixToDateLocal(campaign.startAt),
     endDate: unixToDateLocal(campaign.endAt),

--- a/src/components/ExplorerAdminPanel.tsx
+++ b/src/components/ExplorerAdminPanel.tsx
@@ -1,30 +1,40 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState, type FormEvent } from 'react';
 import {
   ArrowPathIcon,
   ArrowTopRightOnSquareIcon,
-  ChevronDownIcon,
+  CalendarDaysIcon,
   CheckIcon,
+  ChevronDownIcon,
   ClockIcon,
+  PencilSquareIcon,
   XMarkIcon,
 } from '@heroicons/react/24/outline';
-import type { Season } from '../types';
 import { trpc } from '../utils/trpc';
-import { formatUnixDate, formatUtcIsoDateTime } from '../utils/dateUtils';
-import SeasonSelector from './SeasonSelector';
+import {
+  dateToUnixEnd,
+  dateToUnixStart,
+  formatUnixDate,
+  formatUtcIsoDateTime,
+  unixToDateLocal,
+} from '../utils/dateUtils';
 import './AdminPanel.css';
 import './Card.css';
 import './ExplorerAdminPanel.css';
 
 interface ExplorerAdminPanelProps {
   isAdmin: boolean;
-  seasons: Season[];
-  selectedSeasonId: number | null;
-  onSeasonChange: (seasonId: number) => void;
 }
 
 interface FlashMessage {
   type: 'success' | 'error' | 'info';
   text: string;
+}
+
+interface CampaignFormState {
+  displayName: string;
+  rulesBlurb: string;
+  startDate: string;
+  endDate: string;
 }
 
 interface PreviewDestination {
@@ -35,6 +45,31 @@ interface PreviewDestination {
   city?: string | null;
   state?: string | null;
   country?: string | null;
+}
+
+interface AdminCampaignDestination {
+  id: number;
+  displayLabel: string;
+  customLabel: string | null;
+  segmentName: string;
+  displayOrder: number;
+  sourceUrl: string | null;
+  stravaSegmentId: string;
+  createdAt: string | null;
+  distance: number | null;
+  averageGrade: number | null;
+  city: string | null;
+  state: string | null;
+  country: string | null;
+}
+
+interface AdminCampaign {
+  id: number;
+  name: string;
+  startAt: number;
+  endAt: number;
+  rulesBlurb: string | null;
+  destinations: AdminCampaignDestination[];
 }
 
 function parseSegmentId(sourceUrl: string): string | null {
@@ -108,30 +143,64 @@ function getDestinationStatItems({
   return statItems;
 }
 
-function ExplorerAdminPanel({
-  isAdmin,
-  seasons,
-  selectedSeasonId,
-  onSeasonChange,
-}: ExplorerAdminPanelProps) {
+function createEmptyCampaignForm(): CampaignFormState {
+  return {
+    displayName: '',
+    rulesBlurb: '',
+    startDate: '',
+    endDate: '',
+  };
+}
+
+function createCampaignFormFromRecord(campaign: AdminCampaign): CampaignFormState {
+  return {
+    displayName: campaign.name === 'Explorer Campaign' ? '' : campaign.name,
+    rulesBlurb: campaign.rulesBlurb ?? '',
+    startDate: unixToDateLocal(campaign.startAt),
+    endDate: unixToDateLocal(campaign.endAt),
+  };
+}
+
+function getCampaignStatus(campaign: AdminCampaign, nowTimestamp: number): 'active' | 'upcoming' | 'completed' {
+  if (campaign.startAt <= nowTimestamp && campaign.endAt >= nowTimestamp) {
+    return 'active';
+  }
+
+  if (campaign.startAt > nowTimestamp) {
+    return 'upcoming';
+  }
+
+  return 'completed';
+}
+
+function getCampaignStatusLabel(status: 'active' | 'upcoming' | 'completed'): string {
+  if (status === 'active') {
+    return 'Active now';
+  }
+
+  if (status === 'upcoming') {
+    return 'Upcoming';
+  }
+
+  return 'Completed';
+}
+
+function ExplorerAdminPanel({ isAdmin }: ExplorerAdminPanelProps) {
   const utils = trpc.useUtils();
   const messageTimeoutRef = useRef<number | null>(null);
   const previewRequestIdRef = useRef(0);
-  const [campaignForm, setCampaignForm] = useState({
-    displayName: '',
-    rulesBlurb: '',
-  });
-  const [destinationForm, setDestinationForm] = useState({ sourceUrl: '' });
+  const nowTimestamp = Math.floor(Date.now() / 1000);
+
+  const [createForm, setCreateForm] = useState<CampaignFormState>(() => createEmptyCampaignForm());
+  const [campaignForms, setCampaignForms] = useState<Record<number, CampaignFormState>>({});
+  const [destinationSourceByCampaign, setDestinationSourceByCampaign] = useState<Record<number, string>>({});
   const [destinationPreview, setDestinationPreview] = useState<PreviewDestination | null>(null);
+  const [previewCampaignId, setPreviewCampaignId] = useState<number | null>(null);
   const [previewError, setPreviewError] = useState<string | null>(null);
   const [isValidatingPreview, setIsValidatingPreview] = useState(false);
+  const [expandedCampaignId, setExpandedCampaignId] = useState<number | null>(null);
   const [expandedDestinationId, setExpandedDestinationId] = useState<number | null>(null);
   const [message, setMessage] = useState<FlashMessage | null>(null);
-
-  const hasSelectedSeason =
-    selectedSeasonId !== null && seasons.some((season) => season.id === selectedSeasonId);
-  const resolvedSeasonId = hasSelectedSeason ? selectedSeasonId : seasons[0]?.id ?? null;
-  const selectedSeason = seasons.find((season) => season.id === resolvedSeasonId) || null;
 
   useEffect(() => {
     return () => {
@@ -141,15 +210,37 @@ function ExplorerAdminPanel({
     };
   }, []);
 
-  const campaignQuery = trpc.explorerAdmin.getCampaignForSeason.useQuery(
-    { seasonId: resolvedSeasonId ?? 0 },
-    {
-      enabled: isAdmin && resolvedSeasonId !== null,
-      refetchOnWindowFocus: false,
-    }
-  );
+  const campaignsQuery = trpc.explorerAdmin.getCampaigns.useQuery(undefined, {
+    enabled: isAdmin,
+    refetchOnWindowFocus: false,
+  });
 
-  const setTimedMessage = (nextMessage: FlashMessage, timeoutMs: number = 5000) => {
+  const campaigns = useMemo(() => (campaignsQuery.data ?? []) as AdminCampaign[], [campaignsQuery.data]);
+
+  useEffect(() => {
+    if (campaigns.length > 0 && expandedCampaignId == null) {
+      setExpandedCampaignId(campaigns[0].id);
+    }
+  }, [campaigns, expandedCampaignId]);
+
+  useEffect(() => {
+    if (campaigns.length === 0) {
+      setCampaignForms({});
+      return;
+    }
+
+    setCampaignForms((current) => {
+      const next: Record<number, CampaignFormState> = {};
+
+      for (const campaign of campaigns) {
+        next[campaign.id] = current[campaign.id] ?? createCampaignFormFromRecord(campaign);
+      }
+
+      return next;
+    });
+  }, [campaigns]);
+
+  const setTimedMessage = (nextMessage: FlashMessage, timeoutMs = 5000) => {
     setMessage(nextMessage);
 
     if (messageTimeoutRef.current !== null) {
@@ -163,10 +254,21 @@ function ExplorerAdminPanel({
   };
 
   const createCampaignMutation = trpc.explorerAdmin.createCampaign.useMutation({
+    onSuccess: async (campaign) => {
+      await utils.explorerAdmin.getCampaigns.invalidate();
+      setCreateForm(createEmptyCampaignForm());
+      setExpandedCampaignId(campaign.id);
+      setTimedMessage({ type: 'success', text: 'Explorer campaign created.' });
+    },
+    onError: (error) => {
+      setTimedMessage({ type: 'error', text: error.message });
+    },
+  });
+
+  const updateCampaignMutation = trpc.explorerAdmin.updateCampaign.useMutation({
     onSuccess: async () => {
-      await utils.explorerAdmin.getCampaignForSeason.invalidate({ seasonId: resolvedSeasonId ?? 0 });
-      setCampaignForm({ displayName: '', rulesBlurb: '' });
-      setTimedMessage({ type: 'success', text: 'Explorer campaign created for the selected season.' });
+      await utils.explorerAdmin.getCampaigns.invalidate();
+      setTimedMessage({ type: 'success', text: 'Explorer campaign updated.' });
     },
     onError: (error) => {
       setTimedMessage({ type: 'error', text: error.message });
@@ -175,8 +277,11 @@ function ExplorerAdminPanel({
 
   const addDestinationMutation = trpc.explorerAdmin.addDestination.useMutation({
     onSuccess: async (destination) => {
-      await utils.explorerAdmin.getCampaignForSeason.invalidate({ seasonId: resolvedSeasonId ?? 0 });
-      setDestinationForm({ sourceUrl: '' });
+      await utils.explorerAdmin.getCampaigns.invalidate();
+      if (previewCampaignId != null) {
+        setDestinationSourceByCampaign((current) => ({ ...current, [previewCampaignId]: '' }));
+      }
+      previewRequestIdRef.current += 1;
       setDestinationPreview(null);
       setPreviewError(null);
       setExpandedDestinationId(destination.id);
@@ -193,131 +298,118 @@ function ExplorerAdminPanel({
     },
   });
 
-  const handleCreateCampaign = async (event: React.FormEvent) => {
-    event.preventDefault();
-
-    if (!resolvedSeasonId) {
-      setTimedMessage({ type: 'error', text: 'Select a season before creating an Explorer campaign.' });
-      return;
-    }
-
-    await createCampaignMutation.mutateAsync({
-      seasonId: resolvedSeasonId,
-      displayName: campaignForm.displayName.trim() || null,
-      rulesBlurb: campaignForm.rulesBlurb.trim() || null,
-    });
-  };
-
-  const requestDestinationPreview = useCallback(async () => {
-    const trimmedSourceUrl = destinationForm.sourceUrl.trim();
-    const requestId = previewRequestIdRef.current + 1;
-
-    previewRequestIdRef.current = requestId;
-
-    if (!trimmedSourceUrl) {
-      setDestinationPreview(null);
-      setPreviewError(null);
-      return;
-    }
-
-    const parsedSegmentId = parseSegmentId(trimmedSourceUrl);
-
-    if (!parsedSegmentId) {
-      setDestinationPreview(null);
-      setPreviewError('Please provide a valid Strava segment URL');
-      return;
-    }
-
-    setIsValidatingPreview(true);
-    setPreviewError(null);
-
-    try {
-      const segment = await utils.client.segment.validate.query(parsedSegmentId);
-
-      if (previewRequestIdRef.current !== requestId || destinationForm.sourceUrl.trim() !== trimmedSourceUrl) {
-        return;
-      }
-
-      if (!segment) {
-        throw new Error('Segment metadata could not be loaded');
-      }
-
-      setDestinationPreview({
-        sourceUrl: trimmedSourceUrl,
-        name: segment.name,
-        distance: segment.distance,
-        averageGrade: segment.average_grade,
-        city: segment.city,
-        state: segment.state,
-        country: segment.country,
-      });
-    } catch (error) {
-      if (previewRequestIdRef.current !== requestId || destinationForm.sourceUrl.trim() !== trimmedSourceUrl) {
-        return;
-      }
-
-      const errorMessage = error instanceof Error ? error.message : 'Segment metadata could not be loaded';
-      setDestinationPreview(null);
-      setPreviewError(errorMessage);
-    } finally {
-      if (previewRequestIdRef.current === requestId) {
-        setIsValidatingPreview(false);
-      }
-    }
-  }, [destinationForm.sourceUrl, utils.client.segment.validate]);
-
-  const handleAcceptPreview = async () => {
-    if (!destinationPreview) {
-      return;
-    }
-
-    if (!campaignQuery.data) {
-      setTimedMessage({ type: 'error', text: 'Create a campaign before adding Explorer destinations.' });
-      return;
-    }
-
-    await addDestinationMutation.mutateAsync({
-      explorerCampaignId: campaignQuery.data.id,
-      sourceUrl: destinationPreview.sourceUrl,
-    });
-  };
-
   useEffect(() => {
-    if (!campaignQuery.data) {
-      return;
-    }
+    const sourceUrl = expandedCampaignId != null ? destinationSourceByCampaign[expandedCampaignId]?.trim() ?? '' : '';
 
-    const trimmedSourceUrl = destinationForm.sourceUrl.trim();
-
-    if (!trimmedSourceUrl) {
+    if (!expandedCampaignId || !sourceUrl) {
       previewRequestIdRef.current += 1;
       setDestinationPreview(null);
       setPreviewError(null);
+      setIsValidatingPreview(false);
       return;
     }
 
+    const parsedSegmentId = parseSegmentId(sourceUrl);
+    if (!parsedSegmentId) {
+      previewRequestIdRef.current += 1;
+      setDestinationPreview(null);
+      setPreviewCampaignId(expandedCampaignId);
+      setPreviewError('Please provide a valid Strava segment URL');
+      setIsValidatingPreview(false);
+      return;
+    }
+
+    const requestId = previewRequestIdRef.current + 1;
+    previewRequestIdRef.current = requestId;
+    setPreviewCampaignId(expandedCampaignId);
+    setIsValidatingPreview(true);
+    setPreviewError(null);
+
     const previewTimeout = window.setTimeout(() => {
-      void requestDestinationPreview();
+      void utils.client.segment.validate.query(parsedSegmentId)
+        .then((segment) => {
+          if (previewRequestIdRef.current !== requestId) {
+            return;
+          }
+
+          if (!segment) {
+            throw new Error('Segment metadata could not be loaded');
+          }
+
+          setDestinationPreview({
+            sourceUrl,
+            name: segment.name,
+            distance: segment.distance,
+            averageGrade: segment.average_grade,
+            city: segment.city,
+            state: segment.state,
+            country: segment.country,
+          });
+        })
+        .catch((error: unknown) => {
+          if (previewRequestIdRef.current !== requestId) {
+            return;
+          }
+
+          const errorMessage = error instanceof Error ? error.message : 'Segment metadata could not be loaded';
+          setDestinationPreview(null);
+          setPreviewError(errorMessage);
+        })
+        .finally(() => {
+          if (previewRequestIdRef.current === requestId) {
+            setIsValidatingPreview(false);
+          }
+        });
     }, 150);
 
     return () => {
       window.clearTimeout(previewTimeout);
     };
-  }, [campaignQuery.data, destinationForm.sourceUrl, requestDestinationPreview]);
+  }, [destinationSourceByCampaign, expandedCampaignId, utils.client.segment.validate]);
 
-  const sortedDestinations = campaignQuery.data
-    ? [...campaignQuery.data.destinations].sort((left, right) => {
-        if (left.createdAt && right.createdAt && left.createdAt !== right.createdAt) {
-          return right.createdAt.localeCompare(left.createdAt);
-        }
+  const handleCreateCampaign = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
 
-        if (left.displayOrder !== right.displayOrder) {
-          return right.displayOrder - left.displayOrder;
-        }
+    if (!createForm.startDate || !createForm.endDate) {
+      setTimedMessage({ type: 'error', text: 'Enter start and end dates for the Explorer campaign.' });
+      return;
+    }
 
-        return right.id - left.id;
-      })
-    : [];
+    await createCampaignMutation.mutateAsync({
+      startAt: dateToUnixStart(createForm.startDate),
+      endAt: dateToUnixEnd(createForm.endDate),
+      displayName: createForm.displayName.trim() || null,
+      rulesBlurb: createForm.rulesBlurb.trim() || null,
+    });
+  };
+
+  const handleSaveCampaign = async (campaignId: number) => {
+    const formState = campaignForms[campaignId];
+
+    if (!formState?.startDate || !formState.endDate) {
+      setTimedMessage({ type: 'error', text: 'Enter start and end dates before saving the campaign.' });
+      return;
+    }
+
+    await updateCampaignMutation.mutateAsync({
+      explorerCampaignId: campaignId,
+      startAt: dateToUnixStart(formState.startDate),
+      endAt: dateToUnixEnd(formState.endDate),
+      displayName: formState.displayName.trim() || null,
+      rulesBlurb: formState.rulesBlurb.trim() || null,
+    });
+  };
+
+  const handleAcceptPreview = async () => {
+    if (!destinationPreview || previewCampaignId == null) {
+      return;
+    }
+
+    await addDestinationMutation.mutateAsync({
+      explorerCampaignId: previewCampaignId,
+      sourceUrl: destinationPreview.sourceUrl,
+    });
+  };
 
   if (!isAdmin) {
     return (
@@ -338,335 +430,487 @@ function ExplorerAdminPanel({
         </div>
       ) : null}
 
-      {seasons.length > 0 ? (
-        <div className="admin-season-selector-wrapper">
-          <SeasonSelector
-            seasons={seasons}
-            selectedSeasonId={resolvedSeasonId}
-            setSelectedSeasonId={onSeasonChange}
-          />
+      <section className="leaderboard-card explorer-card explorer-admin-hero" data-testid="explorer-admin-hero">
+        <div>
+          <p className="explorer-section-label">Explorer admin</p>
+          <h2>Campaign editor</h2>
         </div>
-      ) : null}
+        <p className="explorer-muted-copy">
+          Explorer campaigns now manage their own date windows. Create one campaign at a time, keep date ranges non-overlapping, and add destinations directly inside the active card.
+        </p>
+      </section>
 
-      {seasons.length === 0 ? (
-        <div className="explorer-empty-state">
-          <h2>No seasons available</h2>
-          <p>Create a season before setting up an Explorer campaign.</p>
+      <section className="leaderboard-card explorer-card explorer-create-shell" data-testid="explorer-create-campaign-card">
+        <div className="explorer-card-header">
+          <div>
+            <p className="explorer-section-label">New campaign</p>
+            <h3>Create Explorer Campaign</h3>
+          </div>
+          <p>Start the next Explorer campaign with its own dates, then add destinations inside the campaign card below.</p>
         </div>
-      ) : !selectedSeason ? (
-        <div className="explorer-empty-state">
-          <h2>Select a season</h2>
-          <p>Choose a season before managing an Explorer campaign.</p>
-        </div>
-      ) : (
-        <>
-          <section className="leaderboard-card explorer-season-summary" data-testid="explorer-season-summary">
-            <div>
-              <p className="explorer-section-label">Selected season</p>
-              <h2>{selectedSeason.name}</h2>
+
+        <form
+          className="explorer-form"
+          data-testid="explorer-create-campaign-form"
+          onSubmit={(event) => {
+            void handleCreateCampaign(event);
+          }}
+        >
+          <div className="explorer-form-grid">
+            <div className="explorer-form-group">
+              <label htmlFor="explorer-display-name">Display name</label>
+              <input
+                id="explorer-display-name"
+                data-testid="explorer-display-name-input"
+                value={createForm.displayName}
+                onChange={(event) => {
+                  setCreateForm((current) => ({ ...current, displayName: event.target.value }));
+                }}
+                placeholder="Optional campaign name"
+                maxLength={255}
+              />
             </div>
-            <p className="explorer-season-window">
-              {formatUnixDate(selectedSeason.start_at)} to {formatUnixDate(selectedSeason.end_at)}
-            </p>
-          </section>
 
-          {campaignQuery.isLoading ? (
-            <section className="leaderboard-card explorer-card">
-              <p className="explorer-muted-copy">Loading Explorer campaign…</p>
-            </section>
-          ) : campaignQuery.data == null ? (
-            <section className="leaderboard-card explorer-card" data-testid="explorer-create-campaign-card">
-              <div className="explorer-card-header">
-                <div>
-                  <p className="explorer-section-label">Phase 4B setup</p>
-                  <h3>Create Explorer Campaign</h3>
-                </div>
-                <p>Start with a campaign shell for this season, then add destinations below.</p>
-              </div>
+            <div className="explorer-form-group">
+              <label htmlFor="explorer-start-date">Start date</label>
+              <input
+                id="explorer-start-date"
+                data-testid="explorer-start-date-input"
+                type="date"
+                value={createForm.startDate}
+                onChange={(event) => {
+                  setCreateForm((current) => ({ ...current, startDate: event.target.value }));
+                }}
+                required
+              />
+            </div>
 
-              <form className="explorer-form" data-testid="explorer-create-campaign-form" onSubmit={(event) => {
-                void handleCreateCampaign(event);
-              }}>
-                <div className="explorer-form-group">
-                  <label htmlFor="explorer-display-name">Display name</label>
-                  <input
-                    id="explorer-display-name"
-                    data-testid="explorer-display-name-input"
-                    value={campaignForm.displayName}
-                    onChange={(event) => {
-                      setCampaignForm((current) => ({ ...current, displayName: event.target.value }));
-                    }}
-                    placeholder={`Defaults to ${selectedSeason.name}`}
-                    maxLength={255}
-                  />
-                </div>
+            <div className="explorer-form-group">
+              <label htmlFor="explorer-end-date">End date</label>
+              <input
+                id="explorer-end-date"
+                data-testid="explorer-end-date-input"
+                type="date"
+                value={createForm.endDate}
+                onChange={(event) => {
+                  setCreateForm((current) => ({ ...current, endDate: event.target.value }));
+                }}
+                required
+              />
+            </div>
+          </div>
 
-                <div className="explorer-form-group">
-                  <label htmlFor="explorer-rules-blurb">Rules blurb</label>
-                  <textarea
-                    id="explorer-rules-blurb"
-                    data-testid="explorer-rules-blurb-input"
-                    value={campaignForm.rulesBlurb}
-                    onChange={(event) => {
-                      setCampaignForm((current) => ({ ...current, rulesBlurb: event.target.value }));
-                    }}
-                    placeholder="Optional guidance shown alongside the Explorer campaign"
-                    rows={4}
-                    maxLength={2000}
-                  />
-                </div>
+          <div className="explorer-form-group">
+            <label htmlFor="explorer-rules-blurb">Rules blurb</label>
+            <textarea
+              id="explorer-rules-blurb"
+              data-testid="explorer-rules-blurb-input"
+              value={createForm.rulesBlurb}
+              onChange={(event) => {
+                setCreateForm((current) => ({ ...current, rulesBlurb: event.target.value }));
+              }}
+              placeholder="Optional guidance shown alongside the Explorer campaign"
+              rows={4}
+              maxLength={2000}
+            />
+          </div>
 
-                <div className="explorer-form-actions">
-                  <button
-                    type="submit"
-                    className="explorer-submit-button"
-                    data-testid="explorer-create-campaign-button"
-                    disabled={createCampaignMutation.isPending}
-                  >
-                    {createCampaignMutation.isPending ? 'Creating...' : 'Create Explorer Campaign'}
-                  </button>
-                </div>
-              </form>
-            </section>
-          ) : (
-            <>
-              <section className="leaderboard-card explorer-card" data-testid="explorer-campaign-summary-card">
-                <div className="explorer-card-header">
-                  <div>
-                    <p className="explorer-section-label">Explorer campaign</p>
-                    <h3 data-testid="explorer-campaign-name">{campaignQuery.data.name}</h3>
+          <div className="explorer-form-actions">
+            <button
+              type="submit"
+              className="explorer-submit-button"
+              data-testid="explorer-create-campaign-button"
+              disabled={createCampaignMutation.isPending}
+            >
+              {createCampaignMutation.isPending ? 'Creating...' : 'Create Explorer Campaign'}
+            </button>
+          </div>
+        </form>
+      </section>
+
+      {campaignsQuery.isLoading ? (
+        <section className="leaderboard-card explorer-card">
+          <p className="explorer-muted-copy">Loading Explorer campaigns...</p>
+        </section>
+      ) : campaigns.length === 0 ? (
+        <section className="leaderboard-card explorer-card" data-testid="explorer-empty-state">
+          <h3>No Explorer campaigns yet</h3>
+          <p className="explorer-muted-copy">Create the first campaign above to begin destination authoring.</p>
+        </section>
+      ) : (
+        <section className="explorer-campaign-stack" data-testid="explorer-campaign-stack">
+          {campaigns.map((campaign) => {
+            const isExpanded = expandedCampaignId === campaign.id;
+            const campaignForm = campaignForms[campaign.id] ?? createCampaignFormFromRecord(campaign);
+            const destinationSource = destinationSourceByCampaign[campaign.id] ?? '';
+            const destinationPreviewVisible = previewCampaignId === campaign.id ? destinationPreview : null;
+            const previewErrorVisible = previewCampaignId === campaign.id ? previewError : null;
+            const isPreviewLoading = previewCampaignId === campaign.id && isValidatingPreview;
+            const status = getCampaignStatus(campaign, nowTimestamp);
+
+            return (
+              <article
+                key={campaign.id}
+                className="leaderboard-card explorer-card explorer-campaign-shell"
+                data-testid={`explorer-campaign-card-${campaign.id}`}
+              >
+                <button
+                  type="button"
+                  className="explorer-campaign-toggle"
+                  data-testid={`explorer-campaign-toggle-${campaign.id}`}
+                  aria-expanded={isExpanded}
+                  onClick={() => {
+                    setExpandedCampaignId((current) => current === campaign.id ? null : campaign.id);
+                    setPreviewCampaignId(campaign.id);
+                    setDestinationPreview(null);
+                    setPreviewError(null);
+                  }}
+                >
+                  <div className="explorer-campaign-toggle-main">
+                    <div>
+                      <p className="explorer-section-label">Explorer campaign</p>
+                      <h3 data-testid={campaign.id === campaigns[0]?.id ? 'explorer-campaign-name' : undefined}>{campaign.name}</h3>
+                    </div>
+                    <div className="explorer-chip-cluster">
+                      <span className={`week-header-chip explorer-status-chip explorer-status-${status}`}>
+                        {getCampaignStatusLabel(status)}
+                      </span>
+                      <span className="week-header-chip">
+                        <CalendarDaysIcon className="explorer-chip-icon" aria-hidden="true" />
+                        {formatUnixDate(campaign.startAt, { month: 'short', day: 'numeric', year: 'numeric' })} to {formatUnixDate(campaign.endAt, { month: 'short', day: 'numeric', year: 'numeric' })}
+                      </span>
+                      <span className="week-header-chip">{campaign.destinations.length} destination{campaign.destinations.length === 1 ? '' : 's'}</span>
+                    </div>
                   </div>
-                  <p>
-                    {campaignQuery.data.destinations.length} destination{campaignQuery.data.destinations.length === 1 ? '' : 's'}
-                  </p>
-                </div>
+                  <ChevronDownIcon className={`explorer-destination-chevron${isExpanded ? ' is-expanded' : ''}`} aria-hidden="true" />
+                </button>
 
-                {campaignQuery.data.rulesBlurb ? (
-                  <p className="explorer-rules-blurb" data-testid="explorer-campaign-rules-blurb">
-                    {campaignQuery.data.rulesBlurb}
-                  </p>
-                ) : (
-                  <p className="explorer-muted-copy">No rules blurb has been added yet.</p>
-                )}
-              </section>
+                {isExpanded ? (
+                  <div className="card-expanded-details explorer-campaign-details">
+                    <div className="explorer-campaign-editor-grid">
+                      <section className="explorer-campaign-editor-block">
+                        <div className="explorer-card-header">
+                          <div>
+                            <p className="explorer-section-label">Campaign details</p>
+                            <h4>Edit campaign window</h4>
+                          </div>
+                          <span className="explorer-preview-status explorer-inline-status">
+                            <PencilSquareIcon className="explorer-button-icon" aria-hidden="true" />
+                            <span>One campaign card at a time</span>
+                          </span>
+                        </div>
 
-              <section className="leaderboard-card explorer-card" data-testid="explorer-add-destination-card">
-                <div className="explorer-card-header">
-                  <div>
-                    <p className="explorer-section-label">Destination authoring</p>
-                    <h3>Add Destination</h3>
-                  </div>
-                  <p>Paste a Strava segment URL and Explorer will validate it into a quick add preview automatically.</p>
-                </div>
-
-                <div className="explorer-form" data-testid="explorer-add-destination-form">
-                  <div className="explorer-form-group">
-                    <label htmlFor="explorer-source-url">Strava segment URL</label>
-                    <input
-                      id="explorer-source-url"
-                      data-testid="explorer-source-url-input"
-                      value={destinationForm.sourceUrl}
-                      onChange={(event) => {
-                        setDestinationForm({ sourceUrl: event.target.value });
-                        setDestinationPreview(null);
-                        setPreviewError(null);
-                      }}
-                      placeholder="https://www.strava.com/segments/2234642"
-                      required
-                    />
-                    <p className="explorer-input-help">
-                      Explorer keeps the original Strava URL and previews the segment automatically as you paste.
-                    </p>
-                  </div>
-
-                  {isValidatingPreview ? (
-                    <p className="explorer-preview-status" data-testid="explorer-preview-status">
-                      <ArrowPathIcon className="explorer-button-icon explorer-spin" aria-hidden="true" />
-                      <span>Validating segment...</span>
-                    </p>
-                  ) : null}
-
-                  {previewError ? (
-                    <p className="explorer-preview-error" data-testid="explorer-preview-error">
-                      {previewError}
-                    </p>
-                  ) : null}
-
-                  {destinationPreview ? (
-                    (() => {
-                      const previewStatItems = getDestinationStatItems(destinationPreview);
-
-                      return (
-                        <article className="explorer-preview-card" data-testid="explorer-destination-preview-card">
-                          <div className="explorer-preview-header">
-                            <p className="explorer-section-label">Preview</p>
-                            <div className="explorer-preview-actions">
-                              <button
-                                type="button"
-                                className="explorer-icon-button explorer-icon-button-accept"
-                                data-testid="explorer-accept-preview-button"
-                                aria-label="Accept destination preview"
-                                onClick={() => {
-                                  void handleAcceptPreview();
+                        <div className="explorer-form explorer-form-tight">
+                          <div className="explorer-form-grid">
+                            <div className="explorer-form-group">
+                              <label htmlFor={`explorer-campaign-name-${campaign.id}`}>Display name</label>
+                              <input
+                                id={`explorer-campaign-name-${campaign.id}`}
+                                data-testid={`explorer-campaign-name-input-${campaign.id}`}
+                                value={campaignForm.displayName}
+                                onChange={(event) => {
+                                  setCampaignForms((current) => ({
+                                    ...current,
+                                    [campaign.id]: { ...campaignForm, displayName: event.target.value },
+                                  }));
                                 }}
-                                disabled={addDestinationMutation.isPending}
-                              >
-                                <CheckIcon aria-hidden="true" />
-                              </button>
-                              <button
-                                type="button"
-                                className="explorer-icon-button explorer-icon-button-reject"
-                                data-testid="explorer-reject-preview-button"
-                                aria-label="Reject destination preview"
-                                onClick={() => {
-                                  setDestinationPreview(null);
-                                  setPreviewError(null);
+                                placeholder="Optional campaign name"
+                                maxLength={255}
+                              />
+                            </div>
+
+                            <div className="explorer-form-group">
+                              <label htmlFor={`explorer-campaign-start-${campaign.id}`}>Start date</label>
+                              <input
+                                id={`explorer-campaign-start-${campaign.id}`}
+                                data-testid={`explorer-campaign-start-date-input-${campaign.id}`}
+                                type="date"
+                                value={campaignForm.startDate}
+                                onChange={(event) => {
+                                  setCampaignForms((current) => ({
+                                    ...current,
+                                    [campaign.id]: { ...campaignForm, startDate: event.target.value },
+                                  }));
                                 }}
-                              >
-                                <XMarkIcon aria-hidden="true" />
-                              </button>
+                              />
+                            </div>
+
+                            <div className="explorer-form-group">
+                              <label htmlFor={`explorer-campaign-end-${campaign.id}`}>End date</label>
+                              <input
+                                id={`explorer-campaign-end-${campaign.id}`}
+                                data-testid={`explorer-campaign-end-date-input-${campaign.id}`}
+                                type="date"
+                                value={campaignForm.endDate}
+                                onChange={(event) => {
+                                  setCampaignForms((current) => ({
+                                    ...current,
+                                    [campaign.id]: { ...campaignForm, endDate: event.target.value },
+                                  }));
+                                }}
+                              />
                             </div>
                           </div>
 
-                          <div className="explorer-destination-surface explorer-destination-surface-preview">
-                            <h3 className="explorer-destination-hero-title" data-testid="explorer-preview-name">
-                              <a
-                                className="explorer-destination-surface-link"
-                                href={destinationPreview.sourceUrl}
-                                target="_blank"
-                                rel="noopener noreferrer"
-                              >
-                                {destinationPreview.name}
-                                <ArrowTopRightOnSquareIcon aria-hidden="true" />
-                              </a>
-                            </h3>
-
-                            {previewStatItems.length > 0 ? (
-                              <div className="explorer-destination-chip-row">
-                                {previewStatItems.map((item) => (
-                                  <span key={item} className="week-header-chip">{item}</span>
-                                ))}
-                              </div>
-                            ) : null}
-                          </div>
-                        </article>
-                      );
-                    })()
-                  ) : null}
-                </div>
-              </section>
-
-              <section className="explorer-destination-section" data-testid="explorer-destination-list-card">
-                <div className="explorer-card-header">
-                  <div>
-                    <p className="explorer-section-label">Current campaign map</p>
-                    <h3>Destinations</h3>
-                  </div>
-                </div>
-
-                {campaignQuery.data.destinations.length === 0 ? (
-                  <p className="explorer-muted-copy">No destinations added yet.</p>
-                ) : (
-                  <ol className="explorer-destination-list" data-testid="explorer-destination-list">
-                    {sortedDestinations.map((destination) => {
-                      const isExpanded = expandedDestinationId === destination.id;
-                      const createdAtLabel = formatDestinationCreatedAt(destination.createdAt);
-                      const destinationStatItems = getDestinationStatItems({
-                        distance: destination.distance,
-                        averageGrade: destination.averageGrade,
-                        city: destination.city,
-                        state: destination.state,
-                        country: destination.country,
-                      });
-
-                      return (
-                        <li
-                          key={destination.id}
-                          className="explorer-destination-card"
-                          data-expanded={isExpanded}
-                          data-testid={`explorer-destination-row-${destination.id}`}
-                        >
-                          <div
-                            role="button"
-                            tabIndex={0}
-                            className="explorer-destination-summary"
-                            onClick={() => {
-                              setExpandedDestinationId((current) => current === destination.id ? null : destination.id);
-                            }}
-                            onKeyDown={(event) => {
-                              if (event.key === 'Enter' || event.key === ' ') {
-                                event.preventDefault();
-                                setExpandedDestinationId((current) => current === destination.id ? null : destination.id);
-                              }
-                            }}
-                            aria-expanded={isExpanded}
-                            data-testid={`explorer-destination-toggle-${destination.id}`}
-                          >
-                            <div className="explorer-destination-surface explorer-destination-summary-card">
-                              <div>
-                                <h4 className="explorer-destination-hero-title explorer-destination-list-title">
-                                  {destination.sourceUrl ? (
-                                    <a
-                                      className="explorer-destination-surface-link"
-                                      href={destination.sourceUrl}
-                                      target="_blank"
-                                      rel="noopener noreferrer"
-                                      onClick={(event) => {
-                                        event.stopPropagation();
-                                      }}
-                                    >
-                                      {destination.displayLabel}
-                                      <ArrowTopRightOnSquareIcon aria-hidden="true" />
-                                    </a>
-                                  ) : (
-                                    <span className="explorer-destination-label">{destination.displayLabel}</span>
-                                  )}
-                                </h4>
-
-                                {destinationStatItems.length > 0 ? (
-                                  <div className="explorer-destination-chip-row">
-                                    {destinationStatItems.map((item) => (
-                                      <span key={item} className="week-header-chip">{item}</span>
-                                    ))}
-                                  </div>
-                                ) : null}
-                              </div>
-
-                              <ChevronDownIcon className={`explorer-destination-chevron${isExpanded ? ' is-expanded' : ''}`} aria-hidden="true" />
-                            </div>
+                          <div className="explorer-form-group">
+                            <label htmlFor={`explorer-campaign-rules-${campaign.id}`}>Rules blurb</label>
+                            <textarea
+                              id={`explorer-campaign-rules-${campaign.id}`}
+                              data-testid={`explorer-campaign-rules-input-${campaign.id}`}
+                              value={campaignForm.rulesBlurb}
+                              onChange={(event) => {
+                                setCampaignForms((current) => ({
+                                  ...current,
+                                  [campaign.id]: { ...campaignForm, rulesBlurb: event.target.value },
+                                }));
+                              }}
+                              rows={4}
+                              maxLength={2000}
+                            />
                           </div>
 
-                          {isExpanded ? (
-                            <div className="card-expanded-details explorer-destination-details">
-                              <div className="explorer-destination-detail-block">
-                                <p className="explorer-detail-label">Details</p>
+                          <div className="explorer-form-actions">
+                            <button
+                              type="button"
+                              className="explorer-submit-button"
+                              data-testid={`explorer-save-campaign-button-${campaign.id}`}
+                              onClick={() => {
+                                void handleSaveCampaign(campaign.id);
+                              }}
+                              disabled={updateCampaignMutation.isPending}
+                            >
+                              {updateCampaignMutation.isPending ? 'Saving...' : 'Save Campaign'}
+                            </button>
+                          </div>
+                        </div>
+                      </section>
 
-                                {destination.customLabel && destination.customLabel !== destination.segmentName ? (
-                                  <p className="explorer-preview-subtitle">Original segment name: {destination.segmentName}</p>
-                                ) : null}
+                      <section className="explorer-campaign-editor-block" data-testid="explorer-add-destination-card">
+                        <div className="explorer-card-header">
+                          <div>
+                            <p className="explorer-section-label">Destination authoring</p>
+                            <h4>Add destination</h4>
+                          </div>
+                          <p>Paste a Strava segment URL and Explorer will validate it into a preview automatically.</p>
+                        </div>
 
-                                <div className="explorer-destination-detail-row">
-                                  {createdAtLabel ? (
-                                    <p className="explorer-destination-meta">
-                                      <ClockIcon aria-hidden="true" />
-                                      <span>Added {createdAtLabel}</span>
-                                    </p>
-                                  ) : (
-                                    <p className="explorer-muted-copy">Added date unavailable.</p>
-                                  )}
-                                </div>
-                              </div>
-                            </div>
+                        <div className="explorer-form explorer-form-tight">
+                          <div className="explorer-form-group">
+                            <label htmlFor={`explorer-source-url-${campaign.id}`}>Strava segment URL</label>
+                            <input
+                              id={`explorer-source-url-${campaign.id}`}
+                              data-testid="explorer-source-url-input"
+                              value={destinationSource}
+                              onChange={(event) => {
+                                const nextValue = event.target.value;
+                                setPreviewCampaignId(campaign.id);
+                                setDestinationSourceByCampaign((current) => ({ ...current, [campaign.id]: nextValue }));
+                                setDestinationPreview(null);
+                                setPreviewError(null);
+                              }}
+                              placeholder="https://www.strava.com/segments/2234642"
+                              required
+                            />
+                            <p className="explorer-input-help">
+                              Explorer keeps the original Strava URL and previews the segment automatically as you paste.
+                            </p>
+                          </div>
+
+                          {isPreviewLoading ? (
+                            <p className="explorer-preview-status" data-testid="explorer-preview-status">
+                              <ArrowPathIcon className="explorer-button-icon explorer-spin" aria-hidden="true" />
+                              <span>Validating segment...</span>
+                            </p>
                           ) : null}
-                        </li>
-                      );
-                    })}
-                  </ol>
-                )}
-              </section>
-            </>
-          )}
-        </>
+
+                          {previewErrorVisible ? (
+                            <p className="explorer-preview-error" data-testid="explorer-preview-error">
+                              {previewErrorVisible}
+                            </p>
+                          ) : null}
+
+                          {destinationPreviewVisible ? (
+                            (() => {
+                              const previewStatItems = getDestinationStatItems(destinationPreviewVisible);
+
+                              return (
+                                <article className="explorer-preview-card" data-testid="explorer-destination-preview-card">
+                                  <div className="explorer-preview-header">
+                                    <p className="explorer-section-label">Preview</p>
+                                    <div className="explorer-preview-actions">
+                                      <button
+                                        type="button"
+                                        className="explorer-icon-button explorer-icon-button-accept"
+                                        data-testid="explorer-accept-preview-button"
+                                        aria-label="Accept destination preview"
+                                        onClick={() => {
+                                          void handleAcceptPreview();
+                                        }}
+                                        disabled={addDestinationMutation.isPending}
+                                      >
+                                        <CheckIcon aria-hidden="true" />
+                                      </button>
+                                      <button
+                                        type="button"
+                                        className="explorer-icon-button explorer-icon-button-reject"
+                                        data-testid="explorer-reject-preview-button"
+                                        aria-label="Reject destination preview"
+                                        onClick={() => {
+                                          previewRequestIdRef.current += 1;
+                                          setDestinationPreview(null);
+                                          setPreviewError(null);
+                                        }}
+                                      >
+                                        <XMarkIcon aria-hidden="true" />
+                                      </button>
+                                    </div>
+                                  </div>
+
+                                  <div className="explorer-destination-surface explorer-destination-surface-preview">
+                                    <h4 className="explorer-destination-hero-title" data-testid="explorer-preview-name">
+                                      <a
+                                        className="explorer-destination-surface-link"
+                                        href={destinationPreviewVisible.sourceUrl}
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                      >
+                                        {destinationPreviewVisible.name}
+                                        <ArrowTopRightOnSquareIcon aria-hidden="true" />
+                                      </a>
+                                    </h4>
+
+                                    {previewStatItems.length > 0 ? (
+                                      <div className="explorer-destination-chip-row">
+                                        {previewStatItems.map((item) => (
+                                          <span key={item} className="week-header-chip">{item}</span>
+                                        ))}
+                                      </div>
+                                    ) : null}
+                                  </div>
+                                </article>
+                              );
+                            })()
+                          ) : null}
+                        </div>
+                      </section>
+                    </div>
+
+                    <section className="explorer-destination-section" data-testid="explorer-destination-list-card">
+                      <div className="explorer-card-header">
+                        <div>
+                          <p className="explorer-section-label">Current campaign map</p>
+                          <h4>Destinations</h4>
+                        </div>
+                      </div>
+
+                      {campaign.destinations.length === 0 ? (
+                        <p className="explorer-muted-copy">No destinations added yet.</p>
+                      ) : (
+                        <ol className="explorer-destination-list" data-testid="explorer-destination-list">
+                          {[...campaign.destinations]
+                            .sort((left, right) => left.displayOrder - right.displayOrder || left.id - right.id)
+                            .map((destination) => {
+                              const isDestinationExpanded = expandedDestinationId === destination.id;
+                              const createdAtLabel = formatDestinationCreatedAt(destination.createdAt);
+                              const destinationStatItems = getDestinationStatItems({
+                                distance: destination.distance,
+                                averageGrade: destination.averageGrade,
+                                city: destination.city,
+                                state: destination.state,
+                                country: destination.country,
+                              });
+
+                              return (
+                                <li
+                                  key={destination.id}
+                                  className="explorer-destination-card"
+                                  data-expanded={isDestinationExpanded}
+                                  data-testid={`explorer-destination-row-${destination.id}`}
+                                >
+                                  <div
+                                    role="button"
+                                    tabIndex={0}
+                                    className="explorer-destination-summary"
+                                    onClick={() => {
+                                      setExpandedDestinationId((current) => current === destination.id ? null : destination.id);
+                                    }}
+                                    onKeyDown={(event) => {
+                                      if (event.key === 'Enter' || event.key === ' ') {
+                                        event.preventDefault();
+                                        setExpandedDestinationId((current) => current === destination.id ? null : destination.id);
+                                      }
+                                    }}
+                                    aria-expanded={isDestinationExpanded}
+                                    data-testid={`explorer-destination-toggle-${destination.id}`}
+                                  >
+                                    <div className="explorer-destination-surface explorer-destination-summary-card">
+                                      <div>
+                                        <h5 className="explorer-destination-hero-title explorer-destination-list-title">
+                                          {destination.sourceUrl ? (
+                                            <a
+                                              className="explorer-destination-surface-link"
+                                              href={destination.sourceUrl}
+                                              target="_blank"
+                                              rel="noopener noreferrer"
+                                              onClick={(event) => {
+                                                event.stopPropagation();
+                                              }}
+                                            >
+                                              {destination.displayLabel}
+                                              <ArrowTopRightOnSquareIcon aria-hidden="true" />
+                                            </a>
+                                          ) : (
+                                            <span className="explorer-destination-label">{destination.displayLabel}</span>
+                                          )}
+                                        </h5>
+
+                                        {destinationStatItems.length > 0 ? (
+                                          <div className="explorer-destination-chip-row">
+                                            {destinationStatItems.map((item) => (
+                                              <span key={item} className="week-header-chip">{item}</span>
+                                            ))}
+                                          </div>
+                                        ) : null}
+                                      </div>
+
+                                      <ChevronDownIcon className={`explorer-destination-chevron${isDestinationExpanded ? ' is-expanded' : ''}`} aria-hidden="true" />
+                                    </div>
+                                  </div>
+
+                                  {isDestinationExpanded ? (
+                                    <div className="card-expanded-details explorer-destination-details">
+                                      <div className="explorer-destination-detail-block">
+                                        <p className="explorer-detail-label">Details</p>
+
+                                        {destination.customLabel && destination.customLabel !== destination.segmentName ? (
+                                          <p className="explorer-preview-subtitle">Original segment name: {destination.segmentName}</p>
+                                        ) : null}
+
+                                        <div className="explorer-destination-detail-row">
+                                          {createdAtLabel ? (
+                                            <p className="explorer-destination-meta">
+                                              <ClockIcon aria-hidden="true" />
+                                              <span>Added {createdAtLabel}</span>
+                                            </p>
+                                          ) : (
+                                            <p className="explorer-muted-copy">Added date unavailable.</p>
+                                          )}
+                                        </div>
+                                      </div>
+                                    </div>
+                                  ) : null}
+                                </li>
+                              );
+                            })}
+                        </ol>
+                      )}
+                    </section>
+                  </div>
+                ) : null}
+              </article>
+            );
+          })}
+        </section>
       )}
     </div>
   );

--- a/src/components/__tests__/ExplorerAdminPanel.test.tsx
+++ b/src/components/__tests__/ExplorerAdminPanel.test.tsx
@@ -1,7 +1,7 @@
 import { act, type ComponentProps } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { dateToUnixEnd, dateToUnixStart } from '../../utils/dateUtils';
+import { dateToUnixEnd, dateToUnixStart, unixToDateLocal } from '../../utils/dateUtils';
 import ExplorerAdminPanel from '../ExplorerAdminPanel';
 
 (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
@@ -151,7 +151,21 @@ interface RenderResult {
   root: Root;
 }
 
+interface DeferredValue<T> {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+}
+
 let renderResult: RenderResult | null = null;
+
+function createDeferredValue<T>(): DeferredValue<T> {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+
+  return { promise, resolve };
+}
 
 async function renderPanel(overrides: Partial<ComponentProps<typeof ExplorerAdminPanel>> = {}) {
   const container = document.createElement('div');
@@ -292,6 +306,7 @@ describe('ExplorerAdminPanel', () => {
       {
         id: 41,
         name: 'Spring Explorer',
+        displayNameRaw: 'Spring Explorer',
         startAt: 1748736000,
         endAt: 1751327999,
         rulesBlurb: 'Ride every destination once.',
@@ -322,6 +337,7 @@ describe('ExplorerAdminPanel', () => {
       {
         id: 41,
         name: 'Spring Explorer',
+        displayNameRaw: 'Spring Explorer',
         startAt: 1748736000,
         endAt: 1751327999,
         rulesBlurb: 'Ride every destination once.',
@@ -371,6 +387,7 @@ describe('ExplorerAdminPanel', () => {
       {
         id: 41,
         name: 'Spring Explorer',
+        displayNameRaw: 'Spring Explorer',
         startAt: 1748736000,
         endAt: 1751327999,
         rulesBlurb: 'Ride every destination once.',
@@ -399,5 +416,123 @@ describe('ExplorerAdminPanel', () => {
     expect(getByTestId(container, 'explorer-destination-list').textContent).toContain('Hilltown opener');
     await clickElement(getByTestId(container, 'explorer-destination-toggle-301'));
     expect(getByTestId(container, 'explorer-destination-row-301').textContent).toContain('Added');
+  });
+
+  it('preserves an explicit Explorer Campaign display name when saving', async () => {
+    trpcMocks.campaignsQuery.data = [
+      {
+        id: 41,
+        name: 'Explorer Campaign',
+        displayNameRaw: 'Explorer Campaign',
+        startAt: 1748736000,
+        endAt: 1751327999,
+        rulesBlurb: null,
+        destinations: [],
+      },
+    ];
+
+    const { container } = await renderPanel();
+
+    expect((getByTestId(container, 'explorer-campaign-name-input-41') as HTMLInputElement).value).toBe('Explorer Campaign');
+
+    await clickElement(getByTestId(container, 'explorer-save-campaign-button-41'));
+
+    expect(trpcMocks.updateCampaign).toHaveBeenCalledWith({
+      explorerCampaignId: 41,
+      startAt: dateToUnixStart(unixToDateLocal(1748736000)),
+      endAt: dateToUnixEnd(unixToDateLocal(1751327999)),
+      displayName: 'Explorer Campaign',
+      rulesBlurb: null,
+    });
+  });
+
+  it('ignores stale preview responses when the source URL changes mid-request', async () => {
+    vi.useFakeTimers();
+    trpcMocks.campaignsQuery.data = [
+      {
+        id: 41,
+        name: 'Spring Explorer',
+        displayNameRaw: 'Spring Explorer',
+        startAt: 1748736000,
+        endAt: 1751327999,
+        rulesBlurb: 'Ride every destination once.',
+        destinations: [],
+      },
+    ];
+
+    const firstPreview = createDeferredValue({
+      strava_segment_id: '2234642',
+      name: 'Older Preview',
+      distance: 1000,
+      average_grade: 2.1,
+      city: 'Oldtown',
+      state: 'MA',
+      country: 'USA',
+    });
+    const secondPreview = createDeferredValue({
+      strava_segment_id: '9999999',
+      name: 'Newest Preview',
+      distance: 4500,
+      average_grade: 6.2,
+      city: 'Newtown',
+      state: 'VT',
+      country: 'USA',
+    });
+
+    trpcMocks.validateSegment.mockReset();
+    trpcMocks.validateSegment
+      .mockReturnValueOnce(firstPreview.promise)
+      .mockReturnValueOnce(secondPreview.promise);
+
+    const { container } = await renderPanel();
+
+    await setValue(
+      getByTestId(container, 'explorer-source-url-input') as HTMLInputElement,
+      'https://www.strava.com/segments/2234642'
+    );
+    await act(async () => {
+      vi.advanceTimersByTime(150);
+      await Promise.resolve();
+    });
+
+    await setValue(
+      getByTestId(container, 'explorer-source-url-input') as HTMLInputElement,
+      'https://www.strava.com/segments/9999999'
+    );
+    await act(async () => {
+      vi.advanceTimersByTime(150);
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      firstPreview.resolve({
+        strava_segment_id: '2234642',
+        name: 'Older Preview',
+        distance: 1000,
+        average_grade: 2.1,
+        city: 'Oldtown',
+        state: 'MA',
+        country: 'USA',
+      });
+      await Promise.resolve();
+    });
+
+    expect(queryByTestId(container, 'explorer-destination-preview-card')).toBeNull();
+
+    await act(async () => {
+      secondPreview.resolve({
+        strava_segment_id: '9999999',
+        name: 'Newest Preview',
+        distance: 4500,
+        average_grade: 6.2,
+        city: 'Newtown',
+        state: 'VT',
+        country: 'USA',
+      });
+      await Promise.resolve();
+    });
+
+    expect(getByTestId(container, 'explorer-destination-preview-card').textContent).toContain('Newest Preview');
+    expect(getByTestId(container, 'explorer-destination-preview-card').textContent).not.toContain('Older Preview');
   });
 });

--- a/src/components/__tests__/ExplorerAdminPanel.test.tsx
+++ b/src/components/__tests__/ExplorerAdminPanel.test.tsx
@@ -1,16 +1,18 @@
-import { act } from 'react';
+import { act, type ComponentProps } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import type { Season } from '../../types';
+import { dateToUnixEnd, dateToUnixStart } from '../../utils/dateUtils';
 import ExplorerAdminPanel from '../ExplorerAdminPanel';
 
 (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
 const trpcMocks = vi.hoisted(() => ({
-  campaignQuery: {
-    data: null as null | {
+  campaignsQuery: {
+    data: [] as Array<{
       id: number;
       name: string;
+      startAt: number;
+      endAt: number;
       rulesBlurb: string | null;
       destinations: Array<{
         id: number;
@@ -27,7 +29,7 @@ const trpcMocks = vi.hoisted(() => ({
         state: string | null;
         country: string | null;
       }>;
-    },
+    }>,
     error: null as Error | null,
     isLoading: false,
   },
@@ -41,12 +43,23 @@ const trpcMocks = vi.hoisted(() => ({
     state: 'Surrey',
     country: 'United Kingdom',
   })),
-  createCampaign: vi.fn(async (_input?: unknown) => ({ id: 1 })),
+  createCampaign: vi.fn(async (_input?: unknown) => ({
+    id: 91,
+    start_at: 1748736000,
+    end_at: 1751327999,
+    display_name: 'Explorer June',
+  })),
+  updateCampaign: vi.fn(async (_input?: unknown) => ({
+    id: 41,
+    start_at: 1748736000,
+    end_at: 1751327999,
+    display_name: 'Updated Explorer',
+  })),
   addDestination: vi.fn(async (_input?: unknown) => ({
-    id: 1,
-    cached_name: 'Segment 1',
-    strava_segment_id: '1',
-    usedPlaceholderMetadata: true,
+    id: 201,
+    cached_name: 'Box Hill KOM',
+    strava_segment_id: '2234642',
+    usedPlaceholderMetadata: false,
   })),
 }));
 
@@ -61,14 +74,14 @@ vi.mock('../../utils/trpc', () => ({
         },
       },
       explorerAdmin: {
-        getCampaignForSeason: {
+        getCampaigns: {
           invalidate: trpcMocks.invalidate,
         },
       },
     }),
     explorerAdmin: {
-      getCampaignForSeason: {
-        useQuery: () => trpcMocks.campaignQuery,
+      getCampaigns: {
+        useQuery: () => trpcMocks.campaignsQuery,
       },
       createCampaign: {
         useMutation: (options: {
@@ -88,6 +101,24 @@ vi.mock('../../utils/trpc', () => ({
           },
         }),
       },
+      updateCampaign: {
+        useMutation: (options: {
+          onError?: (error: Error) => void;
+          onSuccess?: (result: unknown) => Promise<void> | void;
+        }) => ({
+          isPending: false,
+          mutateAsync: async (input: unknown) => {
+            try {
+              const result = await trpcMocks.updateCampaign(input);
+              await options.onSuccess?.(result);
+              return result;
+            } catch (error) {
+              options.onError?.(error as Error);
+              throw error;
+            }
+          },
+        }),
+      },
       addDestination: {
         useMutation: (options: {
           onError?: (error: Error) => void;
@@ -95,6 +126,7 @@ vi.mock('../../utils/trpc', () => ({
             cached_name: string;
             strava_segment_id: string;
             usedPlaceholderMetadata: boolean;
+            id: number;
           }) => Promise<void> | void;
         }) => ({
           isPending: false,
@@ -114,57 +146,20 @@ vi.mock('../../utils/trpc', () => ({
   },
 }));
 
-const seasons: Season[] = [
-  {
-    id: 7,
-    name: 'Spring 2026',
-    start_at: 1711929600,
-    end_at: 1714521600,
-  },
-  {
-    id: 8,
-    name: 'Summer 2026',
-    start_at: 1717200000,
-    end_at: 1719792000,
-  },
-];
-
 interface RenderResult {
   container: HTMLDivElement;
   root: Root;
 }
 
-interface DeferredValue<T> {
-  promise: Promise<T>;
-  resolve: (value: T) => void;
-}
-
 let renderResult: RenderResult | null = null;
 
-function createDeferredValue<T>(): DeferredValue<T> {
-  let resolve!: (value: T) => void;
-  const promise = new Promise<T>((resolvePromise) => {
-    resolve = resolvePromise;
-  });
-
-  return { promise, resolve };
-}
-
-async function renderPanel(overrides: Partial<React.ComponentProps<typeof ExplorerAdminPanel>> = {}) {
+async function renderPanel(overrides: Partial<ComponentProps<typeof ExplorerAdminPanel>> = {}) {
   const container = document.createElement('div');
   document.body.appendChild(container);
   const root = createRoot(container);
 
   await act(async () => {
-    root.render(
-      <ExplorerAdminPanel
-        isAdmin
-        seasons={seasons}
-        selectedSeasonId={seasons[0].id}
-        onSeasonChange={vi.fn()}
-        {...overrides}
-      />
-    );
+    root.render(<ExplorerAdminPanel isAdmin {...overrides} />);
   });
 
   renderResult = { container, root };
@@ -215,9 +210,9 @@ async function clickElement(element: HTMLElement) {
 
 describe('ExplorerAdminPanel', () => {
   beforeEach(() => {
-    trpcMocks.campaignQuery.data = null;
-    trpcMocks.campaignQuery.error = null;
-    trpcMocks.campaignQuery.isLoading = false;
+    trpcMocks.campaignsQuery.data = [];
+    trpcMocks.campaignsQuery.error = null;
+    trpcMocks.campaignsQuery.isLoading = false;
     trpcMocks.invalidate.mockClear();
     trpcMocks.validateSegment.mockReset();
     trpcMocks.validateSegment.mockResolvedValue({
@@ -230,11 +225,23 @@ describe('ExplorerAdminPanel', () => {
       country: 'United Kingdom',
     });
     trpcMocks.createCampaign.mockReset();
-    trpcMocks.createCampaign.mockResolvedValue({ id: 1 });
+    trpcMocks.createCampaign.mockResolvedValue({
+      id: 91,
+      start_at: 1748736000,
+      end_at: 1751327999,
+      display_name: 'Explorer June',
+    });
+    trpcMocks.updateCampaign.mockReset();
+    trpcMocks.updateCampaign.mockResolvedValue({
+      id: 41,
+      start_at: 1748736000,
+      end_at: 1751327999,
+      display_name: 'Updated Explorer',
+    });
     trpcMocks.addDestination.mockReset();
     trpcMocks.addDestination.mockResolvedValue({
-      id: 1,
-      cached_name: 'Segment 2234642',
+      id: 201,
+      cached_name: 'Box Hill KOM',
       strava_segment_id: '2234642',
       usedPlaceholderMetadata: false,
     });
@@ -244,7 +251,7 @@ describe('ExplorerAdminPanel', () => {
   afterEach(async () => {
     if (renderResult) {
       await act(async () => {
-        renderResult?.root.unmount();
+        renderResult.root.unmount();
       });
       renderResult.container.remove();
       renderResult = null;
@@ -260,69 +267,82 @@ describe('ExplorerAdminPanel', () => {
     expect(container.textContent).toContain('do not have admin permissions');
   });
 
-  it('falls back to the first season when no admin season is selected', async () => {
-    const { container } = await renderPanel({ selectedSeasonId: null });
+  it('creates a campaign with date-bound input', async () => {
+    const { container } = await renderPanel();
 
-    expect(getByTestId(container, 'explorer-season-summary').textContent).toContain('Spring 2026');
+    await setValue(getByTestId(container, 'explorer-display-name-input') as HTMLInputElement, 'Explorer June');
+    await setValue(getByTestId(container, 'explorer-start-date-input') as HTMLInputElement, '2025-06-01');
+    await setValue(getByTestId(container, 'explorer-end-date-input') as HTMLInputElement, '2025-06-30');
+    await setValue(getByTestId(container, 'explorer-rules-blurb-input') as HTMLTextAreaElement, 'Ride every destination once.');
 
     await submitForm(getByTestId(container, 'explorer-create-campaign-form'));
 
     expect(trpcMocks.createCampaign).toHaveBeenCalledWith({
-      seasonId: 7,
-      displayName: null,
-      rulesBlurb: null,
-    });
-    expect(trpcMocks.invalidate).toHaveBeenCalledWith({ seasonId: 7 });
-  });
-
-  it('falls back to the first season when the selected season is missing', async () => {
-    const { container } = await renderPanel({ selectedSeasonId: 999 });
-
-    expect(getByTestId(container, 'explorer-season-summary').textContent).toContain('Spring 2026');
-  });
-
-  it('shows the empty state when there are no seasons to configure', async () => {
-    const { container } = await renderPanel({ seasons: [], selectedSeasonId: null });
-
-    expect(container.textContent).toContain('No seasons available');
-    expect(queryByTestId(container, 'explorer-create-campaign-form')).toBeNull();
-  });
-
-  it('auto-previews, accepts, and rejects destinations while preserving the latest flash message timer', async () => {
-    vi.useFakeTimers();
-    trpcMocks.campaignQuery.data = {
-      id: 41,
-      name: 'Spring 2026 Explorer',
+      startAt: dateToUnixStart('2025-06-01'),
+      endAt: dateToUnixEnd('2025-06-30'),
+      displayName: 'Explorer June',
       rulesBlurb: 'Ride every destination once.',
-      destinations: [],
-    };
-    trpcMocks.addDestination
-      .mockResolvedValueOnce({
-        id: 1,
-        cached_name: 'Segment 2234642',
-        strava_segment_id: '2234642',
-        usedPlaceholderMetadata: true,
-      })
-      .mockResolvedValueOnce({
-        id: 2,
-        cached_name: 'Box Hill KOM',
-        strava_segment_id: '2234642',
-        usedPlaceholderMetadata: false,
-      });
+    });
+    expect(trpcMocks.invalidate).toHaveBeenCalled();
+    expect(getByTestId(container, 'explorer-admin-message').textContent).toContain('Explorer campaign created.');
+  });
+
+  it('updates an existing campaign from the expanded card', async () => {
+    trpcMocks.campaignsQuery.data = [
+      {
+        id: 41,
+        name: 'Spring Explorer',
+        startAt: 1748736000,
+        endAt: 1751327999,
+        rulesBlurb: 'Ride every destination once.',
+        destinations: [],
+      },
+    ];
+
+    const { container } = await renderPanel();
+
+    await setValue(getByTestId(container, 'explorer-campaign-name-input-41') as HTMLInputElement, 'Updated Explorer');
+    await setValue(getByTestId(container, 'explorer-campaign-start-date-input-41') as HTMLInputElement, '2025-06-02');
+    await setValue(getByTestId(container, 'explorer-campaign-end-date-input-41') as HTMLInputElement, '2025-06-29');
+    await setValue(getByTestId(container, 'explorer-campaign-rules-input-41') as HTMLTextAreaElement, 'Updated rules.');
+    await clickElement(getByTestId(container, 'explorer-save-campaign-button-41'));
+
+    expect(trpcMocks.updateCampaign).toHaveBeenCalledWith({
+      explorerCampaignId: 41,
+      startAt: dateToUnixStart('2025-06-02'),
+      endAt: dateToUnixEnd('2025-06-29'),
+      displayName: 'Updated Explorer',
+      rulesBlurb: 'Updated rules.',
+    });
+  });
+
+  it('auto-previews, rejects, and accepts destinations for the expanded campaign', async () => {
+    vi.useFakeTimers();
+    trpcMocks.campaignsQuery.data = [
+      {
+        id: 41,
+        name: 'Spring Explorer',
+        startAt: 1748736000,
+        endAt: 1751327999,
+        rulesBlurb: 'Ride every destination once.',
+        destinations: [],
+      },
+    ];
 
     const { container } = await renderPanel();
 
     await setValue(
       getByTestId(container, 'explorer-source-url-input') as HTMLInputElement,
-      '  https://www.strava.com/segments/2234642  '
+      'https://www.strava.com/segments/2234642'
     );
+
     await act(async () => {
       vi.advanceTimersByTime(150);
       await Promise.resolve();
     });
 
-    expect(getByTestId(container, 'explorer-destination-preview-card').textContent).toContain('Box Hill KOM');
-    expect(getByTestId(container, 'explorer-destination-preview-card').textContent).toContain('2.93 km');
+    expect(trpcMocks.validateSegment).toHaveBeenCalledWith('2234642');
+    expect(getByTestId(container, 'explorer-preview-name').textContent).toContain('Box Hill KOM');
 
     await clickElement(getByTestId(container, 'explorer-reject-preview-button'));
     expect(queryByTestId(container, 'explorer-destination-preview-card')).toBeNull();
@@ -331,198 +351,53 @@ describe('ExplorerAdminPanel', () => {
       getByTestId(container, 'explorer-source-url-input') as HTMLInputElement,
       'https://www.strava.com/segments/2234642'
     );
+
     await act(async () => {
       vi.advanceTimersByTime(150);
       await Promise.resolve();
     });
-    await clickElement(getByTestId(container, 'explorer-accept-preview-button'));
-
-    expect(getByTestId(container, 'explorer-admin-message').textContent).toContain('placeholder metadata');
-    expect(trpcMocks.addDestination).toHaveBeenNthCalledWith(1, {
-      explorerCampaignId: 41,
-      sourceUrl: 'https://www.strava.com/segments/2234642',
-    });
-
-    await act(async () => {
-      vi.advanceTimersByTime(1000);
-    });
-
-    await setValue(
-      getByTestId(container, 'explorer-source-url-input') as HTMLInputElement,
-      'https://www.strava.com/segments/2234642'
-    );
-    await act(async () => {
-      vi.advanceTimersByTime(150);
-      await Promise.resolve();
-    });
-
-    expect(getByTestId(container, 'explorer-preview-name').textContent).toContain('Box Hill KOM');
 
     await clickElement(getByTestId(container, 'explorer-accept-preview-button'));
 
-    expect(getByTestId(container, 'explorer-admin-message').textContent).toContain('Destination added to the Explorer campaign.');
-    expect(trpcMocks.addDestination).toHaveBeenNthCalledWith(2, {
+    expect(trpcMocks.addDestination).toHaveBeenCalledWith({
       explorerCampaignId: 41,
       sourceUrl: 'https://www.strava.com/segments/2234642',
     });
-
-    await act(async () => {
-      vi.advanceTimersByTime(4000);
-    });
-
     expect(getByTestId(container, 'explorer-admin-message').textContent).toContain('Destination added to the Explorer campaign.');
-
-    await act(async () => {
-      vi.advanceTimersByTime(1000);
-    });
-
-    expect(queryByTestId(container, 'explorer-admin-message')).toBeNull();
   });
 
-  it('requests a single preview validation for each source-url change', async () => {
-    vi.useFakeTimers();
-    trpcMocks.campaignQuery.data = {
-      id: 41,
-      name: 'Spring 2026 Explorer',
-      rulesBlurb: 'Ride every destination once.',
-      destinations: [],
-    };
+  it('renders and expands existing destinations inside the campaign shell', async () => {
+    trpcMocks.campaignsQuery.data = [
+      {
+        id: 41,
+        name: 'Spring Explorer',
+        startAt: 1748736000,
+        endAt: 1751327999,
+        rulesBlurb: 'Ride every destination once.',
+        destinations: [
+          {
+            id: 301,
+            displayLabel: 'Hilltown opener',
+            customLabel: null,
+            segmentName: 'Hilltown opener',
+            displayOrder: 0,
+            sourceUrl: 'https://www.strava.com/segments/2234642',
+            stravaSegmentId: '2234642',
+            createdAt: '2025-06-03T09:05:00Z',
+            distance: 2931,
+            averageGrade: 5.4,
+            city: 'Dorking',
+            state: 'Surrey',
+            country: 'United Kingdom',
+          },
+        ],
+      },
+    ];
 
     const { container } = await renderPanel();
 
-    await setValue(
-      getByTestId(container, 'explorer-source-url-input') as HTMLInputElement,
-      'https://www.strava.com/segments/2234642'
-    );
-
-    await act(async () => {
-      vi.advanceTimersByTime(150);
-      await Promise.resolve();
-    });
-
-    expect(trpcMocks.validateSegment).toHaveBeenCalledTimes(1);
-    expect(trpcMocks.validateSegment).toHaveBeenCalledWith('2234642');
-  });
-
-  it('ignores stale preview responses when the source URL changes mid-request', async () => {
-    vi.useFakeTimers();
-    trpcMocks.campaignQuery.data = {
-      id: 41,
-      name: 'Spring 2026 Explorer',
-      rulesBlurb: 'Ride every destination once.',
-      destinations: [],
-    };
-
-    const firstPreview = createDeferredValue({
-      strava_segment_id: '2234642',
-      name: 'Older Preview',
-      distance: 1000,
-      average_grade: 2.1,
-      city: 'Oldtown',
-      state: 'MA',
-      country: 'USA',
-    });
-    const secondPreview = createDeferredValue({
-      strava_segment_id: '9999999',
-      name: 'Newest Preview',
-      distance: 4500,
-      average_grade: 6.2,
-      city: 'Newtown',
-      state: 'VT',
-      country: 'USA',
-    });
-
-    trpcMocks.validateSegment.mockReset();
-    trpcMocks.validateSegment
-      .mockReturnValueOnce(firstPreview.promise)
-      .mockReturnValueOnce(secondPreview.promise);
-
-    const { container } = await renderPanel();
-
-    await setValue(
-      getByTestId(container, 'explorer-source-url-input') as HTMLInputElement,
-      'https://www.strava.com/segments/2234642'
-    );
-    await act(async () => {
-      vi.advanceTimersByTime(150);
-      await Promise.resolve();
-    });
-
-    await setValue(
-      getByTestId(container, 'explorer-source-url-input') as HTMLInputElement,
-      'https://www.strava.com/segments/9999999'
-    );
-    await act(async () => {
-      vi.advanceTimersByTime(150);
-      await Promise.resolve();
-    });
-
-    await act(async () => {
-      firstPreview.resolve({
-        strava_segment_id: '2234642',
-        name: 'Older Preview',
-        distance: 1000,
-        average_grade: 2.1,
-        city: 'Oldtown',
-        state: 'MA',
-        country: 'USA',
-      });
-      await Promise.resolve();
-    });
-
-    expect(queryByTestId(container, 'explorer-destination-preview-card')).toBeNull();
-
-    await act(async () => {
-      secondPreview.resolve({
-        strava_segment_id: '9999999',
-        name: 'Newest Preview',
-        distance: 4500,
-        average_grade: 6.2,
-        city: 'Newtown',
-        state: 'VT',
-        country: 'USA',
-      });
-      await Promise.resolve();
-    });
-
-    expect(getByTestId(container, 'explorer-destination-preview-card').textContent).toContain('Newest Preview');
-    expect(getByTestId(container, 'explorer-destination-preview-card').textContent).not.toContain('Older Preview');
-  });
-
-  it('renders richer destination cards when a campaign already has destinations', async () => {
-    trpcMocks.campaignQuery.data = {
-      id: 41,
-      name: 'Spring 2026 Explorer',
-      rulesBlurb: 'Ride every destination once.',
-      destinations: [
-        {
-          id: 99,
-          displayLabel: 'Box Hill opener',
-          customLabel: 'Box Hill opener',
-          segmentName: 'Box Hill KOM',
-          displayOrder: 0,
-          sourceUrl: 'https://www.strava.com/segments/2234642',
-          stravaSegmentId: '2234642',
-          createdAt: '2026-04-17 13:15:00',
-          distance: 2931,
-          averageGrade: 5.4,
-          city: 'Dorking',
-          state: 'Surrey',
-          country: 'United Kingdom',
-        },
-      ],
-    };
-
-    const { container } = await renderPanel();
-
-    expect(getByTestId(container, 'explorer-destination-row-99').textContent).toContain('Box Hill opener');
-    expect(getByTestId(container, 'explorer-destination-row-99').textContent).toContain('2.93 km');
-    expect(getByTestId(container, 'explorer-destination-row-99').textContent).toContain('5.4% avg grade');
-    expect(getByTestId(container, 'explorer-destination-row-99').textContent).toContain('Dorking, Surrey, United Kingdom');
-
-    await clickElement(getByTestId(container, 'explorer-destination-toggle-99'));
-
-    expect(getByTestId(container, 'explorer-destination-row-99').textContent).toContain('Original segment name: Box Hill KOM');
-    expect(getByTestId(container, 'explorer-destination-row-99').textContent).toContain('Added');
+    expect(getByTestId(container, 'explorer-destination-list').textContent).toContain('Hilltown opener');
+    await clickElement(getByTestId(container, 'explorer-destination-toggle-301'));
+    expect(getByTestId(container, 'explorer-destination-row-301').textContent).toContain('Added');
   });
 });


### PR DESCRIPTION
## Summary
This slice corrects Explorer from the older season-attached model to the approved campaign-first model.

It moves Explorer campaigns onto campaign-owned date windows, enforces the v1 no-overlap rule, updates matching and admin contracts to operate on campaign dates, and replaces the minimal admin setup screen with a unified leaderboard-styled campaign editor.

## What Changed
- migrate `explorer_campaign` from `season_id` to `start_at` and `end_at`
- add the `0011_explorer_campaign_dates` migration and update legacy schema repair coverage
- refactor Explorer admin, matching, and query services to use campaign windows
- replace season-based admin reads with `getCampaigns`, `createCampaign`, and `updateCampaign`
- rewrite the Explorer admin UI into an all-in-one campaign editor with nested preview-first destination authoring
- update backend, frontend, and Playwright coverage plus Explorer API and database docs

## Validation
- pre-commit typecheck passed
- pre-commit lint passed
- `npm test`
- `npm run build`
- Docker build rerun by user
- E2E rerun by user

## Notes
- `VERSION` and `CHANGELOG.md` are intentionally unchanged because this slice is being prepared for review rather than a final user-facing release commit.
