### PR TITLE
Add Explorer athlete hub read surface

### DIFF
--- a/.github/skills/leaderboard-design-audit/SKILL.md
+++ b/.github/skills/leaderboard-design-audit/SKILL.md
@@ -27,6 +27,8 @@ argument-hint: 'Describe the UI surface to audit or design and whether you want 
 - `src/components/CollapsibleSegmentProfile.tsx`
 - `src/components/WeeklyLeaderboard.tsx`
 - `src/components/ScheduleTable.tsx`
+- `src/components/BottomNav.tsx`
+- `src/components/BottomNav.css`
 
 ## Procedure
 
@@ -34,8 +36,9 @@ argument-hint: 'Describe the UI surface to audit or design and whether you want 
 2. Read `docs/LEADERBOARD_DESIGN_SYSTEM.md` first.
 3. Identify which leaderboard source files are the closest analog for the target UI.
 4. Decide whether the target surface is primarily a ranking card, a hero header, a compact segment-object card, or a reveal panel.
-5. Call out any gaps where the current design system does not define a stable pattern, especially forms and admin controls.
-6. Recommend the smallest set of new styles necessary after reuse is exhausted.
+5. If the surface switches between peer app views such as Weekly, Season, Schedule, Hub, or Destinations, check whether it should reuse the fixed bottom-nav pattern instead of introducing pill tabs, segmented controls, or ad hoc local nav.
+6. Call out any gaps where the current design system does not define a stable pattern, especially forms and admin controls.
+7. Recommend the smallest set of new styles necessary after reuse is exhausted.
 
 ## Output Expectations
 
@@ -53,6 +56,8 @@ Return a compact result with:
 - Prefer tokenized colors and font scale from `src/index.css` over hardcoded values.
 - Prefer `leaderboard-card`, `card-*`, and `week-header-chip` over bespoke replacements when the semantics match.
 - Prefer `SegmentCard` for compact segment or destination-object title and metadata styling when there is no ranking-row hierarchy.
+- Prefer the existing fixed bottom-nav pattern for switching between top-level peer views inside a leaderboard-inspired surface; do not replace it with pill tabs unless the design system explicitly documents a new navigation primitive.
+- Preserve the leaderboard heading hierarchy: hero and section headings should usually remain WMV purple, while `var(--wmv-text-dark)` should be reserved for dense values, participant identity, and compact destination titles.
 - Prefer icon-only circular action buttons for obvious row or card actions when accessible labels are provided.
 - Keep carets as the dedicated expand or collapse affordance and place them at the far right of mixed-action rows unless there is a documented reason not to.
 - If the leaderboard does not yet define a pattern, name that gap explicitly instead of guessing.

--- a/docs/LEADERBOARD_DESIGN_SYSTEM.md
+++ b/docs/LEADERBOARD_DESIGN_SYSTEM.md
@@ -34,6 +34,7 @@ Use these files in this order when building or reviewing leaderboard-style UI:
 | Segment profile wrapper | `src/components/CollapsibleSegmentProfile.tsx` | Collapsible segment-detail heading and reveal pattern |
 | Weekly tab composition | `src/components/WeeklyLeaderboard.tsx` | Card stacking, expansion rhythm, no-results state |
 | Schedule tab composition | `src/components/ScheduleTable.tsx` and `src/components/ScheduleTable.css` | Week-list rhythm, next-up badge, schedule expansion layout |
+| Bottom navigation | `src/components/BottomNav.tsx` and `src/components/BottomNav.css` | Fixed mobile-first peer-view navigation for Weekly, Season, Schedule, and analogous Explorer subviews |
 
 If a new UI conflicts with these files, the new UI should usually change before the leaderboard primitives do.
 
@@ -76,7 +77,10 @@ The global type system lives in `src/index.css`.
 Rules:
 - Prefer the tokenized font scale over hardcoded pixel values.
 - For card titles and key metadata, reuse existing leaderboard classes before inventing new font rules.
+- Let section, hero, and card headings keep the default WMV purple unless the surface is intentionally acting like a dense row or compact object title.
+- Reserve `var(--wmv-text-dark)` for primary values, participant identity, compact destination or segment titles, and other dense data surfaces rather than flattening every heading to dark body text.
 - Secondary metadata should usually sit on `var(--wmv-text-light)` and `var(--font-sm)` or smaller.
+- Progress annotations, completion copy, helper text, and empty-state body copy should usually stay on `var(--wmv-text-light)` unless product meaning requires stronger emphasis.
 
 ### Layout And Spacing
 
@@ -198,6 +202,25 @@ Rules:
 
 ## Tab-Specific Patterns
 
+### Bottom Navigation
+
+Source files:
+- `src/components/BottomNav.tsx`
+- `src/components/BottomNav.css`
+
+Defining traits:
+- fixed to the bottom edge of the viewport
+- three peer views presented as icon-plus-label items
+- active item uses orange highlight while inactive items stay muted
+- built for app-level mode switching, not for inline filtering or segmented control behavior
+- supported by a spacer in content flow so the last card is not hidden behind the nav
+
+Rules:
+- when a leaderboard-inspired surface needs switching between peer views such as Weekly, Season, Schedule, Hub, Destinations, or a future Map, prefer this bottom-nav pattern first
+- do not replace this with pill tabs, chip toggles, or a top-of-card segmented control unless a new navigation primitive is intentionally documented
+- if one destination or mode is not ready yet, keep the item visually present but clearly disabled rather than inventing a different navigation container
+- keep icon weight, label scale, and active-state treatment aligned with `BottomNav.css`
+
 ### Weekly
 
 Source files:
@@ -209,6 +232,7 @@ Source files:
 Defining traits:
 - the week header is the hero surface for the page
 - the week name itself is the Strava link, styled in orange with an inline external-link icon
+- surrounding headings retain the WMV purple hierarchy instead of being reset to body-dark
 - metadata directly under the title is quiet and compact
 - detailed rider rows use the shared card shell, not bespoke component framing
 - expanded rider details keep metrics and links compact, not dashboard-like
@@ -285,8 +309,15 @@ Explorer should default to the leaderboard system in this order:
 4. Reuse `SegmentCard` title and metadata treatment whenever an Explorer destination is behaving like a compact segment object.
 5. Reuse the linked-title pattern from `WeeklyHeader.tsx` for hero-level Explorer headers or destination surfaces that are acting like weekly-header analogs.
 6. Reuse the `Schedule` segment-entry hierarchy for Explorer destination rows when they are the primary objects in a list and need the larger title, inline arrow affordance, and flatter single-surface card treatment.
-7. Reuse `CollapsibleSegmentProfile` as the default reference for deeper segment or destination detail reveals inside expanded surfaces.
-8. Only add Explorer-specific classes for layout or semantics the leaderboard primitives do not already express.
+7. Reuse `BottomNav` as the default reference when Explorer needs local peer-view switching between Hub, Destinations, Map, or similar sections.
+8. Reuse `CollapsibleSegmentProfile` as the default reference for deeper segment or destination detail reveals inside expanded surfaces.
+9. Only add Explorer-specific classes for layout or semantics the leaderboard primitives do not already express.
+
+Explorer typography note:
+- do not reset all Explorer headings to `var(--wmv-text-dark)` just because the page is data-heavy
+- keep hero and section headings in the standard purple hierarchy
+- use dark text more selectively for compact destination titles and numeric values
+- keep supporting copy, completion text, and helper states quieter on `var(--wmv-text-light)`
 
 Do not treat legacy admin components as the source of truth for public Explorer UI.
 
@@ -318,9 +349,10 @@ Before approving a new leaderboard-inspired UI, check:
 2. Does it reuse `leaderboard-card`, `card-*`, or `week-header-chip` where the semantics match?
 3. Does it use `SegmentCard` conventions when the surface is fundamentally a segment or destination object rather than a ranking row?
 4. Does the title, metadata, and value hierarchy feel consistent with Weekly, Season, Schedule, or Segment patterns?
-5. Is the link treatment consistent with the public leaderboard rather than legacy admin?
-6. Are any new classes truly new primitives, or are they accidental duplicates of existing ones?
-7. If a new primitive is real, has it been documented here or in a companion UI standard?
+5. If the surface switches between peer views, does it reuse the fixed bottom-nav pattern rather than inventing a local pill-tab system?
+6. Is the link treatment consistent with the public leaderboard rather than legacy admin?
+7. Are any new classes truly new primitives, or are they accidental duplicates of existing ones?
+8. If a new primitive is real, has it been documented here or in a companion UI standard?
 
 ## Non-Authoritative References
 

--- a/docs/prds/wmv-explorer-destinations-phases.md
+++ b/docs/prds/wmv-explorer-destinations-phases.md
@@ -212,7 +212,7 @@ Validation:
 
 Goal: tighten the shared segment metadata model so Explorer admin cards can show stable destination details now and future map work can start from stored coordinates rather than from ad hoc Strava fetches.
 
-Status: approved as the next bounded follow-on slice after 4B-4.
+Status: merged on `main` as the shared segment metadata baseline for later athlete-facing Explorer work.
 
 Scope:
 
@@ -241,16 +241,74 @@ Validation:
 - Frontend unit tests for expanded destination detail rendering when added-at and metadata-freshness values are present or absent
 - Slice-normal `npm run lint`, `npm run typecheck`, and targeted build verification
 
-## Phase 5: Explorer Hub MVP
+## Phase 5: Athlete Explorer Rollout
 
-Goal: ship the athlete-facing Explorer view only after the admin flow is stable and Explorer is approved for end-user release.
+Goal: introduce the athlete-facing Explorer experience in deliberately small, progress-first slices after the admin flow and shared segment metadata baseline are stable.
+
+### Slice 5A: Athlete Hub Read Surface
+
+Goal: ship the smallest useful athlete Explorer page, still admin-gated, so logged-in athletes can understand the active campaign and their own completion state without opening map or social scope yet.
+
+Status: approved as the next bounded slice after 4B-5.
+
 
 Scope:
+- Add a new Explorer page or route, still admin-gated for now, that can later become the public Explorer entry surface.
+- Reuse the documented leaderboard design system for hierarchy, hero framing, chips, compact destination metadata, and empty-state rhythm instead of falling back to legacy admin styling.
+- Show the active Explorer campaign with campaign title, date context, and a short rules summary.
+- Show the logged-in athlete's progress summary for the active campaign, including completed destinations versus total destinations.
+- Render a list-first destination experience that makes remaining versus completed destinations easy to scan without introducing rank-order semantics.
+- Keep the page focused on current-athlete understanding first: what destinations exist, what has been completed, and what remains.
+- Keep the route and data shape compatible with later ungated release, but do not add public navigation yet.
 
-- Challenges hub route
-- Active campaign header
-- Progress bar
-- Destination checklist
+Out of scope:
+
+- Map rendering, location permission prompts, proximity search, or map-provider selection
+- Social-feed behavior, destination activity feed, or broader athlete-to-athlete visibility
+- Rich browse or search behavior beyond the minimum list organization needed to keep the page understandable
+- Public release exposure to non-admin users
+- Ranking, leaderboard semantics, or competition-style ordering
+
+Validation:
+
+- Backend tests for active-campaign athlete progress and destination-list reads if new Explorer query surfaces are added
+- Frontend unit tests for the athlete Explorer page, including progress summary, completed or remaining destination rendering, and empty states
+- Targeted Playwright coverage for the admin-gated Explorer page if a new protected route is added
+- Slice-normal `npm run lint`, `npm run typecheck`, and targeted build verification
+
+Implementation note:
+
+- Prefer a list-first page for 5A. The shared segment coordinates captured in 4B-5 enable later map planning, but they do not force map rendering into the first athlete-facing slice.
+
+### Slice 5B: Checklist And Browse Refinement
+
+Goal: improve the athlete checklist experience once the 5A page exists and real campaign volume exposes where scanning or filtering starts to break down.
+
+Candidate scope:
+
+- Refine list organization for larger destination sets
+- Add lightweight search, filtering, or grouping only if 5A usage shows the list needs it
+- Improve destination card detail hierarchy while preserving the progress-first model
+
+### Slice 5C: Map Discovery
+
+Goal: add map-based discovery only after the list-first athlete page exists and the map product questions are explicitly answered.
+
+Candidate scope:
+
+- Choose a map provider and document licensing, hosting, and mobile behavior tradeoffs
+- Define how a destination should appear on the map, including whether the UI centers on a segment start point, end point, midpoint, or later geometry
+- Add a clear relationship between the map and the destination list instead of forcing both into one overloaded first page
+
+### Slice 5D: Social Visibility
+
+Goal: add lightweight communal visibility only after the athlete's personal-progress experience is stable.
+
+Candidate scope:
+
+- Completers summary expansion beyond the minimum MVP treatment
+- Recent completion activity or other social visibility patterns if they still fit the progress-first product intent
+- Explicit guardrails to avoid drifting into a second race-style leaderboard
 - Completers summary with all names
 
 ## Phase 6: Hardening And Follow-on Expansion

--- a/docs/prds/wmv-explorer-execution-briefing.md
+++ b/docs/prds/wmv-explorer-execution-briefing.md
@@ -177,10 +177,11 @@ Prompts should remain narrow and convenient.
 - Run local validation.
 - Update docs if the slice changes visible behavior or planning state.
 
-### Slice-splitting note for 4B
+### Slice-splitting note for Explorer follow-on work
 
-- The earlier 4B split is now complete through 4B-4: 4B-1 hardened the portable E2E harness, 4B-2 landed the minimal admin-only Explorer UI, 4B-3 corrected the campaign model and unified admin shell, and 4B-4 refined the admin workflow hierarchy.
-- Follow-on work should now start from updated `main` on a fresh branch for the approved 4B-5 segment metadata fidelity and freshness slice rather than reopening the merged admin-shell work.
+- The earlier 4B split is now complete through 4B-5: 4B-1 hardened the portable E2E harness, 4B-2 landed the minimal admin-only Explorer UI, 4B-3 corrected the campaign model and unified admin shell, 4B-4 refined the admin workflow hierarchy, and 4B-5 landed the shared segment metadata fidelity baseline.
+- Follow-on work should now start from updated `main` on a fresh branch for the approved 5A athlete hub read surface rather than reopening the merged admin-shell work or broadening immediately into map and social features.
+- Treat map-provider research, location-aware discovery, and social-feed ideas as separate later slices unless the planning docs explicitly re-approve them as part of a new bounded implementation brief.
 
 ### Slice completion discipline
 

--- a/docs/prds/wmv-explorer-readiness-checklist.md
+++ b/docs/prds/wmv-explorer-readiness-checklist.md
@@ -17,23 +17,23 @@ The ideas backlog is intentionally excluded from v1 implementation scope. It exi
 
 ## Current Go Decision
 
-**Status:** Phase 1 Complete; Campaign-First Explorer Correction Landed; Phase 4A Admin Backend Complete; Phase 4B-1 E2E Harness Hardening Merged; Phase 4B-2 Minimal Admin UI Merged; Phase 4B-3 Campaign Decoupling And Unified Admin Shell Merged; Phase 4B-4 Admin Workflow Hierarchy And Destination Management Merged; Ready For Phase 4B-5 Segment Metadata Fidelity And Freshness
+**Status:** Phase 1 Complete; Campaign-First Explorer Correction Landed; Phase 4A Admin Backend Complete; Phase 4B-1 E2E Harness Hardening Merged; Phase 4B-2 Minimal Admin UI Merged; Phase 4B-3 Campaign Decoupling And Unified Admin Shell Merged; Phase 4B-4 Admin Workflow Hierarchy And Destination Management Merged; Phase 4B-5 Segment Metadata Fidelity And Freshness Merged; Ready For Phase 5A Athlete Hub Read Surface
 
-Explorer has completed the narrow Phase 1 webhook-orchestration slice that preserves current competition behavior while introducing delegated in-process handlers. The planning set corrected Explorer to a campaign-first model with campaign-owned date boundaries, returned `Season` to competition-only semantics, deferred overlapping or nested campaign structures, and locked a no-overlap Explorer rule for v1. The current-or-next admin workflow refinement is now also merged on `main`, so the next recommended work is a bounded 4B-5 metadata-fidelity slice that extends the shared segment model with the coordinates and freshness data needed for richer admin details and later map-safe follow-on work.
+Explorer has completed the narrow Phase 1 webhook-orchestration slice that preserves current competition behavior while introducing delegated in-process handlers. The planning set corrected Explorer to a campaign-first model with campaign-owned date boundaries, returned `Season` to competition-only semantics, deferred overlapping or nested campaign structures, and locked a no-overlap Explorer rule for v1. The shared segment metadata-fidelity slice is now also merged on `main`, so the next recommended work is a deliberately small 5A athlete read surface that stays admin-gated, reuses the modern leaderboard design system, and proves the active-campaign plus personal-progress experience before the project opens map or social scope.
 
-The current 4B-5 boundary is explicit: keep the merged 4B-4 workflow intact; extend the shared segment metadata path with start or end coordinates plus metadata freshness; make expanded admin details reliably show available timestamps instead of ambiguous placeholders; and avoid broadening into bespoke Explorer refresh controls, polyline storage, or map rendering in the same slice.
+The current 5A boundary is explicit: keep the merged admin flow and shared segment metadata baseline intact; add one athlete-facing Explorer page that explains the active campaign and the current athlete's completion state; organize destinations through a list-first progress model; remain admin-gated until release approval; and avoid broadening into map-provider decisions, location-based discovery, or social-feed behavior in the same slice.
 
 ## Current Status Summary
 
 | Area | Status | Notes |
 | --- | --- | --- |
 | Product framing | Ready | The PRD is now aligned to a campaign-first Explorer model with campaign-owned dates and competition-only `Season` semantics. |
-| Execution phasing | Ready For Phase 4B-5 | The phases doc now records 4B-4 as merged and names 4B-5 as the metadata-fidelity and freshness slice. |
-| Architecture closure | Ready For Shared Metadata Refinement | The campaign-first correction and current admin hierarchy are merged, so follow-on work can focus on segment-model fidelity instead of reopening the Explorer shell. |
+| Execution phasing | Ready For Phase 5A | The phases doc now records 4B-5 as merged and names 5A as the smallest athlete-facing read surface. |
+| Architecture closure | Ready For Athlete Read Surface | The campaign-first correction, current admin hierarchy, and shared segment metadata baseline are merged, so follow-on work can focus on athlete progress presentation instead of reopening the admin shell. |
 | Open questions handling | Ready | The worklog now records the superseded season-attached decision and the locked no-overlap rule. |
-| Blocking research closure | Ready For Phase 4B-5 | The product-model correction is closed and the next work is a bounded shared-metadata refinement slice. |
-| Test planning | Ready For Phase 4B-5 | The next test-planning work is attached to coordinate persistence, metadata freshness, and admin detail rendering rather than more workflow hierarchy changes. |
-| Documentation impact plan | Ready For Phase 4B-5 | The next documentation impact is slice-local planning-state maintenance plus technical-spec and schema notes created by 4B-5. |
+| Blocking research closure | Ready For Phase 5A | The next slice is intentionally list-first and admin-gated, so map-provider and social-feed questions are recorded as deferred rather than blocking the first athlete surface. |
+| Test planning | Ready For Phase 5A | The next test-planning work is attached to athlete progress reads, destination-list presentation, and protected-route behavior rather than more admin-shell changes. |
+| Documentation impact plan | Ready For Phase 5A | The next documentation impact is slice-local planning-state maintenance plus any athlete Explorer API or UX notes created by 5A. |
 
 ## Must Resolve Before Broad Implementation
 
@@ -52,23 +52,23 @@ The current 4B-5 boundary is explicit: keep the merged 4B-4 workflow intact; ext
 
 | Field | Value |
 | --- | --- |
-| Status | Ready |
+| Status | Ready For 5A |
 | Gate | Must Resolve |
 | Why it matters | Engineering should not start building around two competing summary models. |
-| Evidence | The corrected technical spec now explicitly chooses computed on read for `ExplorerAthleteCampaignSummary`, with `ExplorerDestinationMatch` as the durable source of truth. |
-| Acceptance criteria | The tech spec explicitly chooses one v1 approach: computed on read or cached summary. It also states the reason for that choice and what is deferred. |
-| Next action | Carry the locked decision into the corrected implementation brief and tests. |
+| Evidence | The corrected technical spec explicitly chooses computed on read for `ExplorerAthleteCampaignSummary`, with `ExplorerDestinationMatch` as the durable source of truth, which is the right foundation for a read-only first athlete page. |
+| Acceptance criteria | The 5A slice uses the computed-on-read summary model for the active campaign and does not introduce a cached-summary table just to power the first athlete page. |
+| Next action | Carry the locked summary decision into the 5A implementation brief and tests. |
 
 ### 3. Explorer Destination Metadata Strategy
 
 | Field | Value |
 | --- | --- |
-| Status | Ready |
+| Status | Ready For 5A |
 | Gate | Must Resolve |
 | Why it matters | Explorer destination setup depends on how segment data is validated, stored, and displayed over time. |
-| Evidence | The current UI already has real segment URL parsing and validation patterns in [src/components/SegmentInput.tsx](../../src/components/SegmentInput.tsx) and [src/components/ManageSegments.tsx](../../src/components/ManageSegments.tsx), Explorer already reuses shared segment rows for distance and location reads, and the current Strava client package exposes `start_latlng` and `end_latlng` on segment responses even though the app does not store them yet. |
-| Acceptance criteria | The tech spec explicitly states that Explorer continues to reuse the shared segment table, that the shared table should now capture the available coordinate and metadata-freshness fields needed for later map-safe work, and that Explorer does not add bespoke refresh logic for those values. |
-| Next action | Carry the locked DB-first storage policy, coordinate capture, and metadata-freshness fields into 4B-5, while keeping polylines, true map rendering, and Explorer-specific refresh controls out of scope. |
+| Evidence | Explorer continues to reuse shared segment rows for distance and location reads, and 4B-5 has now landed the stored coordinate and metadata-freshness baseline needed for later map-safe work without forcing map rendering into the first athlete slice. |
+| Acceptance criteria | The 5A page reads from the existing DB-first destination and progress model, uses the shared segment metadata already captured, and does not introduce new map-specific storage, geolocation prompts, or Explorer-only refresh logic. |
+| Next action | Carry the locked DB-first storage policy and existing shared segment metadata into 5A while keeping map-provider, geometry, and browse-discovery work deferred to later Phase 5 slices. |
 
 ### 4. Centralized Open Questions
 
@@ -77,7 +77,7 @@ The current 4B-5 boundary is explicit: keep the merged 4B-4 workflow intact; ext
 | Status | Ready |
 | Gate | Must Resolve |
 | Why it matters | Scattered uncertainty forces implementation chats to rediscover unresolved design choices. |
-| Evidence | The worklog open-questions table now reflects the corrected campaign model and remaining non-blocking questions. |
+| Evidence | The worklog open-questions table now reflects the corrected campaign model, the admin-gated athlete-page decision for 5A, and the remaining non-blocking map or social follow-on questions. |
 | Acceptance criteria | One section in the worklog or readiness checklist lists all unresolved questions, their current status, and whether they block implementation. |
 | Next action | Seed the worklog with a dedicated open-questions section and keep it current. |
 
@@ -85,12 +85,12 @@ The current 4B-5 boundary is explicit: keep the merged 4B-4 workflow intact; ext
 
 | Field | Value |
 | --- | --- |
-| Status | Ready |
+| Status | Ready For 5A |
 | Gate | Must Resolve |
-| Why it matters | The team needs a shared rule for what can proceed now that the campaign-first correction and admin workflow hierarchy are both merged. |
-| Evidence | The implemented webhook seam remains valid, 4A, 4B-1, 4B-2, 4B-3, and 4B-4 are merged, and the next slice is now re-approved as Phase 4B-5 segment metadata fidelity plus freshness. |
-| Acceptance criteria | The readiness artifacts clearly state that Explorer is ready for one bounded shared-metadata slice next and identify what remains out of scope. |
-| Next action | Keep the current go decision updated as additional corrected Explorer slices are approved or deferred, and close slice-local planning state in the implementation PR when the slice changes readiness or phase status. |
+| Why it matters | The team needs a shared rule for what can proceed now that the campaign-first correction, admin workflow hierarchy, and shared segment metadata baseline are all merged. |
+| Evidence | The implemented webhook seam remains valid, 4A through 4B-5 are merged, and the next slice is now approved as Phase 5A athlete hub read surface. |
+| Acceptance criteria | The readiness artifacts clearly state that Explorer is ready for one bounded athlete read-surface slice next and identify map, browse, and social follow-ons as out of scope. |
+| Next action | Keep the current go decision updated as additional athlete-facing Explorer slices are approved or deferred, and close slice-local planning state in the implementation PR when the slice changes readiness or phase status. |
 
 ## Should Resolve Before 4A And 4B Expand
 
@@ -120,12 +120,12 @@ The current 4B-5 boundary is explicit: keep the merged 4B-4 workflow intact; ext
 
 | Field | Value |
 | --- | --- |
-| Status | Ready For Phase 4B-5 |
+| Status | Ready For Phase 5A |
 | Gate | Should Resolve |
 | Why it matters | Explorer touches admin, athlete, API, database, and release-note surfaces. That work should be visible before coding. |
-| Evidence | The 4A slice updated `docs/API.md`, `docs/DATABASE_DESIGN.md`, and the slice-local planning docs, while 4B-3 and 4B-4 carried the structural correction plus admin workflow refinement. The 4B-5 slice is expected to update slice-local planning docs, the technical spec, and schema documentation if shared segment fields expand. |
-| Acceptance criteria | The worklog or implementation slice names the docs expected to change when the slice lands, including any slice-local planning docs needed to close the state transition. |
-| Next action | Keep the documentation-impact checklist current and treat 4B-5 planning-state maintenance plus any shared-segment schema notes as the next expected update set. |
+| Evidence | The 4A slice updated `docs/API.md`, `docs/DATABASE_DESIGN.md`, and the slice-local planning docs, while 4B-3 through 4B-5 carried the structural correction, admin workflow refinement, and shared segment metadata baseline. The 5A slice is expected to update slice-local planning docs and any athlete Explorer API or UX documentation that changes when the first athlete page lands. |
+| Acceptance criteria | The worklog or implementation slice names the docs expected to change when 5A lands, including any slice-local planning docs needed to close the state transition. |
+| Next action | Keep the documentation-impact checklist current and treat 5A planning-state maintenance plus any athlete Explorer API or UX notes as the next expected update set. |
 
 ### 4. Smallest End-To-End Slice
 
@@ -170,7 +170,8 @@ If a slice is expected to change the approved next step, readiness wording, or p
 | Phase 4A Admin Backend Complete | Yes |
 | Phase 4B-1 E2E Harness Hardening Merged | Yes |
 | Phase 4B-2 Minimal Admin UI Merged | Yes |
-| Ready For Phase 4B-5 Segment Metadata Fidelity And Freshness | Yes |
+| Phase 4B-5 Segment Metadata Fidelity And Freshness Merged | Yes |
+| Ready For Phase 5A Athlete Hub Read Surface | Yes |
 | Ready For Broad Feature Implementation | No |
 
-If this file says anything stronger than **Phase 1 Complete; Campaign-First Explorer Correction Landed; Phase 4A Admin Backend Complete; Phase 4B-1 E2E Harness Hardening Merged; Phase 4B-2 Minimal Admin UI Merged; Phase 4B-3 Campaign Decoupling And Unified Admin Shell Merged; Phase 4B-4 Admin Workflow Hierarchy And Destination Management Merged; Ready For Phase 4B-5 Segment Metadata Fidelity And Freshness**, the linked worklog should show exactly what changed to justify that shift.
+If this file says anything stronger than **Phase 1 Complete; Campaign-First Explorer Correction Landed; Phase 4A Admin Backend Complete; Phase 4B-1 E2E Harness Hardening Merged; Phase 4B-2 Minimal Admin UI Merged; Phase 4B-3 Campaign Decoupling And Unified Admin Shell Merged; Phase 4B-4 Admin Workflow Hierarchy And Destination Management Merged; Phase 4B-5 Segment Metadata Fidelity And Freshness Merged; Ready For Phase 5A Athlete Hub Read Surface**, the linked worklog should show exactly what changed to justify that shift.

--- a/docs/prds/wmv-explorer-worklog.md
+++ b/docs/prds/wmv-explorer-worklog.md
@@ -4,16 +4,17 @@ This worklog is the active operating log for Explorer. The readiness checklist i
 
 ## Current Focus
 
-- Refine the shared segment metadata model so Explorer admin details expose stable destination information and future map work starts from stored coordinates rather than from ad hoc Strava calls.
-- Capture the Strava segment coordinates and metadata freshness fields the app can store now, while keeping Explorer destination reads DB-first.
+- Define the smallest athlete-facing Explorer page that is still useful while keeping the route admin-gated for now.
+- Use a list-first progress model so athletes can see what destinations are available, what they have completed, and what remains without opening map or social scope yet.
+- Carry the modern leaderboard design system into the first athlete Explorer page instead of drifting back toward legacy admin styling.
 - Keep any pre-release Explorer UI admin-gated until there is an explicit end-user release decision.
-- Keep the next handoff and implementation brief aligned with the merged campaign-first model plus the existing shared `SegmentService` metadata seam.
+- Keep the next handoff and implementation brief aligned with the merged campaign-first model, the shared segment metadata baseline, and a route that can later become the public Explorer page.
 
 ## Current Go State
 
-- **Readiness:** Phase 1 Complete; Campaign-First Explorer Correction Landed; Phase 4A Admin Backend Complete; Phase 4B-1 E2E Harness Hardening Merged; Phase 4B-2 Minimal Admin UI Merged; Phase 4B-3 Campaign Decoupling And Unified Admin Shell Merged; Phase 4B-4 Admin Workflow Hierarchy And Destination Management Merged; Ready For Phase 4B-5 Segment Metadata Fidelity And Freshness
-- **Immediate scope:** extend the shared segment model so Explorer can show reliable added-at and metadata detail now, and preserve coordinate data for later map-safe work without inventing Explorer-only Strava refresh behavior
-- **Not yet in scope:** public athlete-facing Explorer release, public navigation to Explorer, mini-campaigns, or explicit publish-status workflows
+- **Readiness:** Phase 1 Complete; Campaign-First Explorer Correction Landed; Phase 4A Admin Backend Complete; Phase 4B-1 E2E Harness Hardening Merged; Phase 4B-2 Minimal Admin UI Merged; Phase 4B-3 Campaign Decoupling And Unified Admin Shell Merged; Phase 4B-4 Admin Workflow Hierarchy And Destination Management Merged; Phase 4B-5 Segment Metadata Fidelity And Freshness Merged; Ready For Phase 5A Athlete Hub Read Surface
+- **Immediate scope:** add one admin-gated athlete Explorer page that shows the active campaign, the current athlete's progress summary, and a list-first destination checklist
+- **Not yet in scope:** public athlete-facing Explorer release, public navigation to Explorer, map rendering, location-based discovery, social-feed behavior, mini-campaigns, or explicit publish-status workflows
 
 ## Decisions Made
 
@@ -48,6 +49,9 @@ This worklog is the active operating log for Explorer. The readiness checklist i
 - Shared segment-field expansion should benefit both competition and Explorer because the backend segment model is shared, even if Explorer admin is the first surface to display the extra detail.
 - The next metadata slice should not introduce bespoke Explorer refresh controls; any future refresh should continue to ride through the shared segment metadata service and broader resync paths.
 - Polyline or full geometry storage remains deferred; start and end coordinates are the minimum useful map-safe capture for now.
+- The first athlete-facing Explorer slice should stay admin-gated, centered on the active campaign plus the current athlete's own progress, and reuse the documented leaderboard design system rather than legacy admin styling.
+- Map-based discovery is important follow-on work, but it should start only after the list-first athlete page exists and the map product questions are answered explicitly.
+- Social visibility can grow later, but a social feed is not the smallest useful first athlete-facing Explorer surface.
 
 ## Open Questions
 
@@ -70,6 +74,9 @@ This worklog is the active operating log for Explorer. The readiness checklist i
 | Should already-added Explorer destination cards support persisted inline editing in the first UX-refinement slice? | Closed For 4B-3 | No | No. Keep 4B-3 to preview-add flow plus richer read-only cards. |
 | Does Explorer need true map-ready coordinate storage now? | Closed For 4B-5 | No | No. The next slice should capture Strava start and end coordinates plus metadata freshness in the shared `segment` table, while deferring polylines, geometry, and map rendering. |
 | Should Explorer introduce its own Strava metadata refresh workflow? | Closed For 4B-5 | No | No. Keep metadata refresh tied to the shared segment metadata service and later broader resync flows rather than adding Explorer-only refresh behavior. |
+| What is the smallest useful first athlete-facing Explorer page after 4B-5? | Closed For 5A | No | A list-first, admin-gated athlete page showing the active campaign, personal progress, and completed versus remaining destinations. |
+| Should map-based destination discovery be part of the first athlete-facing slice? | Closed For 5A | No | No. Defer map-provider selection, geolocation behavior, and map/list interaction design to a later Phase 5 slice. |
+| Should a social feed or broader athlete activity visibility be part of the first athlete-facing slice? | Closed For 5A | No | No. Defer social expansion until after the personal-progress page is stable. |
 
 ## Blockers
 
@@ -156,26 +163,25 @@ The current preservation target is backed by:
 ### Recommended Next PR
 
 - Start from updated `main` on a dedicated implementation branch.
-- Keep the next implementation PR scoped to the shared segment metadata-fidelity slice:
-	- extend the shared `segment` storage path to capture Strava start and end coordinates when available
-	- add a metadata freshness timestamp so segment detail reads can show when the cached metadata was last updated
-	- keep Explorer destination reads DB-first and surface reliable added-at and metadata freshness details in expanded admin cards
-	- show Strava-sourced detail fields as read-only and keep any future WMV override fields separate from the raw Strava values
-	- normalize Strava segment fixtures, mapping, and persistence so the stored shape matches what the existing client already returns
-	- make the shared segment-field expansion available to competition and Explorer alike instead of adding an Explorer-only persistence path
-	- do not add Explorer-only refresh or backfill controls in the same slice
+- Keep the next implementation PR scoped to Phase 5A athlete hub read surface:
+	- add a new Explorer page or route that remains admin-gated for now and can later become the public Explorer surface
+	- show the active campaign header with date context and a short rules summary
+	- show the current athlete's progress summary for the active campaign
+	- render a list-first destination experience that clearly separates completed versus remaining destinations without rank-order semantics
+	- reuse the documented leaderboard design system for header hierarchy, chips, compact destination metadata, and empty states instead of legacy admin styling
+	- preserve the shared segment metadata baseline from 4B-5 without adding map rendering, location prompts, or Explorer-only browse logic
+	- do not add social-feed behavior or broader athlete-to-athlete visibility in the same slice
 - Validation path for the next PR:
-	- backend tests for shared segment metadata mapping and persistence, including coordinate and freshness fields
-	- focused Explorer query or service tests for destination detail reads
-	- frontend unit tests for expanded destination detail rendering when added-at and metadata-freshness values are present or absent
+	- backend tests for active-campaign athlete progress and destination-list reads if 5A needs new Explorer query procedures
+	- frontend unit tests for the athlete Explorer page, including progress summary, completed or remaining destination rendering, and empty states
+	- targeted Playwright for the new admin-gated page if the slice adds a protected route
 	- `npm run lint`, `npm run typecheck`, and targeted build verification
-	- targeted Playwright only if the admin detail presentation changes in a browser-significant way
-- Planning and documentation surfaces likely to change when 4B-5 lands:
+- Planning and documentation surfaces likely to change when 5A lands:
 	- `docs/prds/wmv-explorer-destinations-phases.md`
 	- `docs/prds/wmv-explorer-worklog.md`
 	- `docs/prds/wmv-explorer-readiness-checklist.md`
 	- `docs/prds/wmv-explorer-destinations-tech-spec.md`
-	- `docs/DATABASE_DESIGN.md` if shared segment fields expand
+	- `docs/API.md` if new athlete Explorer procedures are added
 
 ### 4B-3 Outcome
 
@@ -208,6 +214,36 @@ The current preservation target is backed by:
 - Existing Playwright impact:
 	- preserve the admin-only route and navigation behavior
 	- add or adjust browser coverage for the new hierarchy and destination removal flow
+	- continue using the hardened E2E harness rather than local-only assumptions
+
+### 4B-5 Outcome
+
+- Phase: 4B-5 Segment Metadata Fidelity And Freshness
+- Status: merged on `main`
+- Landed outcome:
+	- shared `segment` rows now carry the Strava coordinate and metadata-freshness fields needed for later athlete-facing Explorer follow-on work
+	- Explorer admin detail reads now surface stable destination timestamps and read-only Strava metadata more clearly
+	- the shared segment metadata path remains the single persistence seam for both Explorer and competition consumers
+
+### 5A Implementation Handoff
+
+- Slice: Phase 5A only.
+- Branch start point: updated `main`, then a dedicated feature branch before coding.
+- Governing scope: add the first athlete-facing Explorer page while keeping it admin-gated and list-first.
+- UI rule: use the documented leaderboard design system as the source of truth for the page shell, header hierarchy, chips, and destination metadata cards; do not fall back to legacy admin page styling.
+- Product recommendation:
+	- make one active campaign the clear focus of the page
+	- show the current athlete's progress immediately near the top of the page
+	- make the destination list the primary content area
+	- organize the page around remaining and completed destinations rather than around rank, feed events, or map controls
+	- keep the route ready to become the future public Explorer page, but do not add public navigation yet
+- Data recommendation:
+	- use the computed-on-read athlete summary model already approved in the tech spec
+	- reuse existing shared segment and Explorer destination metadata rather than inventing map-specific or feed-specific data for 5A
+	- defer map-provider selection, geolocation, and richer browse controls to later slices
+- Existing Playwright impact:
+	- preserve current admin gating behavior until release approval changes
+	- add targeted browser coverage only for the new protected Explorer page and its core read state if a route is introduced
 	- continue using the hardened E2E harness rather than local-only assumptions
 
 ### 4B-4 Branch-Ready Task List

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import ManageSegments from './components/ManageSegments';
 import SeasonManager from './components/SeasonManager';
 import WebhookManagementPanel from './components/WebhookManagementPanel';
 import ExplorerAdminPanel from './components/ExplorerAdminPanel';
+import ExplorerHubPage from './components/ExplorerHubPage';
 import StravaConnectInfoBox from './components/StravaConnectInfoBox';
 import StravaClubJoinPrompt from './components/StravaClubJoinPrompt';
 import AboutPage from './components/AboutPage';
@@ -29,7 +30,7 @@ import { httpBatchLink } from '@trpc/client';
 import { trpc } from './utils/trpc';
 import { Season, Week } from './types'; // Import shared types
 
-type ViewMode = 'leaderboard' | 'admin' | 'explorer-admin' | 'roles' | 'participants' | 'segments' | 'seasons' | 'webhooks' | 'about' | 'profile' | 'chat' | 'chain-checker';
+type ViewMode = 'leaderboard' | 'admin' | 'explorer' | 'explorer-admin' | 'roles' | 'participants' | 'segments' | 'seasons' | 'webhooks' | 'about' | 'profile' | 'chat' | 'chain-checker';
 
 interface LeaderboardViewProps {
   seasons: Season[];
@@ -189,6 +190,7 @@ function AppContent() {
     const path = location.pathname;
     if (path.startsWith('/admin')) return 'admin';
     if (path.startsWith('/explorer-admin')) return 'explorer-admin';
+    if (path.startsWith('/explorer')) return 'explorer';
     if (path.startsWith('/roles')) return 'roles';
     if (path.startsWith('/participants')) return 'participants';
     if (path.startsWith('/segments')) return 'segments';
@@ -208,6 +210,7 @@ function AppContent() {
   const getPageTitle = (mode: ViewMode) => {
     switch (mode) {
       case 'admin': return 'Manage Competition';
+      case 'explorer': return 'Explorer';
       case 'explorer-admin': return 'Manage Explorer';
       case 'roles': return 'Manage Roles';
       case 'participants': return 'Participant Status';
@@ -266,6 +269,9 @@ function AppContent() {
           } />
           <Route path="/explorer-admin" element={
             <ExplorerAdminPanel isAdmin={isAdmin} />
+          } />
+          <Route path="/explorer" element={
+            <ExplorerHubPage isAdmin={isAdmin} isConnected={isConnected} />
           } />
           <Route path="/roles" element={<AdminRoleManager />} />
           <Route path="/participants" element={<ParticipantStatus />} />

--- a/src/components/BottomNav.css
+++ b/src/components/BottomNav.css
@@ -29,6 +29,8 @@
   max-width: 168px;
   min-width: 64px;
   transition: color 0.2s;
+  text-decoration: none;
+  font: inherit;
 }
 
 .bottom-nav-item svg {
@@ -44,6 +46,19 @@
   color: var(--wmv-orange, #f56004);
 }
 
+.bottom-nav-item.disabled,
+.bottom-nav-item:disabled,
+.bottom-nav-item[aria-disabled='true'] {
+  color: #9a9a9a;
+  cursor: default;
+}
+
 .bottom-nav-item:active {
   background-color: rgba(0, 0, 0, 0.05);
+}
+
+.bottom-nav-item:disabled:active,
+.bottom-nav-item.disabled:active,
+.bottom-nav-item[aria-disabled='true']:active {
+  background-color: transparent;
 }

--- a/src/components/ExplorerBottomNav.tsx
+++ b/src/components/ExplorerBottomNav.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import './BottomNav.css';
+
+export type ExplorerTabType = 'hub' | 'destinations' | 'map';
+
+interface ExplorerBottomNavProps {
+  activeTab: ExplorerTabType;
+  onSelect: (tab: Exclude<ExplorerTabType, 'map'>) => void;
+}
+
+const ExplorerBottomNav: React.FC<ExplorerBottomNavProps> = ({ activeTab, onSelect }) => {
+  return (
+    <div className="bottom-nav" data-testid="explorer-bottom-nav" aria-label="Explorer views">
+      <button
+        type="button"
+        className={`bottom-nav-item ${activeTab === 'hub' ? 'active' : ''}`}
+        data-testid="explorer-tab-hub"
+        aria-pressed={activeTab === 'hub'}
+        onClick={() => onSelect('hub')}
+      >
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+          <rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect>
+          <line x1="16" y1="2" x2="16" y2="6"></line>
+          <line x1="8" y1="2" x2="8" y2="6"></line>
+          <line x1="3" y1="10" x2="21" y2="10"></line>
+        </svg>
+        <span>Hub</span>
+      </button>
+
+      <button
+        type="button"
+        className={`bottom-nav-item ${activeTab === 'destinations' ? 'active' : ''}`}
+        data-testid="explorer-tab-destinations"
+        aria-pressed={activeTab === 'destinations'}
+        onClick={() => onSelect('destinations')}
+      >
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+          <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10Z"></path>
+          <path d="m9 12 2 2 4-4"></path>
+        </svg>
+        <span>Destinations</span>
+      </button>
+
+      <button
+        type="button"
+        className="bottom-nav-item disabled"
+        data-testid="explorer-tab-map"
+        aria-disabled="true"
+        disabled
+      >
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+          <polygon points="3 6 9 3 15 6 21 3 21 18 15 21 9 18 3 21"></polygon>
+          <line x1="9" y1="3" x2="9" y2="18"></line>
+          <line x1="15" y1="6" x2="15" y2="21"></line>
+        </svg>
+        <span>Map</span>
+      </button>
+    </div>
+  );
+};
+
+export default ExplorerBottomNav;

--- a/src/components/ExplorerBottomNav.tsx
+++ b/src/components/ExplorerBottomNav.tsx
@@ -10,7 +10,7 @@ interface ExplorerBottomNavProps {
 
 const ExplorerBottomNav: React.FC<ExplorerBottomNavProps> = ({ activeTab, onSelect }) => {
   return (
-    <div className="bottom-nav" data-testid="explorer-bottom-nav" aria-label="Explorer views">
+    <nav className="bottom-nav" data-testid="explorer-bottom-nav" aria-label="Explorer views">
       <button
         type="button"
         className={`bottom-nav-item ${activeTab === 'hub' ? 'active' : ''}`}
@@ -55,7 +55,7 @@ const ExplorerBottomNav: React.FC<ExplorerBottomNavProps> = ({ activeTab, onSele
         </svg>
         <span>Map</span>
       </button>
-    </div>
+    </nav>
   );
 };
 

--- a/src/components/ExplorerHubPage.css
+++ b/src/components/ExplorerHubPage.css
@@ -1,0 +1,387 @@
+.explorer-hub-page {
+  width: 100%;
+  max-width: 1120px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.explorer-hub-access-denied,
+.explorer-hub-empty-state {
+  background: var(--wmv-white);
+  border: 1px solid var(--wmv-border);
+  border-radius: 16px;
+  padding: 1.5rem;
+  box-shadow: 0 12px 32px rgba(15, 23, 42, 0.06);
+}
+
+.explorer-hub-access-denied {
+  text-align: center;
+}
+
+.explorer-hub-access-denied h2,
+.explorer-hub-empty-state h3,
+.explorer-hub-empty-state h4,
+.explorer-hub-hero h2,
+.explorer-hub-progress-card h3,
+.explorer-hub-section h3,
+.explorer-hub-follow-on-card h3,
+.explorer-hub-destination-card h3 {
+  margin: 0;
+}
+
+.explorer-hub-destination-card h3 {
+  color: var(--wmv-text-dark);
+}
+
+.explorer-hub-access-denied p,
+.explorer-hub-empty-state p {
+  margin: 0.5rem 0 0;
+  color: var(--wmv-text-light);
+}
+
+.explorer-hub-empty-state.compact {
+  padding: 1.25rem;
+  box-shadow: none;
+}
+
+.explorer-hub-hero,
+.explorer-hub-progress-card,
+.explorer-hub-search-card,
+.explorer-hub-follow-on-card,
+.explorer-hub-destination-card {
+  cursor: default;
+  border-left-color: transparent;
+}
+
+.explorer-hub-hero:hover,
+.explorer-hub-progress-card:hover,
+.explorer-hub-search-card:hover,
+.explorer-hub-follow-on-card:hover,
+.explorer-hub-destination-card:hover {
+  transform: none;
+}
+
+.explorer-hub-hero,
+.explorer-hub-progress-card,
+.explorer-hub-search-card,
+.explorer-hub-follow-on-card {
+  padding: 1.5rem;
+  border-radius: 20px;
+  border: 1px solid rgba(123, 63, 242, 0.08);
+}
+
+.explorer-hub-hero {
+  background:
+    radial-gradient(circle at top right, rgba(123, 63, 242, 0.08), transparent 36%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.98), rgba(255, 255, 255, 1));
+  gap: 1rem;
+}
+
+.explorer-hub-hero-topline,
+.explorer-hub-progress-header,
+.explorer-hub-section-header,
+.explorer-hub-destination-header,
+.explorer-hub-follow-on-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.explorer-hub-preview-pill,
+.explorer-hub-status-pill,
+.explorer-hub-section-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  font-size: var(--font-xs);
+  font-weight: 700;
+  letter-spacing: 0.02em;
+}
+
+.explorer-hub-preview-pill {
+  padding: 0.45rem 0.8rem;
+  background: rgba(123, 63, 242, 0.12);
+  color: var(--wmv-purple-dark);
+}
+
+.explorer-section-label {
+  margin: 0 0 0.35rem;
+  font-size: var(--font-xs);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--wmv-text-light);
+}
+
+.explorer-hub-secondary-copy {
+  margin: 0;
+  color: var(--wmv-text-light);
+  font-size: var(--font-sm);
+}
+
+.explorer-hub-section-note {
+  margin: 0.4rem 0 0;
+  color: var(--wmv-text-light);
+  font-size: var(--font-sm);
+}
+
+.explorer-hub-chip-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.explorer-hub-search-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+}
+
+.explorer-hub-destinations-view {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.explorer-hub-progress-card {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.explorer-hub-progress-percent {
+  margin: 0;
+  font-size: clamp(1.5rem, 4vw, 2.5rem);
+  line-height: 1;
+  font-weight: 700;
+  color: var(--wmv-orange);
+}
+
+.explorer-hub-progress-bar {
+  width: 100%;
+  height: 0.85rem;
+  border-radius: 999px;
+  background: rgba(123, 63, 242, 0.08);
+  overflow: hidden;
+}
+
+.explorer-hub-progress-bar-fill {
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, var(--wmv-orange), var(--wmv-purple));
+  transition: width 0.2s ease;
+}
+
+.explorer-hub-progress-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.explorer-hub-progress-grid > div {
+  background: var(--wmv-bg-light);
+  border-radius: 16px;
+  padding: 0.9rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.explorer-hub-progress-grid strong {
+  color: var(--wmv-text-dark);
+  font-size: var(--font-lg);
+}
+
+.explorer-hub-progress-label {
+  color: var(--wmv-text-light);
+  font-size: var(--font-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-weight: 700;
+}
+
+.explorer-hub-section-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1.25rem;
+}
+
+.explorer-hub-section {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.explorer-hub-section-count {
+  min-width: 2.5rem;
+  height: 2.5rem;
+  padding: 0 0.8rem;
+  background: var(--wmv-orange-light);
+  color: var(--wmv-orange);
+}
+
+.explorer-hub-destination-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+}
+
+.explorer-hub-destination-card {
+  padding: 1.1rem 1.1rem 1rem;
+  border: 1px solid rgba(15, 23, 42, 0.06);
+  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.05);
+}
+
+.explorer-hub-destination-main {
+  flex: 1;
+  min-width: 0;
+}
+
+.explorer-hub-destination-title {
+  font-size: var(--font-lg);
+  line-height: 1.2;
+}
+
+.explorer-hub-destination-link {
+  display: inline-flex;
+  align-items: flex-start;
+  gap: 0.35rem;
+  color: var(--wmv-orange);
+  text-decoration: none;
+  font-weight: 700;
+}
+
+.explorer-hub-destination-link-text {
+  display: block;
+}
+
+.explorer-hub-destination-link svg {
+  width: 1rem;
+  height: 1rem;
+  flex-shrink: 0;
+  margin-top: 0.1rem;
+}
+
+.explorer-hub-destination-link:hover {
+  text-decoration: underline;
+}
+
+.explorer-hub-status-pill {
+  padding: 0.4rem 0.75rem;
+}
+
+.explorer-hub-status-pill.remaining {
+  background: rgba(123, 63, 242, 0.08);
+  color: var(--wmv-purple-dark);
+}
+
+.explorer-hub-status-pill.completed {
+  background: rgba(245, 96, 4, 0.12);
+  color: var(--wmv-orange);
+}
+
+.explorer-hub-completion-copy {
+  margin: 0.85rem 0 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  color: var(--wmv-text-light);
+  font-size: var(--font-sm);
+  font-weight: 500;
+}
+
+.explorer-hub-completion-copy svg,
+.explorer-hub-follow-on-header svg {
+  width: 1rem;
+  height: 1rem;
+  color: var(--wmv-orange);
+}
+
+.explorer-hub-follow-on-card {
+  background: linear-gradient(180deg, rgba(245, 96, 4, 0.04), rgba(255, 255, 255, 1));
+}
+
+.explorer-search-stub-input {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  padding: 0.8rem 0.95rem;
+  border: 1px dashed rgba(148, 163, 184, 0.4);
+  border-radius: 12px;
+  background: rgba(248, 250, 252, 0.95);
+  color: var(--wmv-text-light);
+}
+
+.explorer-search-stub-input svg {
+  width: 1rem;
+  height: 1rem;
+  flex-shrink: 0;
+}
+
+.explorer-search-stub-input input {
+  width: 100%;
+  border: none;
+  background: transparent;
+  color: inherit;
+  font-size: var(--font-base);
+}
+
+.explorer-search-stub-input input:disabled {
+  opacity: 1;
+  -webkit-text-fill-color: currentColor;
+}
+
+.explorer-hub-show-more {
+  align-self: flex-start;
+  border: none;
+  background: transparent;
+  color: var(--wmv-orange);
+  font-size: var(--font-sm);
+  font-weight: 700;
+  cursor: pointer;
+  padding: 0.2rem 0;
+}
+
+.explorer-hub-show-more:hover {
+  text-decoration: underline;
+}
+
+@media (max-width: 900px) {
+  .explorer-hub-section-grid,
+  .explorer-hub-progress-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 640px) {
+  .explorer-hub-page {
+    gap: 1rem;
+  }
+
+  .explorer-hub-hero,
+  .explorer-hub-progress-card,
+  .explorer-hub-follow-on-card,
+  .explorer-hub-empty-state,
+  .explorer-hub-access-denied {
+    padding: 1.1rem;
+  }
+
+  .explorer-hub-hero-topline,
+  .explorer-hub-progress-header,
+  .explorer-hub-section-header,
+  .explorer-hub-destination-header,
+  .explorer-hub-follow-on-header {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .explorer-hub-preview-pill,
+  .explorer-hub-status-pill,
+  .explorer-hub-section-count {
+    align-self: flex-start;
+  }
+}

--- a/src/components/ExplorerHubPage.tsx
+++ b/src/components/ExplorerHubPage.tsx
@@ -153,6 +153,7 @@ function ExplorerHubPage({ isAdmin, isConnected }: ExplorerHubPageProps) {
   const [showAllCompleted, setShowAllCompleted] = useState(false);
 
   const activeCampaignQuery = trpc.explorer.getActiveCampaign.useQuery(undefined, {
+    enabled: isAdmin,
     refetchOnWindowFocus: false,
   });
 
@@ -160,7 +161,7 @@ function ExplorerHubPage({ isAdmin, isConnected }: ExplorerHubPageProps) {
   const progressQuery = trpc.explorer.getCampaignProgress.useQuery(
     { campaignId: activeCampaignId ?? 0 },
     {
-      enabled: Boolean(isConnected && activeCampaignId),
+      enabled: Boolean(isAdmin && isConnected && activeCampaignId),
       refetchOnWindowFocus: false,
     }
   );

--- a/src/components/ExplorerHubPage.tsx
+++ b/src/components/ExplorerHubPage.tsx
@@ -1,0 +1,477 @@
+import { useState } from 'react';
+import {
+  ArrowTopRightOnSquareIcon,
+  CalendarDaysIcon,
+  CheckBadgeIcon,
+  CheckCircleIcon,
+  FlagIcon,
+  MagnifyingGlassIcon,
+  MapPinIcon,
+} from '@heroicons/react/24/outline';
+import { trpc } from '../utils/trpc';
+import { formatUnixDate } from '../utils/dateUtils';
+import { useUnits } from '../context/UnitContext';
+import { formatDistance, type UnitSystem } from '../utils/unitConversion';
+import ExplorerBottomNav from './ExplorerBottomNav';
+import './Card.css';
+import './ExplorerHubPage.css';
+
+interface ExplorerHubPageProps {
+  isAdmin: boolean;
+  isConnected: boolean;
+}
+
+interface ExplorerDestinationSummary {
+  id: number;
+  stravaSegmentId: string;
+  displayOrder: number;
+  displayLabel: string;
+  customLabel: string | null;
+  segmentName: string;
+  sourceUrl: string | null;
+  distance: number | null;
+  averageGrade: number | null;
+  city: string | null;
+  state: string | null;
+  country: string | null;
+}
+
+interface ExplorerProgressDestinationSummary extends ExplorerDestinationSummary {
+  completed: boolean;
+  matchedAt: number | null;
+  stravaActivityId: string | null;
+}
+
+type ExplorerTab = 'hub' | 'destinations';
+
+const DEFAULT_REMAINING_VISIBLE = 10;
+const DEFAULT_COMPLETED_VISIBLE = 10;
+
+function formatAverageGrade(averageGrade: number | null | undefined): string | null {
+  if (averageGrade == null) {
+    return null;
+  }
+
+  return `${averageGrade.toFixed(1)}% avg grade`;
+}
+
+function formatLocation(city?: string | null, state?: string | null, country?: string | null): string | null {
+  const locationParts = [city, state, country].filter(Boolean);
+  return locationParts.length > 0 ? locationParts.join(', ') : null;
+}
+
+function getDestinationChips(destination: ExplorerDestinationSummary, units: UnitSystem): string[] {
+  const chips: string[] = [];
+  const distance = destination.distance != null ? formatDistance(destination.distance, units) : null;
+  const grade = formatAverageGrade(destination.averageGrade);
+  const location = formatLocation(destination.city, destination.state, destination.country);
+
+  if (distance) {
+    chips.push(distance);
+  }
+
+  if (grade) {
+    chips.push(grade);
+  }
+
+  if (location) {
+    chips.push(location);
+  }
+
+  return chips;
+}
+
+function ExplorerDestinationCard({
+  destination,
+  completed,
+  matchedAt,
+}: {
+  destination: ExplorerDestinationSummary;
+  completed: boolean;
+  matchedAt: number | null;
+}) {
+  const { units } = useUnits();
+  const chips = getDestinationChips(destination, units);
+  const showRawSegmentName = destination.customLabel && destination.customLabel !== destination.segmentName;
+
+  return (
+    <article className="leaderboard-card explorer-hub-destination-card" data-testid={`explorer-destination-card-${destination.id}`}>
+      <div className="explorer-hub-destination-header">
+        <div className="explorer-hub-destination-main">
+          <p className="explorer-section-label">Destination</p>
+          <h3 className="explorer-hub-destination-title">
+            {destination.sourceUrl ? (
+              <a
+                className="explorer-hub-destination-link"
+                href={destination.sourceUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <span className="explorer-hub-destination-link-text">{destination.displayLabel}</span>
+                <ArrowTopRightOnSquareIcon aria-hidden="true" />
+              </a>
+            ) : (
+              destination.displayLabel
+            )}
+          </h3>
+          {showRawSegmentName ? (
+            <p className="explorer-hub-secondary-copy">Strava segment: {destination.segmentName}</p>
+          ) : null}
+        </div>
+
+        <span
+          className={`explorer-hub-status-pill ${completed ? 'completed' : 'remaining'}`}
+          data-testid={`explorer-destination-status-${destination.id}`}
+        >
+          {completed ? 'Completed' : 'Remaining'}
+        </span>
+      </div>
+
+      {chips.length > 0 ? (
+        <div className="explorer-hub-chip-row">
+          {chips.map((chip) => (
+            <span key={`${destination.id}-${chip}`} className="week-header-chip">{chip}</span>
+          ))}
+        </div>
+      ) : null}
+
+      {completed && matchedAt ? (
+        <p className="explorer-hub-completion-copy">
+          <CheckCircleIcon aria-hidden="true" />
+          Completed on {formatUnixDate(matchedAt, { month: 'short', day: 'numeric', year: 'numeric' })}
+        </p>
+      ) : (
+        <p className="explorer-hub-secondary-copy">Ride this destination once during the campaign to check it off.</p>
+      )}
+    </article>
+  );
+}
+
+function ExplorerHubPage({ isAdmin, isConnected }: ExplorerHubPageProps) {
+  const [activeTab, setActiveTab] = useState<ExplorerTab>('hub');
+  const [showAllRemaining, setShowAllRemaining] = useState(false);
+  const [showAllCompleted, setShowAllCompleted] = useState(false);
+
+  const activeCampaignQuery = trpc.explorer.getActiveCampaign.useQuery(undefined, {
+    refetchOnWindowFocus: false,
+  });
+
+  const activeCampaignId = activeCampaignQuery.data?.id;
+  const progressQuery = trpc.explorer.getCampaignProgress.useQuery(
+    { campaignId: activeCampaignId ?? 0 },
+    {
+      enabled: Boolean(isConnected && activeCampaignId),
+      refetchOnWindowFocus: false,
+    }
+  );
+
+  if (!isAdmin) {
+    return (
+      <div className="explorer-hub-page" data-testid="explorer-hub-page">
+        <div className="explorer-hub-access-denied" data-testid="explorer-hub-access-denied">
+          <h2>Access Denied</h2>
+          <p>You do not have admin permissions to preview the Explorer hub yet.</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (activeCampaignQuery.isLoading) {
+    return (
+      <div className="explorer-hub-page" data-testid="explorer-hub-page">
+        <section className="leaderboard-card explorer-hub-hero">
+          <p className="explorer-section-label">Explorer preview</p>
+          <h2>Loading Explorer</h2>
+          <p className="explorer-hub-secondary-copy">Preparing the active campaign view.</p>
+        </section>
+      </div>
+    );
+  }
+
+  if (activeCampaignQuery.error) {
+    return (
+      <div className="explorer-hub-page" data-testid="explorer-hub-page">
+        <section className="explorer-hub-empty-state" data-testid="explorer-hub-error-state">
+          <h2>Explorer unavailable</h2>
+          <p>{activeCampaignQuery.error.message}</p>
+        </section>
+      </div>
+    );
+  }
+
+  const activeCampaign = activeCampaignQuery.data;
+
+  if (!activeCampaign) {
+    return (
+      <div className="explorer-hub-page" data-testid="explorer-hub-page">
+        <section className="leaderboard-card explorer-hub-hero">
+          <p className="explorer-section-label">Explorer preview</p>
+          <h2>Explorer hub</h2>
+          <p className="explorer-hub-secondary-copy">
+            This route is the future athlete-facing Explorer page. It stays admin-gated until the feature is ready for wider release.
+          </p>
+        </section>
+
+        <section className="explorer-hub-empty-state" data-testid="explorer-hub-empty-state">
+          <h3>No active campaign yet</h3>
+          <p>Create an Explorer campaign and add at least one destination before previewing the athlete page.</p>
+        </section>
+      </div>
+    );
+  }
+
+  const progress = progressQuery.data;
+  const destinations: ExplorerProgressDestinationSummary[] = progress?.destinations ?? activeCampaign.destinations.map((destination) => ({
+    ...destination,
+    completed: false,
+    matchedAt: null,
+    stravaActivityId: null,
+  }));
+  const completedDestinations = progress?.completedDestinations ?? 0;
+  const totalDestinations = progress?.totalDestinations ?? activeCampaign.destinations.length;
+  const remainingDestinations = destinations
+    .filter((destination) => !destination.completed)
+    .sort((left, right) => left.displayOrder - right.displayOrder || left.id - right.id);
+  const finishedDestinations = destinations
+    .filter((destination) => destination.completed)
+    .sort((left, right) => (right.matchedAt ?? 0) - (left.matchedAt ?? 0) || left.displayOrder - right.displayOrder || left.id - right.id);
+  const progressPercent = totalDestinations > 0 ? Math.round((completedDestinations / totalDestinations) * 100) : 0;
+  const visibleRemainingDestinations = showAllRemaining
+    ? remainingDestinations
+    : remainingDestinations.slice(0, DEFAULT_REMAINING_VISIBLE);
+  const visibleCompletedDestinations = showAllCompleted
+    ? finishedDestinations
+    : finishedDestinations.slice(0, DEFAULT_COMPLETED_VISIBLE);
+  const destinationsByCampaignOrder = [...destinations]
+    .sort((left, right) => left.displayOrder - right.displayOrder || left.id - right.id);
+
+  return (
+    <div className="explorer-hub-page" data-testid="explorer-hub-page">
+      <section className="leaderboard-card explorer-hub-hero" data-testid="explorer-hub-hero">
+        <div className="explorer-hub-hero-topline">
+          <div>
+            <p className="explorer-section-label">Explorer preview</p>
+            <h2>{activeCampaign.name}</h2>
+          </div>
+          <span className="explorer-hub-preview-pill">Admin-gated preview</span>
+        </div>
+
+        <div className="explorer-hub-chip-row">
+          <span className="week-header-chip">
+            <CalendarDaysIcon className="week-header-chip-icon" />
+            {formatUnixDate(activeCampaign.startAt, { month: 'short', day: 'numeric' })} - {formatUnixDate(activeCampaign.endAt, { month: 'short', day: 'numeric', year: 'numeric' })}
+          </span>
+          <span className="week-header-chip">
+            <FlagIcon className="week-header-chip-icon" />
+            {totalDestinations} destinations
+          </span>
+          <span className="week-header-chip">
+            <CheckBadgeIcon className="week-header-chip-icon" />
+            {completedDestinations} completed
+          </span>
+        </div>
+
+        <p className="explorer-hub-secondary-copy">
+          {activeCampaign.rulesBlurb || 'Ride each destination once during the campaign window to complete the set.'}
+        </p>
+      </section>
+
+      {!isConnected ? (
+        <section className="explorer-hub-empty-state" data-testid="explorer-hub-connect-state">
+          <h3>Connect Strava to see personal progress</h3>
+          <p>The active campaign is visible, but checklist completion only appears for connected athletes.</p>
+        </section>
+      ) : null}
+
+      {activeTab === 'hub' ? (
+        <>
+          <section className="leaderboard-card explorer-hub-progress-card" data-testid="explorer-progress-card">
+            <div className="explorer-hub-progress-header">
+              <div>
+                <p className="explorer-section-label">Your progress</p>
+                <h3>
+                  {completedDestinations} of {totalDestinations} destinations complete
+                </h3>
+              </div>
+              <p className="explorer-hub-progress-percent" data-testid="explorer-progress-percent">{progressPercent}%</p>
+            </div>
+
+            <div className="explorer-hub-progress-bar" aria-hidden="true">
+              <div className="explorer-hub-progress-bar-fill" style={{ width: `${progressPercent}%` }} />
+            </div>
+
+            <div className="explorer-hub-progress-grid">
+              <div>
+                <span className="explorer-hub-progress-label">Remaining</span>
+                <strong>{remainingDestinations.length}</strong>
+              </div>
+              <div>
+                <span className="explorer-hub-progress-label">Completed</span>
+                <strong>{finishedDestinations.length}</strong>
+              </div>
+              <div>
+                <span className="explorer-hub-progress-label">Campaign status</span>
+                <strong>{finishedDestinations.length === totalDestinations && totalDestinations > 0 ? 'Complete' : 'In progress'}</strong>
+              </div>
+            </div>
+          </section>
+
+          <div className="explorer-hub-section-grid">
+            <section className="explorer-hub-section" data-testid="explorer-remaining-section">
+              <div className="explorer-hub-section-header">
+                <div>
+                  <p className="explorer-section-label">Next up</p>
+                  <h3>Remaining destinations</h3>
+                  <p className="explorer-hub-section-note">Showing campaign order for now.</p>
+                </div>
+                <span className="explorer-hub-section-count">{remainingDestinations.length}</span>
+              </div>
+
+              {remainingDestinations.length === 0 ? (
+                <div className="explorer-hub-empty-state compact" data-testid="explorer-remaining-empty-state">
+                  <h4>All destinations completed</h4>
+                  <p>This athlete has checked off every destination in the active campaign.</p>
+                </div>
+              ) : (
+                <div className="explorer-hub-destination-list">
+                  {visibleRemainingDestinations.map((destination) => (
+                    <ExplorerDestinationCard
+                      key={destination.id}
+                      destination={destination}
+                      completed={false}
+                      matchedAt={null}
+                    />
+                  ))}
+
+                  {remainingDestinations.length > DEFAULT_REMAINING_VISIBLE ? (
+                    <button
+                      type="button"
+                      className="explorer-hub-show-more"
+                      data-testid="explorer-remaining-toggle"
+                      onClick={() => setShowAllRemaining((current) => !current)}
+                    >
+                      {showAllRemaining
+                        ? 'Show fewer remaining destinations'
+                        : `Show all ${remainingDestinations.length} remaining destinations`}
+                    </button>
+                  ) : null}
+                </div>
+              )}
+            </section>
+
+            <section className="explorer-hub-section" data-testid="explorer-completed-section">
+              <div className="explorer-hub-section-header">
+                <div>
+                  <p className="explorer-section-label">Progress log</p>
+                  <h3>Completed destinations</h3>
+                  <p className="explorer-hub-section-note">Newest completions first.</p>
+                </div>
+                <span className="explorer-hub-section-count">{finishedDestinations.length}</span>
+              </div>
+
+              {progressQuery.isLoading && isConnected ? (
+                <div className="explorer-hub-empty-state compact" data-testid="explorer-progress-loading-state">
+                  <h4>Loading progress</h4>
+                  <p>Pulling the athlete's current Explorer matches.</p>
+                </div>
+              ) : finishedDestinations.length === 0 ? (
+                <div className="explorer-hub-empty-state compact" data-testid="explorer-completed-empty-state">
+                  <h4>No destinations completed yet</h4>
+                  <p>Completed destinations will appear here as the athlete checks them off.</p>
+                </div>
+              ) : (
+                <div className="explorer-hub-destination-list">
+                  {visibleCompletedDestinations.map((destination) => (
+                    <ExplorerDestinationCard
+                      key={destination.id}
+                      destination={destination}
+                      completed
+                      matchedAt={destination.matchedAt}
+                    />
+                  ))}
+
+                  {finishedDestinations.length > DEFAULT_COMPLETED_VISIBLE ? (
+                    <button
+                      type="button"
+                      className="explorer-hub-show-more"
+                      data-testid="explorer-completed-toggle"
+                      onClick={() => setShowAllCompleted((current) => !current)}
+                    >
+                      {showAllCompleted
+                        ? 'Show fewer completed destinations'
+                        : `Show all ${finishedDestinations.length} completed destinations`}
+                    </button>
+                  ) : null}
+                </div>
+              )}
+            </section>
+          </div>
+
+          <section className="leaderboard-card explorer-hub-follow-on-card" data-testid="explorer-follow-on-card">
+            <div className="explorer-hub-follow-on-header">
+              <div>
+                <p className="explorer-section-label">Later phases</p>
+                <h3>Map and social work stay deferred</h3>
+              </div>
+              <MapPinIcon aria-hidden="true" />
+            </div>
+            <p className="explorer-hub-secondary-copy">
+              This first athlete page stays list-first on purpose. Map discovery and broader social visibility can layer onto this route later without turning the initial release into an overloaded surface.
+            </p>
+          </section>
+        </>
+      ) : (
+        <section className="explorer-hub-destinations-view" data-testid="explorer-destinations-view">
+          <section className="leaderboard-card explorer-hub-search-card" data-testid="explorer-search-card">
+            <div className="explorer-hub-section-header">
+              <div>
+                <p className="explorer-section-label">Browse stub</p>
+                <h3>Search and filters</h3>
+              </div>
+            </div>
+            <p className="explorer-hub-secondary-copy">
+              This stays disabled for 5A, but it reserves the shape for later browse and location-aware discovery work.
+            </p>
+            <div className="explorer-search-stub" data-testid="explorer-search-stub">
+              <div className="explorer-search-stub-input">
+                <MagnifyingGlassIcon aria-hidden="true" />
+                <input
+                  type="text"
+                  placeholder="Search by destination name or location coming soon"
+                  disabled
+                />
+              </div>
+            </div>
+          </section>
+
+          <section className="explorer-hub-section" data-testid="explorer-all-destinations-section">
+            <div className="explorer-hub-section-header">
+              <div>
+                <p className="explorer-section-label">Campaign list</p>
+                <h3>All destinations</h3>
+                <p className="explorer-hub-section-note">Full campaign order with completion state.</p>
+              </div>
+              <span className="explorer-hub-section-count">{destinationsByCampaignOrder.length}</span>
+            </div>
+
+            <div className="explorer-hub-destination-list">
+              {destinationsByCampaignOrder.map((destination) => (
+                <ExplorerDestinationCard
+                  key={destination.id}
+                  destination={destination}
+                  completed={destination.completed}
+                  matchedAt={destination.matchedAt}
+                />
+              ))}
+            </div>
+          </section>
+        </section>
+      )}
+
+      <div className="bottom-nav-spacer" data-testid="explorer-bottom-nav-spacer" />
+      <ExplorerBottomNav activeTab={activeTab} onSelect={setActiveTab} />
+    </div>
+  );
+}
+
+export default ExplorerHubPage;

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -169,6 +169,20 @@ export const NavBar: React.FC<NavBarProps> = ({
                       Leaderboard
                     </NavLink>
                     
+                    {isAdmin && (
+                      <NavLink 
+                        to="/explorer"
+                        className={({ isActive }) => `menu-item ${isActive ? 'active' : ''}`}
+                        onClick={() => setIsMenuOpen(false)}
+                      >
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" className="menu-icon">
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+                            d="M9 20l-5.447-2.724A1 1 0 013 16.382V5.618a1 1 0 01.553-.894L9 2m0 18l6-3m-6 3V2m6 15l6 3m-6-3V6m6 14V8.618a1 1 0 00-.553-.894L15 5m0 1L9 2" />
+                        </svg>
+                        Explorer
+                      </NavLink>
+                    )}
+
                     <NavLink 
                       to={userAthleteId ? `/profile/${userAthleteId}` : "/profile"} 
                       className={({ isActive }) => `menu-item ${isActive ? 'active' : ''}`}

--- a/src/components/__tests__/ExplorerHubPage.test.tsx
+++ b/src/components/__tests__/ExplorerHubPage.test.tsx
@@ -1,0 +1,579 @@
+import { act, type ComponentProps } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import ExplorerHubPage from '../ExplorerHubPage';
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const unitMocks = vi.hoisted(() => ({
+  units: 'imperial' as 'imperial' | 'metric',
+  setUnits: vi.fn(),
+}));
+
+const trpcMocks = vi.hoisted(() => ({
+  activeCampaignQuery: {
+    data: null as null | {
+      id: number;
+      name: string;
+      startAt: number;
+      endAt: number;
+      rulesBlurb: string | null;
+      destinations: Array<{
+        id: number;
+        stravaSegmentId: string;
+        displayOrder: number;
+        displayLabel: string;
+        customLabel: string | null;
+        segmentName: string;
+        sourceUrl: string | null;
+        distance: number | null;
+        averageGrade: number | null;
+        city: string | null;
+        state: string | null;
+        country: string | null;
+      }>;
+    },
+    isLoading: false,
+    error: null as Error | null,
+  },
+  progressQuery: {
+    data: null as null | {
+      campaign: {
+        id: number;
+        name: string;
+        startAt: number;
+        endAt: number;
+        rulesBlurb: string | null;
+      };
+      completedDestinations: number;
+      totalDestinations: number;
+      destinations: Array<{
+        id: number;
+        stravaSegmentId: string;
+        displayOrder: number;
+        displayLabel: string;
+        customLabel: string | null;
+        segmentName: string;
+        sourceUrl: string | null;
+        distance: number | null;
+        averageGrade: number | null;
+        city: string | null;
+        state: string | null;
+        country: string | null;
+        completed: boolean;
+        matchedAt: number | null;
+        stravaActivityId: string | null;
+      }>;
+    },
+    isLoading: false,
+  },
+}));
+
+vi.mock('../../utils/trpc', () => ({
+  trpc: {
+    explorer: {
+      getActiveCampaign: {
+        useQuery: () => trpcMocks.activeCampaignQuery,
+      },
+      getCampaignProgress: {
+        useQuery: () => trpcMocks.progressQuery,
+      },
+    },
+  },
+}));
+
+vi.mock('../../context/UnitContext', () => ({
+  useUnits: () => unitMocks,
+}));
+
+interface RenderResult {
+  container: HTMLDivElement;
+  root: Root;
+}
+
+let renderResult: RenderResult | null = null;
+
+async function renderPage(overrides: Partial<ComponentProps<typeof ExplorerHubPage>> = {}) {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  await act(async () => {
+    root.render(<ExplorerHubPage isAdmin isConnected {...overrides} />);
+  });
+
+  renderResult = { container, root };
+  return renderResult;
+}
+
+async function clickElement(element: Element | null) {
+  if (!(element instanceof HTMLElement)) {
+    throw new Error('Expected clickable HTMLElement');
+  }
+
+  await act(async () => {
+    element.click();
+  });
+}
+
+describe('ExplorerHubPage', () => {
+  beforeEach(() => {
+    trpcMocks.activeCampaignQuery.data = null;
+    trpcMocks.activeCampaignQuery.error = null;
+    trpcMocks.activeCampaignQuery.isLoading = false;
+    trpcMocks.progressQuery.data = null;
+    trpcMocks.progressQuery.isLoading = false;
+    unitMocks.units = 'imperial';
+  });
+
+  afterEach(async () => {
+    if (renderResult) {
+      const currentRenderResult = renderResult;
+      await act(async () => {
+        currentRenderResult.root.unmount();
+      });
+      currentRenderResult.container.remove();
+      renderResult = null;
+    }
+  });
+
+  it('shows an access denied state for non-admin users', async () => {
+    const { container } = await renderPage({ isAdmin: false });
+
+    expect(container.querySelector('[data-testid="explorer-hub-access-denied"]')?.textContent).toContain('Access Denied');
+  });
+
+  it('shows an empty state when there is no active campaign', async () => {
+    const { container } = await renderPage();
+
+    expect(container.querySelector('[data-testid="explorer-hub-empty-state"]')?.textContent).toContain('No active campaign yet');
+  });
+
+  it('renders the active campaign with remaining and completed destinations', async () => {
+    trpcMocks.activeCampaignQuery.data = {
+      id: 44,
+      name: 'Hilltown Explorer',
+      startAt: 1751328000,
+      endAt: 1753919999,
+      rulesBlurb: 'Ride each destination once.',
+      destinations: [
+        {
+          id: 501,
+          stravaSegmentId: 'seg-501',
+          displayOrder: 1,
+          displayLabel: 'North Road Climb',
+          customLabel: null,
+          segmentName: 'North Road Climb',
+          sourceUrl: 'https://www.strava.com/segments/501',
+          distance: 3200,
+          averageGrade: 4.8,
+          city: 'Shelburne Falls',
+          state: 'MA',
+          country: 'USA',
+        },
+        {
+          id: 502,
+          stravaSegmentId: 'seg-502',
+          displayOrder: 2,
+          displayLabel: 'River Valley Spin',
+          customLabel: 'River Valley Spin',
+          segmentName: 'River Valley Segment',
+          sourceUrl: 'https://www.strava.com/segments/502',
+          distance: 5400,
+          averageGrade: 1.9,
+          city: 'Greenfield',
+          state: 'MA',
+          country: 'USA',
+        },
+      ],
+    };
+
+    trpcMocks.progressQuery.data = {
+      campaign: {
+        id: 44,
+        name: 'Hilltown Explorer',
+        startAt: 1751328000,
+        endAt: 1753919999,
+        rulesBlurb: 'Ride each destination once.',
+      },
+      completedDestinations: 1,
+      totalDestinations: 2,
+      destinations: [
+        {
+          id: 501,
+          stravaSegmentId: 'seg-501',
+          displayOrder: 1,
+          displayLabel: 'North Road Climb',
+          customLabel: null,
+          segmentName: 'North Road Climb',
+          sourceUrl: 'https://www.strava.com/segments/501',
+          distance: 3200,
+          averageGrade: 4.8,
+          city: 'Shelburne Falls',
+          state: 'MA',
+          country: 'USA',
+          completed: false,
+          matchedAt: null,
+          stravaActivityId: null,
+        },
+        {
+          id: 502,
+          stravaSegmentId: 'seg-502',
+          displayOrder: 2,
+          displayLabel: 'River Valley Spin',
+          customLabel: 'River Valley Spin',
+          segmentName: 'River Valley Segment',
+          sourceUrl: 'https://www.strava.com/segments/502',
+          distance: 5400,
+          averageGrade: 1.9,
+          city: 'Greenfield',
+          state: 'MA',
+          country: 'USA',
+          completed: true,
+          matchedAt: 1751673600,
+          stravaActivityId: 'activity-502',
+        },
+      ],
+    };
+
+    const { container } = await renderPage();
+
+    expect(container.querySelector('[data-testid="explorer-bottom-nav"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="explorer-tab-hub"]')?.getAttribute('aria-pressed')).toBe('true');
+    expect(container.querySelector('[data-testid="explorer-hub-hero"]')?.textContent).toContain('Hilltown Explorer');
+    expect(container.querySelector('[data-testid="explorer-progress-percent"]')?.textContent).toContain('50%');
+    expect(container.querySelector('[data-testid="explorer-remaining-section"]')?.textContent).toContain('North Road Climb');
+    expect(container.querySelector('[data-testid="explorer-completed-section"]')?.textContent).toContain('River Valley Spin');
+    expect(container.querySelector('[data-testid="explorer-destination-status-501"]')?.textContent).toContain('Remaining');
+    expect(container.querySelector('[data-testid="explorer-destination-status-502"]')?.textContent).toContain('Completed');
+    expect(container.querySelector('[data-testid="explorer-search-card"]')).toBeNull();
+  });
+
+  it('shows Hub summary lists with a 10-item default cap', async () => {
+    trpcMocks.activeCampaignQuery.data = {
+      id: 88,
+      name: 'Long List Explorer',
+      startAt: 1751328000,
+      endAt: 1753919999,
+      rulesBlurb: null,
+      destinations: [],
+    };
+
+    trpcMocks.progressQuery.data = {
+      campaign: {
+        id: 88,
+        name: 'Long List Explorer',
+        startAt: 1751328000,
+        endAt: 1753919999,
+        rulesBlurb: null,
+      },
+      completedDestinations: 4,
+      totalDestinations: 9,
+      destinations: [
+        {
+          id: 1,
+          stravaSegmentId: 'seg-1',
+          displayOrder: 1,
+          displayLabel: 'Remaining 1',
+          customLabel: null,
+          segmentName: 'Remaining 1',
+          sourceUrl: null,
+          distance: null,
+          averageGrade: null,
+          city: null,
+          state: null,
+          country: null,
+          completed: false,
+          matchedAt: null,
+          stravaActivityId: null,
+        },
+        {
+          id: 2,
+          stravaSegmentId: 'seg-2',
+          displayOrder: 2,
+          displayLabel: 'Remaining 2',
+          customLabel: null,
+          segmentName: 'Remaining 2',
+          sourceUrl: null,
+          distance: null,
+          averageGrade: null,
+          city: null,
+          state: null,
+          country: null,
+          completed: false,
+          matchedAt: null,
+          stravaActivityId: null,
+        },
+        {
+          id: 3,
+          stravaSegmentId: 'seg-3',
+          displayOrder: 3,
+          displayLabel: 'Remaining 3',
+          customLabel: null,
+          segmentName: 'Remaining 3',
+          sourceUrl: null,
+          distance: null,
+          averageGrade: null,
+          city: null,
+          state: null,
+          country: null,
+          completed: false,
+          matchedAt: null,
+          stravaActivityId: null,
+        },
+        {
+          id: 4,
+          stravaSegmentId: 'seg-4',
+          displayOrder: 4,
+          displayLabel: 'Remaining 4',
+          customLabel: null,
+          segmentName: 'Remaining 4',
+          sourceUrl: null,
+          distance: null,
+          averageGrade: null,
+          city: null,
+          state: null,
+          country: null,
+          completed: false,
+          matchedAt: null,
+          stravaActivityId: null,
+        },
+        {
+          id: 5,
+          stravaSegmentId: 'seg-5',
+          displayOrder: 5,
+          displayLabel: 'Remaining 5',
+          customLabel: null,
+          segmentName: 'Remaining 5',
+          sourceUrl: null,
+          distance: null,
+          averageGrade: null,
+          city: null,
+          state: null,
+          country: null,
+          completed: false,
+          matchedAt: null,
+          stravaActivityId: null,
+        },
+        {
+          id: 6,
+          stravaSegmentId: 'seg-6',
+          displayOrder: 6,
+          displayLabel: 'Completed Older',
+          customLabel: null,
+          segmentName: 'Completed Older',
+          sourceUrl: null,
+          distance: null,
+          averageGrade: null,
+          city: null,
+          state: null,
+          country: null,
+          completed: true,
+          matchedAt: 1751500000,
+          stravaActivityId: 'act-6',
+        },
+        {
+          id: 7,
+          stravaSegmentId: 'seg-7',
+          displayOrder: 7,
+          displayLabel: 'Completed Newest',
+          customLabel: null,
+          segmentName: 'Completed Newest',
+          sourceUrl: null,
+          distance: null,
+          averageGrade: null,
+          city: null,
+          state: null,
+          country: null,
+          completed: true,
+          matchedAt: 1751800000,
+          stravaActivityId: 'act-7',
+        },
+        {
+          id: 8,
+          stravaSegmentId: 'seg-8',
+          displayOrder: 8,
+          displayLabel: 'Completed Middle',
+          customLabel: null,
+          segmentName: 'Completed Middle',
+          sourceUrl: null,
+          distance: null,
+          averageGrade: null,
+          city: null,
+          state: null,
+          country: null,
+          completed: true,
+          matchedAt: 1751600000,
+          stravaActivityId: 'act-8',
+        },
+        {
+          id: 9,
+          stravaSegmentId: 'seg-9',
+          displayOrder: 9,
+          displayLabel: 'Completed Hidden',
+          customLabel: null,
+          segmentName: 'Completed Hidden',
+          sourceUrl: null,
+          distance: null,
+          averageGrade: null,
+          city: null,
+          state: null,
+          country: null,
+          completed: true,
+          matchedAt: 1751400000,
+          stravaActivityId: 'act-9',
+        },
+      ],
+    };
+
+    const { container } = await renderPage();
+
+    const remainingSection = container.querySelector('[data-testid="explorer-remaining-section"]');
+    expect(remainingSection?.textContent).toContain('Remaining 5');
+    expect(remainingSection?.textContent).not.toContain('Show all');
+
+    const completedSection = container.querySelector('[data-testid="explorer-completed-section"]');
+    expect(completedSection?.textContent).toContain('Completed Newest');
+    expect(completedSection?.textContent).toContain('Completed Middle');
+    expect(completedSection?.textContent).toContain('Completed Older');
+    expect(completedSection?.textContent).toContain('Completed Hidden');
+    expect(completedSection?.textContent).not.toContain('Show all');
+  });
+
+  it('shows the disabled search stub and full list in Destinations', async () => {
+    trpcMocks.activeCampaignQuery.data = {
+      id: 99,
+      name: 'Destination Browser',
+      startAt: 1751328000,
+      endAt: 1753919999,
+      rulesBlurb: null,
+      destinations: [
+        {
+          id: 900,
+          stravaSegmentId: 'seg-900',
+          displayOrder: 1,
+          displayLabel: 'Alpha Climb',
+          customLabel: null,
+          segmentName: 'Alpha Climb',
+          sourceUrl: null,
+          distance: null,
+          averageGrade: null,
+          city: null,
+          state: null,
+          country: null,
+        },
+        {
+          id: 901,
+          stravaSegmentId: 'seg-901',
+          displayOrder: 2,
+          displayLabel: 'Beta Rollers',
+          customLabel: null,
+          segmentName: 'Beta Rollers',
+          sourceUrl: null,
+          distance: null,
+          averageGrade: null,
+          city: null,
+          state: null,
+          country: null,
+        },
+      ],
+    };
+
+    trpcMocks.progressQuery.data = {
+      campaign: {
+        id: 99,
+        name: 'Destination Browser',
+        startAt: 1751328000,
+        endAt: 1753919999,
+        rulesBlurb: null,
+      },
+      completedDestinations: 1,
+      totalDestinations: 2,
+      destinations: [
+        {
+          id: 900,
+          stravaSegmentId: 'seg-900',
+          displayOrder: 1,
+          displayLabel: 'Alpha Climb',
+          customLabel: null,
+          segmentName: 'Alpha Climb',
+          sourceUrl: null,
+          distance: null,
+          averageGrade: null,
+          city: null,
+          state: null,
+          country: null,
+          completed: false,
+          matchedAt: null,
+          stravaActivityId: null,
+        },
+        {
+          id: 901,
+          stravaSegmentId: 'seg-901',
+          displayOrder: 2,
+          displayLabel: 'Beta Rollers',
+          customLabel: null,
+          segmentName: 'Beta Rollers',
+          sourceUrl: null,
+          distance: null,
+          averageGrade: null,
+          city: null,
+          state: null,
+          country: null,
+          completed: true,
+          matchedAt: 1751400000,
+          stravaActivityId: 'act-901',
+        },
+      ],
+    };
+
+    const { container } = await renderPage();
+
+    await clickElement(container.querySelector('[data-testid="explorer-tab-destinations"]'));
+
+    expect(container.querySelector('[data-testid="explorer-tab-destinations"]')?.getAttribute('aria-pressed')).toBe('true');
+    expect(container.querySelector('[data-testid="explorer-tab-map"]')?.getAttribute('aria-disabled')).toBe('true');
+    expect(container.querySelector('[data-testid="explorer-destinations-view"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="explorer-search-card"]')).not.toBeNull();
+
+    const searchInput = container.querySelector('[data-testid="explorer-search-stub"] input');
+    expect(searchInput).not.toBeNull();
+    expect((searchInput as HTMLInputElement).disabled).toBe(true);
+
+    const allDestinations = container.querySelector('[data-testid="explorer-all-destinations-section"]');
+    expect(allDestinations?.textContent).toContain('Alpha Climb');
+    expect(allDestinations?.textContent).toContain('Beta Rollers');
+    expect(allDestinations?.textContent).toContain('Remaining');
+    expect(allDestinations?.textContent).toContain('Completed');
+  });
+
+  it('shows a connect prompt when the athlete is not connected', async () => {
+    trpcMocks.activeCampaignQuery.data = {
+      id: 77,
+      name: 'Explorer Preview',
+      startAt: 1751328000,
+      endAt: 1753919999,
+      rulesBlurb: null,
+      destinations: [
+        {
+          id: 601,
+          stravaSegmentId: 'seg-601',
+          displayOrder: 1,
+          displayLabel: 'Town Hill',
+          customLabel: null,
+          segmentName: 'Town Hill',
+          sourceUrl: null,
+          distance: null,
+          averageGrade: null,
+          city: null,
+          state: null,
+          country: null,
+        },
+      ],
+    };
+
+    const { container } = await renderPage({ isConnected: false });
+
+    expect(container.querySelector('[data-testid="explorer-hub-connect-state"]')?.textContent).toContain('Connect Strava');
+  });
+});

--- a/src/components/__tests__/ExplorerHubPage.test.tsx
+++ b/src/components/__tests__/ExplorerHubPage.test.tsx
@@ -11,6 +11,8 @@ const unitMocks = vi.hoisted(() => ({
 }));
 
 const trpcMocks = vi.hoisted(() => ({
+  activeCampaignUseQuery: vi.fn(),
+  progressUseQuery: vi.fn(),
   activeCampaignQuery: {
     data: null as null | {
       id: number;
@@ -73,10 +75,16 @@ vi.mock('../../utils/trpc', () => ({
   trpc: {
     explorer: {
       getActiveCampaign: {
-        useQuery: () => trpcMocks.activeCampaignQuery,
+        useQuery: (...args: unknown[]) => {
+          trpcMocks.activeCampaignUseQuery(...args);
+          return trpcMocks.activeCampaignQuery;
+        },
       },
       getCampaignProgress: {
-        useQuery: () => trpcMocks.progressQuery,
+        useQuery: (...args: unknown[]) => {
+          trpcMocks.progressUseQuery(...args);
+          return trpcMocks.progressQuery;
+        },
       },
     },
   },
@@ -118,6 +126,8 @@ async function clickElement(element: Element | null) {
 
 describe('ExplorerHubPage', () => {
   beforeEach(() => {
+    trpcMocks.activeCampaignUseQuery.mockReset();
+    trpcMocks.progressUseQuery.mockReset();
     trpcMocks.activeCampaignQuery.data = null;
     trpcMocks.activeCampaignQuery.error = null;
     trpcMocks.activeCampaignQuery.isLoading = false;
@@ -141,6 +151,8 @@ describe('ExplorerHubPage', () => {
     const { container } = await renderPage({ isAdmin: false });
 
     expect(container.querySelector('[data-testid="explorer-hub-access-denied"]')?.textContent).toContain('Access Denied');
+    expect(trpcMocks.activeCampaignUseQuery).toHaveBeenCalledWith(undefined, expect.objectContaining({ enabled: false }));
+    expect(trpcMocks.progressUseQuery).toHaveBeenCalledWith({ campaignId: 0 }, expect.objectContaining({ enabled: false }));
   });
 
   it('shows an empty state when there is no active campaign', async () => {

--- a/src/components/__tests__/NavBar.explorer-admin.test.tsx
+++ b/src/components/__tests__/NavBar.explorer-admin.test.tsx
@@ -72,20 +72,24 @@ describe('NavBar Explorer admin link', () => {
     }
   });
 
-  it('shows Manage Explorer in the admin menu for admins', async () => {
+  it('shows Explorer links in the admin menu for admins', async () => {
     const { container } = await renderNavBar();
 
     await openMenu(container);
 
-    const explorerLink = container.querySelector('a[href="/explorer-admin"]');
-    expect(explorerLink?.textContent).toContain('Manage Explorer');
+    const explorerPreviewLink = container.querySelector('a[href="/explorer"]');
+    expect(explorerPreviewLink?.textContent).toContain('Explorer');
+
+    const explorerAdminLink = container.querySelector('a[href="/explorer-admin"]');
+    expect(explorerAdminLink?.textContent).toContain('Manage Explorer');
   });
 
-  it('hides Manage Explorer for non-admin users', async () => {
+  it('hides Explorer links for non-admin users', async () => {
     const { container } = await renderNavBar({ isAdmin: false });
 
     await openMenu(container);
 
+    expect(container.querySelector('a[href="/explorer"]')).toBeNull();
     expect(container.querySelector('a[href="/explorer-admin"]')).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
Add the first athlete-facing Explorer read surface as an admin-gated preview route.

This introduces a list-first Explorer page that focuses on the active campaign and the current athlete's progress, while keeping map and social work deferred to later slices.

## What Changed
- add a new `/explorer` route and admin-only nav entry for the Explorer preview
- add the new Explorer hub page with:
  - active campaign hero
  - athlete progress summary
  - remaining and completed destination views
  - destination browse surface with disabled search stub
  - Leaderboard-style bottom navigation for Hub / Destinations / future Map
- align the Explorer UI to the documented Leaderboard design system instead of legacy admin styling
- update the Explorer planning docs to mark 4B-5 merged and define Phase 5A as the current athlete hub slice
- expand the design guidance so future Explorer work explicitly reuses:
  - BottomNav for peer-view navigation
  - the WMV purple heading hierarchy
  - selective dark-text usage for dense values and compact object titles

## Why
Explorer now has the shared segment metadata baseline from the previous slice, so the next bounded step is a useful athlete read surface. This keeps the rollout narrow and reviewable while establishing the route, hierarchy, and design-system patterns for later browse, map, and social follow-on work.

## Validation
- `npx vitest run src/components/__tests__/ExplorerHubPage.test.tsx src/components/__tests__/NavBar.explorer-admin.test.tsx`
- `npm run typecheck`

## Follow-on Work Deferred
- public release / non-admin navigation
- live search and filtering
- map rendering and location-aware discovery
- social feed or broader athlete activity visibility