### PR TITLE
docs: catch up Explorer planning closeout

### DIFF
--- a/.github/agents/dev-agent.md
+++ b/.github/agents/dev-agent.md
@@ -41,7 +41,8 @@ Use the shared repo instructions rather than restating them here:
 2. If the task is a new phase or feature slice, start from updated `main` on a dedicated feature branch.
 3. For pull requests, issue lookups, labels, and repository metadata, prefer GitHub MCP and workspace-integrated GitHub tools first. For pull request review comments and review-thread triage, default to `gh` first, preferably via `gh api graphql`, because the active-PR and MCP paths have been unreliable at returning the full thread state in this repo.
 4. Implement with minimal, focused changes that match the existing architecture.
-5. If the approved slice changes Explorer planning state, such as marking a phase complete, advancing the recommended next slice, or aligning readiness wording with merged code, include those narrow planning-doc updates in the same PR rather than leaving them for a later cleanup.
-6. Hand back to `explorer-planner` only if closing the slice requires new product decisions, broader readiness re-evaluation, or reshaping later slice boundaries rather than straightforward planning-state maintenance.
-7. Validate with `npm run lint`, `npm run typecheck`, `npm test`, and `npm run build` before calling the work complete.
-8. Stage files explicitly with `git add <file>` rather than broad staging.
+5. If the approved slice changes planning state, roadmap state, rollout boundaries, operator guidance, or any documented behavior already represented in repo docs, include the narrow doc closeout updates in the same PR rather than leaving them for a later cleanup.
+6. For Explorer specifically, if the approved slice changes phase completion, the recommended next slice, or readiness wording, update the linked planning docs in that same branch before treating the slice as done.
+7. Hand back to `explorer-planner` only if closing the slice requires new product decisions, broader readiness re-evaluation, or reshaping later slice boundaries rather than straightforward planning-state maintenance.
+8. Validate with `npm run lint`, `npm run typecheck`, `npm test`, and `npm run build` before calling the work complete.
+9. Stage files explicitly with `git add <file>` rather than broad staging.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -72,6 +72,15 @@ Before substantial planning or implementation work:
 4. Do not continue substantial work on an unrelated PR branch just because the workspace was already there.
 5. If you discover after edits that the branch is wrong, transplant the working tree onto a fresh branch from `main` before continuing.
 
+## PR Closeout Discipline
+
+When a PR changes shipped behavior, an approved slice, a rollout boundary, or any planning or operational state already represented in repo docs, update those docs in the same PR.
+
+- Treat planning-doc closeout as part of the implementation scope, not as optional cleanup for later.
+- Check the owning docs before opening a PR. This can include PRDs, phases, readiness checklists, worklogs, roadmap entries, runbooks, API docs, and operator-facing guides.
+- If the PR changes what is complete, what is next, what remains deferred, or how operators review or validate the feature, the corresponding docs should change in that branch before the PR is considered done.
+- Only defer doc closeout to a later PR when the user explicitly requests that split or when a true blocker prevents accurate updates.
+
 ---
 
 ## Project Structure

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,11 +119,16 @@ Before merging or opening a substantive PR, run `npm run audit` locally alongsid
    - Do not update either file during planning or mid-implementation
    - Keep changelog entries high-level rather than a play-by-play of intermediate edits
 
-8. **GitHub workflow tools:**
+8. **PR closeout discipline:**
+   - Before opening a PR, reconcile the branch with any planning or operational docs it changes in practice.
+   - If a PR changes phase status, approved next steps, rollout boundaries, testing reality, operator workflow, or user-visible behavior already described in docs, include those doc updates in the same PR.
+   - Treat catchup PRs as the fallback, not the default. Use them only when the user explicitly wants the split or when the docs cannot be updated accurately until later.
+
+9. **GitHub workflow tools:**
    - For pull requests, review comments, issues, labels, searches, and repository metadata, prefer GitHub MCP and workspace-integrated GitHub tools first
    - Fall back to `gh` only when the MCP path is unavailable, missing a needed capability, or returning incomplete results
    - When falling back to `gh`, keep the usage targeted and explain the blocker or gap that required the fallback
-9. **Leaderboard-inspired UI work:**
+10. **Leaderboard-inspired UI work:**
    - Treat `docs/LEADERBOARD_DESIGN_SYSTEM.md` as the canonical reference for the end-user Weekly, Season, and Schedule design language
    - Do not use legacy admin CSS as the default source of truth for public Explorer UI
    - If the leaderboard does not define a needed pattern, record that gap explicitly instead of freehanding a new local style system

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap & Future Features
 
-**Last Updated:** April 21, 2026  
+**Last Updated:** April 24, 2026  
 **Current Status:** Feature-complete and production-ready. Code quality improvements in progress (Priority 4-5: Database types, UI testing). Below are enhancement ideas for future seasons.
 
 ---
@@ -16,14 +16,14 @@
 - Align the entire app around one clear logged-out posture before more athlete-facing personalization lands
 - Improve the signed-out entry experience with clearer onboarding instead of a sparse prompt
 
-**Current Branch Status:** Implemented in the current auth-access branch; keep this item here until the branch merges.
+**Status:** Landed on `main` as the signed-out default posture.
 
 **Implementation Notes:**
 - Reuse the existing signed-out banner pattern but rewrite the body copy as a generic invitation to join Western Mass Velo with Strava
 - Add supporting signed-out body content and optional WMV branding such as the WMV SVG so the page is not visually bare
 - Make the signed-out shell the only available experience before login, with no About page or alternate public routes
 - Keep logged-in behavior unchanged
-- After this branch merges, return to planning before approving any later Explorer rollout or other athlete personalization work
+- The next Explorer or athlete-personalization follow-on should return to planning before a new slice is approved
 
 **Effort:** 2-4 hours
 **Breaking Changes:** Yes, intentional user-visible access tightening for signed-out users

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -5,9 +5,9 @@
 
 ---
 
-## Priority: High (Season 2+)
+## Completed / Shipped
 
-### 1. Authenticated-Only App Access
+### Authenticated-Only App Access
 
 **Description:** Require login before showing any in-app content, and make the signed-out experience a richer WMV sign-in or join shell instead of a nearly empty page.
 
@@ -16,19 +16,19 @@
 - Align the entire app around one clear logged-out posture before more athlete-facing personalization lands
 - Improve the signed-out entry experience with clearer onboarding instead of a sparse prompt
 
-**Status:** Landed on `main` as the signed-out default posture.
+**Status:** ✅ Landed on `main` as the signed-out default posture.
 
 **Implementation Notes:**
-- Reuse the existing signed-out banner pattern but rewrite the body copy as a generic invitation to join Western Mass Velo with Strava
-- Add supporting signed-out body content and optional WMV branding such as the WMV SVG so the page is not visually bare
-- Make the signed-out shell the only available experience before login, with no About page or alternate public routes
-- Keep logged-in behavior unchanged
-- The next Explorer or athlete-personalization follow-on should return to planning before a new slice is approved
+- Reused the existing signed-out banner pattern with generic WMV invitation copy
+- Added supporting signed-out body content and WMV branding so the page is not visually bare
+- Made the signed-out shell the only available experience before login, with no About page or alternate public routes
+- Logged-in behavior unchanged
 
-**Effort:** 2-4 hours
-**Breaking Changes:** Yes, intentional user-visible access tightening for signed-out users
+---
 
-### 2. Season Archival / Data Retention
+## Priority: High (Season 2+)
+
+### 1. Season Archival / Data Retention
 
 **Description:** Archive final season standings as immutable snapshots when a season ends.
 
@@ -48,7 +48,7 @@
 
 ---
 
-### 3. Strava Webhook Integration
+### 2. Strava Webhook Integration
 
 **Description:** Replace manual "Fetch Results" button with real-time webhooks from Strava.
 
@@ -72,7 +72,7 @@
 
 ---
 
-### 4. Email Notifications
+### 3. Email Notifications
 
 **Description:** Send weekly notifications to participants (optional opt-in).
 
@@ -96,7 +96,7 @@
 
 ---
 
-### 5. Admin UI for Week Creation
+### 4. Admin UI for Week Creation
 
 **Description:** Web form instead of curl commands for creating weeks.
 

--- a/docs/prds/wmv-explorer-destinations-phases.md
+++ b/docs/prds/wmv-explorer-destinations-phases.md
@@ -321,7 +321,7 @@ Landed outcome:
 
 Ordering note:
 
-- The current auth-access branch now tightens the default signed-out posture so logged-out users see one WMV sign-in or join shell instead of leaderboard or Explorer data. That cross-product slice remains outside Explorer phase numbering.
+- The merged auth-access work now tightens the default signed-out posture so logged-out users see one WMV sign-in or join shell instead of leaderboard or Explorer data. That cross-product slice remains outside Explorer phase numbering.
 
 ### Slice 5C: Pinned Destinations And Hub Prioritization
 
@@ -360,7 +360,7 @@ Landed outcome:
 
 Ordering note:
 
-- No later Explorer athlete rollout slice is approved yet; after the auth-access branch merges, return to planning before naming the next implementation slice.
+- No later Explorer athlete rollout slice is approved yet; now that the auth-access slice is merged, return to planning before naming the next implementation slice.
 
 ### Slice 5D: Map Discovery
 

--- a/docs/prds/wmv-explorer-execution-briefing.md
+++ b/docs/prds/wmv-explorer-execution-briefing.md
@@ -181,9 +181,9 @@ Prompts should remain narrow and convenient.
 
 - The earlier 4B split is now complete through 4B-5: 4B-1 hardened the portable E2E harness, 4B-2 landed the minimal admin-only Explorer UI, 4B-3 corrected the campaign model and unified admin shell, 4B-4 refined the admin workflow hierarchy, and 4B-5 landed the shared segment metadata fidelity baseline.
 - The first athlete-facing slices are now merged: 5A landed the admin-gated Explorer hub read surface, 5B merged the lightweight checklist and browse refinement on top of it, and 5C merged athlete-specific pinned-destination prioritization on top of that browse surface.
-- The current auth-access branch now tightens the broader app so logged-out users see only a branded WMV sign-in or join shell by default.
+- The merged auth-access work now tightens the broader app so logged-out users see only a branded WMV sign-in or join shell by default.
 - That auth slice keeps the signed-out copy generic, oriented around joining Western Mass Velo with Strava, and does not leave alternate public destinations such as About reachable before login.
-- After this auth slice merges, follow-on Explorer work should return to planning before approving a later slice such as map or social follow-on work.
+- With that auth slice merged, follow-on Explorer work should return to planning before approving a later slice such as map or social follow-on work.
 - Treat map-provider research, location-aware discovery, and social-feed ideas as separate later slices unless the planning docs explicitly re-approve them as part of a new bounded implementation brief.
 
 ### Slice completion discipline

--- a/docs/prds/wmv-explorer-readiness-checklist.md
+++ b/docs/prds/wmv-explorer-readiness-checklist.md
@@ -19,7 +19,7 @@ The ideas backlog is intentionally excluded from v1 implementation scope. It exi
 
 **Status:** Phase 1 Complete; Campaign-First Explorer Correction Landed; Phase 4A Admin Backend Complete; Phase 4B-1 E2E Harness Hardening Merged; Phase 4B-2 Minimal Admin UI Merged; Phase 4B-3 Campaign Decoupling And Unified Admin Shell Merged; Phase 4B-4 Admin Workflow Hierarchy And Destination Management Merged; Phase 4B-5 Segment Metadata Fidelity And Freshness Merged; Phase 5A Athlete Hub Read Surface Merged; Phase 5B Checklist And Browse Refinement Merged; Phase 5C Pinned Destinations And Hub Prioritization Merged
 
-Explorer has completed the narrow Phase 1 webhook-orchestration slice that preserves current competition behavior while introducing delegated in-process handlers. The planning set corrected Explorer to a campaign-first model with campaign-owned date boundaries, returned `Season` to competition-only semantics, deferred overlapping or nested campaign structures, and locked a no-overlap Explorer rule for v1. The shared segment metadata-fidelity slice, the first admin-gated athlete hub read surface, the lightweight browse refinement, and athlete-specific pinned-destination prioritization are now merged on `main`. The current auth-access change set also locks signed-out users to one branded WMV sign-in or join shell instead of exposing leaderboard or Explorer data by default.
+Explorer has completed the narrow Phase 1 webhook-orchestration slice that preserves current competition behavior while introducing delegated in-process handlers. The planning set corrected Explorer to a campaign-first model with campaign-owned date boundaries, returned `Season` to competition-only semantics, deferred overlapping or nested campaign structures, and locked a no-overlap Explorer rule for v1. The shared segment metadata-fidelity slice, the first admin-gated athlete hub read surface, the lightweight browse refinement, and athlete-specific pinned-destination prioritization are now merged on `main`. The broader auth-access tightening is also merged on `main`, so signed-out users now see one branded WMV sign-in or join shell instead of leaderboard or Explorer data by default.
 
 The current post-auth boundary is explicit: keep the merged admin flow, shared segment metadata baseline, 5A through 5C athlete page, and tighter signed-out app posture intact; do not broaden into public release, map-provider decisions, geolocation, or social-feed behavior until a later Explorer slice is explicitly re-approved through planning.
 
@@ -31,9 +31,9 @@ The current post-auth boundary is explicit: keep the merged admin flow, shared s
 | Execution phasing | Phase 5C Merged | The phases doc now records 5C as merged and leaves later Explorer rollout slices in candidate status pending renewed approval. |
 | Architecture closure | Personalization Baseline Landed | The campaign-first correction, current admin hierarchy, shared segment metadata baseline, and merged athlete browse plus pinning surface are in place, so future Explorer work can build from a stable personalization baseline rather than reopening the admin shell or browse foundations. |
 | Open questions handling | Ready | The worklog now records the superseded season-attached decision and the locked no-overlap rule. |
-| Blocking research closure | Deferred Pending Re-approval | Public-release, map-provider, and social-feed questions remain explicitly deferred and should be re-evaluated only after this auth-access slice is merged and Explorer planning resumes. |
-| Test planning | Auth Slice Implemented | The current change set covers locked signed-out entry behavior; the next test-planning work should wait for a newly approved Explorer slice. |
-| Documentation impact plan | Auth Closeout In Progress | The current documentation impact is the narrow auth-slice closeout and the return-to-planning boundary for later Explorer work. |
+| Blocking research closure | Deferred Pending Re-approval | Public-release, map-provider, and social-feed questions remain explicitly deferred and should be re-evaluated only when Explorer planning resumes. |
+| Test planning | Auth Slice Merged | The merged auth-access slice covers locked signed-out entry behavior; the next test-planning work should wait for a newly approved Explorer slice. |
+| Documentation impact plan | Auth Closeout Recorded | The current documentation impact is the recorded auth-slice outcome plus the return-to-planning boundary for later Explorer work. |
 
 ## Must Resolve Before Broad Implementation
 
@@ -85,11 +85,11 @@ The current post-auth boundary is explicit: keep the merged admin flow, shared s
 
 | Field | Value |
 | --- | --- |
-| Status | Ready For 5B |
+| Status | Ready For Re-Planning |
 | Gate | Must Resolve |
 | Why it matters | The team needs a shared rule for what can proceed now that the campaign-first correction, admin workflow hierarchy, shared segment metadata baseline, and pinned personalization slice are all merged. |
-| Evidence | The implemented webhook seam remains valid, 4A through 5C are now merged on `main`, the current branch locks signed-out users to a single WMV join shell, and no further Explorer rollout slice is currently re-approved. |
-| Acceptance criteria | The readiness artifacts clearly state that 5C has landed, the auth-access slice has been closed out in the implementation PR, and later Explorer rollout still needs renewed approval through planning. |
+| Evidence | The implemented webhook seam remains valid, 4A through 5C are now merged on `main`, the merged auth-access work locks signed-out users to a single WMV join shell, and no further Explorer rollout slice is currently re-approved. |
+| Acceptance criteria | The readiness artifacts clearly state that 5C has landed, the auth-access outcome is recorded on `main`, and later Explorer rollout still needs renewed approval through planning. |
 | Next action | Keep the current go decision updated as additional athlete-facing Explorer slices are approved or deferred, and return to planning before naming another implementation PR. |
 
 ## Should Resolve Before 4A And 4B Expand
@@ -120,11 +120,11 @@ The current post-auth boundary is explicit: keep the merged admin flow, shared s
 
 | Field | Value |
 | --- | --- |
-| Status | Auth Closeout In Progress |
+| Status | Auth Closeout Recorded |
 | Gate | Should Resolve |
 | Why it matters | Explorer touches admin, athlete, API, database, and release-note surfaces. That work should be visible before coding. |
-| Evidence | The 4A slice updated `docs/API.md`, `docs/DATABASE_DESIGN.md`, and the slice-local planning docs, while 4B-3 through 5C carried the structural correction, admin workflow refinement, shared segment metadata baseline, athlete read surface, browse refinement, and pinned-destination prioritization. The current change set also closes out the auth-access slice and restores the return-to-planning boundary. |
-| Acceptance criteria | The worklog or implementation slice records 5C as merged, records the auth-access outcome in the same branch, and leaves later Explorer rollout work unapproved until planning resumes. |
+| Evidence | The 4A slice updated `docs/API.md`, `docs/DATABASE_DESIGN.md`, and the slice-local planning docs, while 4B-3 through 5C carried the structural correction, admin workflow refinement, shared segment metadata baseline, athlete read surface, browse refinement, and pinned-destination prioritization. The merged auth-access slice is now recorded alongside that Explorer baseline and restores the return-to-planning boundary. |
+| Acceptance criteria | The worklog or planning set records 5C as merged, records the auth-access outcome on `main`, and leaves later Explorer rollout work unapproved until planning resumes. |
 | Next action | Keep the documentation-impact checklist current if a later Explorer slice is approved. |
 
 ### 4. Smallest End-To-End Slice

--- a/docs/prds/wmv-explorer-worklog.md
+++ b/docs/prds/wmv-explorer-worklog.md
@@ -177,7 +177,7 @@ The current preservation target is backed by:
 	- the signed-out shell uses generic WMV and Strava join language rather than leaderboard or competition framing
 	- the signed-out shell includes supporting content and WMV branding so the app does not feel sparse before login
 	- the logged-in app shell and logged-in navigation remain intact
-	
+
 - Landed validation:
 	- frontend unit tests for signed-out route gating and the absence of alternate signed-out destinations
 	- slice-normal `npm run lint`, `npm run typecheck`, `npm test`, and `npm run build`

--- a/docs/prds/wmv-explorer-worklog.md
+++ b/docs/prds/wmv-explorer-worklog.md
@@ -4,16 +4,15 @@ This worklog is the active operating log for Explorer. The readiness checklist i
 
 ## Current Focus
 
-- Record 5C as merged on `main` and close out the Explorer personalization slice.
-- Record the broader app auth-access tightening as implemented in this branch so logged-out users now see one WMV sign-in or join shell by default.
-- Leave later Explorer rollout work unapproved until planning resumes after this auth-access branch is reviewed and merged.
+- Keep the merged 5A through 5C Explorer personalization baseline and the merged auth-access posture documented as the current starting point.
+- Leave later Explorer rollout work unapproved until planning resumes from updated `main`.
 - Keep any pre-release Explorer UI admin-gated until there is an explicit end-user release decision.
 - Keep the next planning handoff aligned with the merged campaign-first model, the shared segment metadata baseline, the merged 5A through 5C athlete page, and the tighter signed-out app posture.
 
 ## Current Go State
 
 - **Readiness:** Phase 1 Complete; Campaign-First Explorer Correction Landed; Phase 4A Admin Backend Complete; Phase 4B-1 E2E Harness Hardening Merged; Phase 4B-2 Minimal Admin UI Merged; Phase 4B-3 Campaign Decoupling And Unified Admin Shell Merged; Phase 4B-4 Admin Workflow Hierarchy And Destination Management Merged; Phase 4B-5 Segment Metadata Fidelity And Freshness Merged; Phase 5A Athlete Hub Read Surface Merged; Phase 5B Checklist And Browse Refinement Merged; Phase 5C Pinned Destinations And Hub Prioritization Merged
-- **Immediate scope:** close out the current auth-access branch, then return to planning before approving any later Explorer rollout slice
+- **Immediate scope:** return to planning before approving any later Explorer rollout slice
 - **Not yet in scope:** public athlete-facing Explorer release, public navigation to Explorer, map rendering, location-based discovery, social-feed behavior, mini-campaigns, or explicit publish-status workflows
 
 ## Decisions Made
@@ -54,7 +53,7 @@ This worklog is the active operating log for Explorer. The readiness checklist i
 - The next athlete-facing slice should focus on larger-list usability inside the existing Hub and Destinations views before adding any new top-level Explorer mode.
 - Lightweight browse aids are acceptable in 5B only if they improve list scanning without implying public release, full search, map discovery, or a shift toward leaderboard semantics.
 - Logged-out users should not see leaderboard or Explorer data by default; the default signed-out shell should reuse the existing login prompt language, remove leaderboard-specific copy, and add enough WMV join context that the page does not feel empty.
-- The current auth-access branch now enforces that signed-out users see one WMV join shell instead of leaderboard or About routes, while preserving the logged-in app shell.
+- The merged auth-access work now enforces that signed-out users see one WMV join shell instead of leaderboard or About routes, while preserving the logged-in app shell.
 - The 5C slice now lets a logged-in athlete pin destinations from the Destinations tab and uses that preference state to prioritize remaining destinations on the Hub page without changing campaign order or completion semantics elsewhere.
 - Map-based discovery is important follow-on work, but it should start only after the list-first athlete page exists and the map product questions are answered explicitly.
 - Social visibility can grow later, but a social feed is not the smallest useful first athlete-facing Explorer surface.
@@ -97,7 +96,7 @@ This worklog is the active operating log for Explorer. The readiness checklist i
 
 Resolution:
 
-- These planning blockers are now closed on this branch.
+- These planning blockers are now closed on `main`.
 
 ### Should Resolve Before 4A And 4B Grow Broader
 
@@ -172,16 +171,18 @@ The current preservation target is backed by:
 ### Auth-Access Outcome
 
 - Slice: cross-product auth-access tightening only.
-- Status: implemented in this branch; expected to close out with the same PR.
+- Status: merged on `main`.
 - Landed outcome:
 	- signed-out users now see one branded WMV sign-in or join shell instead of leaderboard, Explorer, or About routes
 	- the signed-out shell uses generic WMV and Strava join language rather than leaderboard or competition framing
 	- the signed-out shell includes supporting content and WMV branding so the app does not feel sparse before login
 	- the logged-in app shell and logged-in navigation remain intact
-- Validation expectation for this branch:
+	
+- Landed validation:
 	- frontend unit tests for signed-out route gating and the absence of alternate signed-out destinations
 	- slice-normal `npm run lint`, `npm run typecheck`, `npm test`, and `npm run build`
-- Next planning handoff after merge:
+
+- Next planning handoff:
 	- return to planning before approving any later Explorer rollout slice such as map or social follow-on work
 
 ### 4B-3 Outcome


### PR DESCRIPTION
This PR catches the Explorer planning set up to the current merged state on `main` and tightens the shared agent instructions so future implementation PRs are expected to carry their own doc closeout.

Summary:
- update the Explorer readiness checklist, worklog, phases doc, execution briefing, and roadmap so they describe the auth-access posture and 5A through 5C state as already merged on `main`
- remove stale wording that still treated auth-access closeout as branch-local or in progress
- add repo-level PR closeout guidance in `.github/copilot-instructions.md`, `AGENTS.md`, and `.github/agents/dev-agent.md`
- make same-PR planning and operational doc updates part of the definition of done rather than a later cleanup step

Validation:
- pre-commit `npm run typecheck`
- pre-commit `npm run lint`
- targeted grep check for stale auth-access branch wording
- editor diagnostics on touched docs/instruction files