### PR TITLE
chore: remove redundant explicit created_at writes (issue #73)

### DIFF
--- a/server/src/__tests__/webhookAdminRouter.replayEvent.test.ts
+++ b/server/src/__tests__/webhookAdminRouter.replayEvent.test.ts
@@ -108,7 +108,6 @@ describe('webhookAdminRouter - replayEvent mutation', () => {
           payload: JSON.stringify(eventPayload),
           processed: 0,
           error_message: null,
-          created_at: new Date().toISOString()
         })
         .returning()
         .execute();
@@ -151,7 +150,6 @@ describe('webhookAdminRouter - replayEvent mutation', () => {
           payload: JSON.stringify(eventPayload),
           processed: 0,
           error_message: null,
-          created_at: new Date().toISOString()
         })
         .returning()
         .execute();
@@ -194,7 +192,6 @@ describe('webhookAdminRouter - replayEvent mutation', () => {
           payload: JSON.stringify(eventPayload),
           processed: 0,
           error_message: 'Activity not found on Strava',
-          created_at: new Date().toISOString()
         })
         .returning()
         .execute();
@@ -231,7 +228,6 @@ describe('webhookAdminRouter - replayEvent mutation', () => {
           payload: JSON.stringify({ object_id: 111, owner_id: 100 }),
           processed: 0,
           error_message: null,
-          created_at: new Date().toISOString()
         })
         .returning()
         .execute();
@@ -242,7 +238,6 @@ describe('webhookAdminRouter - replayEvent mutation', () => {
           payload: JSON.stringify({ object_id: 222, owner_id: 200 }),
           processed: 0,
           error_message: null,
-          created_at: new Date().toISOString()
         })
         .returning()
         .execute();
@@ -253,7 +248,6 @@ describe('webhookAdminRouter - replayEvent mutation', () => {
           payload: JSON.stringify({ object_id: 333, owner_id: 300 }),
           processed: 0,
           error_message: null,
-          created_at: new Date().toISOString()
         })
         .returning()
         .execute();
@@ -281,7 +275,6 @@ describe('webhookAdminRouter - replayEvent mutation', () => {
           payload: JSON.stringify({ data: 'first' }),
           processed: 0,
           error_message: null,
-          created_at: new Date().toISOString()
         })
         .returning()
         .execute();
@@ -292,7 +285,6 @@ describe('webhookAdminRouter - replayEvent mutation', () => {
           payload: JSON.stringify({ data: 'second' }),
           processed: 0,
           error_message: null,
-          created_at: new Date().toISOString()
         })
         .returning()
         .execute();
@@ -339,7 +331,6 @@ describe('webhookAdminRouter - replayEvent mutation', () => {
           payload: JSON.stringify(complexPayload),
           processed: 0,
           error_message: null,
-          created_at: new Date().toISOString()
         })
         .returning()
         .execute();
@@ -379,7 +370,6 @@ describe('webhookAdminRouter - replayEvent mutation', () => {
           payload: JSON.stringify(athleteDisconnectPayload),
           processed: 0,
           error_message: null,
-          created_at: new Date().toISOString()
         })
         .returning()
         .execute();
@@ -413,7 +403,6 @@ describe('webhookAdminRouter - replayEvent mutation', () => {
           payload: JSON.stringify(minimalPayload),
           processed: 0,
           error_message: null,
-          created_at: new Date().toISOString()
         })
         .returning()
         .execute();
@@ -497,7 +486,6 @@ describe('webhookAdminRouter - replayEvent mutation', () => {
           payload: JSON.stringify(eventPayload),
           processed: 0,
           error_message: null,
-          created_at: new Date().toISOString()
         })
         .returning()
         .execute();
@@ -535,7 +523,6 @@ describe('webhookAdminRouter - replayEvent mutation', () => {
           payload: JSON.stringify(eventPayload),
           processed: 0,
           error_message: null,
-          created_at: new Date().toISOString()
         })
         .returning()
         .execute();

--- a/server/src/services/ChainWaxService.ts
+++ b/server/src/services/ChainWaxService.ts
@@ -103,7 +103,6 @@ export class ChainWaxService {
    */
   async waxChain(waxedAt: number): Promise<void> {
     const currentPeriod = await this.getCurrentPeriod();
-    const createdAt = new Date().toISOString();
 
     await this.db.transaction(async (tx) => {
       // Close current period
@@ -119,7 +118,6 @@ export class ChainWaxService {
           .values({
             started_at: waxedAt,
             total_distance_meters: 0,
-            created_at: createdAt,
           })
       );
 
@@ -146,7 +144,6 @@ export class ChainWaxService {
    */
   async newPuck(): Promise<void> {
     const now = Math.floor(Date.now() / 1000);
-    const createdAt = new Date().toISOString();
 
     await this.db.transaction(async (tx) => {
       // Retire current puck
@@ -163,7 +160,6 @@ export class ChainWaxService {
             started_at: now,
             wax_count: 0,
             is_current: true,
-            created_at: createdAt,
           })
       );
     });
@@ -181,7 +177,6 @@ export class ChainWaxService {
     activityStartAt: number
   ): Promise<boolean> {
     const currentPeriod = await this.getCurrentPeriod();
-    const createdAt = new Date().toISOString();
 
     // Only count activities that started after the current wax period began
     if (activityStartAt < currentPeriod.started_at) {
@@ -195,7 +190,6 @@ export class ChainWaxService {
         strava_athlete_id: athleteId,
         distance_meters: distanceMeters,
         activity_start_at: activityStartAt,
-        created_at: createdAt,
       }).onConflictDoNothing().returning({ id: chainWaxActivity.id })
     );
 

--- a/server/src/webhooks/logger.ts
+++ b/server/src/webhooks/logger.ts
@@ -31,7 +31,6 @@ export class WebhookLogger {
           payload: JSON.stringify(entry.payload),
           processed: processedValue,
           error_message: entry.errorMessage || null,
-          created_at: new Date().toISOString()
         })
       );
     } catch (error) {


### PR DESCRIPTION
## Summary

Closes #73

Post-deploy cleanup after PR #72 normalized all timestamp columns to `timestamptz` with `DEFAULT now()`. Four spots in service code and thirteen test fixtures were still explicitly setting `created_at: new Date().toISOString()` on INSERT — patterns that predated the column defaults working correctly in production.

## Changes

**Production code (4 inserts):**
- `server/src/webhooks/logger.ts` — `WebhookLogger.logEvent()`: drop `created_at` field from `webhook_event` INSERT
- `server/src/services/ChainWaxService.ts` — `waxChain()`, `newPuck()`, `recordActivity()`: remove `const createdAt = new Date().toISOString()` local vars and their `created_at:` INSERT fields

**Test fixtures (13 inserts):**
- `server/src/__tests__/webhookAdminRouter.replayEvent.test.ts`: remove `created_at: new Date().toISOString()` from all 13 fixture INSERTs into `webhook_event`

## Validation

- `npm --prefix server run typecheck` ✅
- `npm test` ✅ 650/650 tests pass
- Pre-commit hook (lint + typecheck) ✅
